### PR TITLE
Don't kill the NiceDataLoop when no packets are available.

### DIFF
--- a/erizo/src/erizo/DtlsTransport.cpp
+++ b/erizo/src/erizo/DtlsTransport.cpp
@@ -298,10 +298,9 @@ void DtlsTransport::processLocalSdp(SdpInfo *localSdp_) {
 void DtlsTransport::getNiceDataLoop(){
   while(running_ == true){
     p_ = nice_->getPacket();
-    if (p_->length <=0){
-      return;
+    if (p_->length > 0) {
+        this->onNiceData(p_->comp, p_->data, p_->length, NULL);
     }
-    this->onNiceData(p_->comp, p_->data, p_->length, NULL);
   }
 }
 bool DtlsTransport::isDtlsPacket(const char* buf, int len) {


### PR DESCRIPTION
It's entirely possible that the timed_wait in NiceConnection::getPacket
fires before we get any data on the NiceConnection. When that happens,
we don't want to kill the thread passing data on to the DtlsTransport.
