### PR TITLE
Fixing a simple bug in browser version detection

### DIFF
--- a/erizo_controller/erizoClient/src/Connection.js
+++ b/erizo_controller/erizoClient/src/Connection.js
@@ -22,13 +22,18 @@ Erizo.Connection = function (spec) {
         console.log("Stable!");
         that = Erizo.ChromeStableStack(spec);
         that.browser = "chrome-stable";
-    } else if (window.navigator.appVersion.match(/Chrome\/([\w\W]*?)\./)[1] === "24" ||
-               window.navigator.appVersion.match(/Chrome\/([\w\W]*?)\./)[1] === "25") {
+    } else if (window.navigator.appVersion.match(/Chrome\/([\w\W]*?)\./)[1] === "28" ||
+        window.navigator.appVersion.match(/Chrome\/([\w\W]*?)\./)[1] === "29") {
         // Google Chrome Canary.
         console.log("Canary!");
         that = Erizo.ChromeCanaryStack(spec);
         that.browser = "chrome-canary";
-    } else if (window.navigator.appVersion.match(/Bowser\/([\w\W]*?)\./)[1] === "25") {
+    }  else if (window.navigator.userAgent.toLowerCase().indexOf("chrome")>=0) {
+        // Probably Google Chrome Stable.
+        console.log("Probably stable!");
+        that = Erizo.ChromeStableStack(spec);
+        that.browser = "chrome-stable";
+    }  else if (window.navigator.appVersion.match(/Bowser\/([\w\W]*?)\./)[1] === "25") {
         // Bowser
         that.browser = "bowser";
     } else if (window.navigator.appVersion.match(/Mozilla\/([\w\W]*?)\./)[1] === "25") {


### PR DESCRIPTION
As current dev and canary versions of chrome are numbered '29', erizo_client have stopped functioning properly. 
Obvious bug is that erizo can't understand that user is using chrome and tries to detect 'bowser' version and then it raises unhandled "Cannot read the property [1] of null" exception.

Commit to fix that bug is really simple and is almost self-descriptive.
