### PR TITLE
Rather than kludging up a (bad) guess at the host and deleting it manual...

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -95,12 +95,7 @@ Erizo.Room = function (spec) {
     // It connects to the server through socket.io
     connectSocket = function (token, callback, error) {
         // Once we have connected
-
-        var host = 'http://' + token.host;
-
-        delete io.sockets[host];
-
-        that.socket = io.connect(token.host, {reconnect: false, secure: false});
+        that.socket = io.connect(token.host, {reconnect: false, secure: false, 'force new connection': true});
 
         // We receive an event with a new stream in the room.
         // type can be "media" or "data"


### PR DESCRIPTION
...ly, just pass in the 'force new connection' option, which forces socket.io to refresh the socket.
