### PR TITLE
Only start mongod and rabbitmq if necessary.

### DIFF
--- a/scripts/initLicode.sh
+++ b/scripts/initLicode.sh
@@ -10,9 +10,10 @@ EXTRAS=$ROOT/extras
 
 export PATH=$PATH:/usr/local/sbin
 
-sudo echo
-
-sudo rabbitmq-server > $BUILD_DIR/rabbit.log &
+if ! pgrep -q -f rabbitmq; then
+  sudo echo
+  sudo rabbitmq-server > $BUILD_DIR/rabbit.log &
+fi
 
 cd $ROOT/nuve
 ./initNuve.sh

--- a/scripts/installNuve.sh
+++ b/scripts/installNuve.sh
@@ -16,13 +16,17 @@ install_nuve(){
 
 populate_mongo(){
 
-  echo [licode] Starting mongodb
-  if [ ! -d "$DB_DIR" ]; then
-    mkdir -p "$DB_DIR"/db
+  if ! pgrep -q mongod; then
+    echo [licode] Starting mongodb
+    if [ ! -d "$DB_DIR" ]; then
+      mkdir -p "$DB_DIR"/db
+    fi
+    mongod --repair --dbpath $DB_DIR
+    mongod --dbpath $DB_DIR --logpath $BUILD_DIR/mongo.log --fork
+    sleep 5
+  else
+    echo [licode] mongodb already running
   fi
-  mongod --repair --dbpath $DB_DIR
-  mongod --dbpath $DB_DIR --logpath $BUILD_DIR/mongo.log --fork
-  sleep 5
 
   dbURL=`grep "config.nuve.dataBaseURL" $PATHNAME/licode_default.js`
 
@@ -37,8 +41,10 @@ populate_mongo(){
   SERVID=`echo $SERVID| cut -d'"' -f 2`
   SERVID=`echo $SERVID| cut -d'"' -f 1`
 
-  echo "Mongo Logs: "
-  cat $BUILD_DIR/mongo.log
+  if [ -f "$BUILD_DIR/mongo.log" ]; then
+    echo "Mongo Logs: "
+    cat $BUILD_DIR/mongo.log
+  fi
 
   echo [licode] SuperService ID $SERVID
   echo [licode] SuperService KEY $SERVKEY


### PR DESCRIPTION
On Ubuntu, installing these packages starts them immediately so there's
no point starting them in the install and init scripts here. On Mac the
situation is a little more complex because it's a manual step to make
something installed from homebrew run as a service. Account for both
cases in the scripts.
