### PR TITLE
ruby stdlib for SHA1 encoding

### DIFF
--- a/nuve/nuveClient_ruby/nuve.rb
+++ b/nuve/nuveClient_ruby/nuve.rb
@@ -1,6 +1,6 @@
 require 'net/http'
 require 'base64'
-require 'hmac-sha1'
+require 'openssl'
 
 class Nuve
 
@@ -107,9 +107,9 @@ class Nuve
 
 	private
 	def calculateSignature (toSign, key)
-		hmac = HMAC::SHA1.new(key)
-		hex = hmac.update(toSign)
-		signed   = Base64.encode64("#{hex}")
+		digest = OpenSSL::Digest.new('sha1')
+		hex = OpenSSL::HMAC.hexdigest(digest, key, toSign)
+		signed   = Base64.encode64(hex)
 		return signed
 	end
 


### PR DESCRIPTION
This uses the ruby stdlb for encoding SHA1 contents, the previous code actually required a third party gem which wasn't even documented. This will work on most ruby installations out of the box AFAIK.
