### PR TITLE
Small fix for the cloudHandler when creating an EC2 client

### DIFF
--- a/nuve/nuveAPI/cloudHandler.js
+++ b/nuve/nuveAPI/cloudHandler.js
@@ -95,7 +95,7 @@ var addNewAmazonErizoController = function(privateIP, callback) {
     var instaceId;
 
     if (ec2 === undefined) {
-        ec2 = require('aws-lib').createEC2Client(config.cloudProvider.accessKey, config.cloudProvider.secretAccessKey, {host:'ec2.eu-west-1.amazonaws.com', version: '2012-12-01'});
+        ec2 = require('aws-lib').createEC2Client(config.cloudProvider.accessKey, config.cloudProvider.secretAccessKey);
     }
     console.log('private ip ', privateIP);
 


### PR DESCRIPTION
The current call to `aws-lib` createEC2 client is passing a hardcoded third argument that is causing problems when getting the instance info:

``` javascript
ec2 = require('aws-lib').createEC2Client(config.cloudProvider.accessKey,
 config.cloudProvider.secretAccessKey, 
{host:'ec2.eu-west-1.amazonaws.com', version: '2012-12-01'});

```

The `host` option is not necessary, since the default one is `ec2.amazon.com`, and that's good for all the different zones. 

And the second one, `version`, is probably neglected by `aws-lib`, since there's no such an option.
