### PR TITLE
fix TypeMismatchError in Chrome Stable

### DIFF
--- a/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
@@ -18,7 +18,7 @@ Erizo.ChromeStableStack = function (spec) {
         that.pc_config.iceServers.push({"url": spec.stunServerUrl});
     } 
 
-    if (spec.turnServer !== undefined) {
+    if ((spec.turnServer || {}).url) {
         that.pc_config.iceServers.push({"username": spec.turnServer.username, "credential": spec.turnServer.password, "url": spec.turnServer.url});
     }
 


### PR DESCRIPTION
fixes TypeMismatchError: The type of an object was incompatible with the
expected type of the parameter associated to the object. when turnServer
is empty.

Reproduces in Chrome Stable:

new webkitRTCPeerConnection({iceServers: [{url: 'stun:stun.l.google.com:19302'}, {credential: "", username: "", url: ""}]}, {optional: [{DtlsSrtpKeyAgreement: true}]}); will fail with the error.
