### PR TITLE
 FireFox supports range sliders as of version 23

### DIFF
--- a/erizo_controller/erizoClient/src/views/Speaker.js
+++ b/erizo_controller/erizoClient/src/views/Speaker.js
@@ -51,6 +51,7 @@ Erizo.Speaker = function (spec) {
         that.picker.max = 100;
         that.picker.step = 10;
         that.picker.value = lastVolume;
+        that.picker.orient = "vertical"; //  FireFox supports range sliders as of version 23
         that.div.appendChild(that.picker);
         that.media.volume = that.picker.value / 100;
 


### PR DESCRIPTION
Volume bar uses "-webkit-appearance: slider-vertical;" , but FF doesn't support it. Firefox support orient="vertical".

Also check: http://stackoverflow.com/questions/15935837/how-to-display-a-range-input-vertically
