### PR TITLE
Make this definition match the rest.

### DIFF
--- a/erizo/src/erizo/NiceConnection.h
+++ b/erizo/src/erizo/NiceConnection.h
@@ -21,7 +21,7 @@ typedef unsigned int uint;
 
 namespace erizo {
 //forward declarations
-struct CandidateInfo;
+class CandidateInfo;
 class WebRtcConnection;
 
 /**


### PR DESCRIPTION
All the other instances of CandidateInfo declare it as a class. This
doesn't break anything, but changing it gives clang one less warning to
scream about.
