### PR TITLE
Stop installing libnice package.

### DIFF
--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -29,7 +29,7 @@ install_apt_deps(){
   sudo apt-get install software-properties-common
   sudo add-apt-repository ppa:chris-lea/node.js
   sudo apt-get update
-  sudo apt-get install git make gcc g++ libssl-dev cmake libnice10 libnice-dev libglib2.0-dev pkg-config nodejs libboost-regex-dev libboost-thread-dev libboost-system-dev liblog4cxx10-dev rabbitmq-server mongodb openjdk-6-jre curl
+  sudo apt-get install git make gcc g++ libssl-dev cmake libglib2.0-dev pkg-config nodejs libboost-regex-dev libboost-thread-dev libboost-system-dev liblog4cxx10-dev rabbitmq-server mongodb openjdk-6-jre curl
   sudo npm install -g node-gyp
   sudo chown -R `whoami` ~/.npm ~/tmp/
 }


### PR DESCRIPTION
We use a local copy of libnice-0.1.4 instead of the distribution
packaged libnice-0.1.1. No need to install the distribution package.
