### PR TITLE
Don't throw away the first packet.

### DIFF
--- a/erizo/src/erizo/media/rtp/RtpPacketQueue.cpp
+++ b/erizo/src/erizo/media/rtp/RtpPacketQueue.cpp
@@ -49,6 +49,7 @@ namespace erizo{
       lastNseq_ = nseq;
       lastTs_ = ts;
       cleanQueue();
+      enqueuePacket(data, length, nseq);
     }
     else if (nseqdiff > 1)
     {


### PR DESCRIPTION
We're resetting the queue here, but we might as well enqueue the data we
just received.
