### PR TITLE
Opus support

### DIFF
--- a/scripts/installMacDeps.sh
+++ b/scripts/installMacDeps.sh
@@ -77,13 +77,13 @@ install_libsrtp(){
 }
 
 install_mediadeps(){
-  brew install yasm libvpx x264
+  brew install yasm libvpx x264 opus
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O https://www.libav.org/releases/libav-9.9.tar.gz
-    tar -zxvf libav-9.9.tar.gz
-    cd libav-9.9
-    ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264
+    curl -O https://www.libav.org/releases/libav-9.13.tar.gz
+    tar -zxvf libav-9.13.tar.gz
+    cd libav-9.13
+    ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus
     make -s V=0
     make install
     cd $CURRENT_DIR
@@ -94,13 +94,13 @@ install_mediadeps(){
 }
 
 install_mediadeps_nogpl(){
-  brew install yasm libvpx
+  brew install yasm libvpx opus
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O https://www.libav.org/releases/libav-9.9.tar.gz
-    tar -zxvf libav-9.9.tar.gz
-    cd libav-9.9
-    ./configure --prefix=$PREFIX_DIR --enable-shared --enable-libvpx
+    curl -O https://www.libav.org/releases/libav-9.13.tar.gz
+    tar -zxvf libav-9.13.tar.gz
+    cd libav-9.13
+    ./configure --prefix=$PREFIX_DIR --enable-shared --enable-libvpx --enable-libopus
     make -s V=0
     make install
     cd $CURRENT_DIR

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -70,6 +70,18 @@ install_libnice(){
   fi
 }
 
+install_opus(){
+  [ -d $LIB_DIR ] || mkdir -p $LIB_DIR
+  cd $LIB_DIR
+  curl -O http://downloads.xiph.org/releases/opus/opus-1.1.tar.gz
+  tar -zxvf opus-1.1.tar.gz
+  cd opus-1.1
+  ./configure --prefix=$PREFIX_DIR
+  make -s V=0
+  make install
+  cd $CURRENT_DIR
+}
+
 install_mediadeps(){
   sudo apt-get install yasm libvpx. libx264.
   if [ -d $LIB_DIR ]; then
@@ -77,7 +89,7 @@ install_mediadeps(){
     curl -O https://www.libav.org/releases/libav-9.13.tar.gz
     tar -zxvf libav-9.13.tar.gz
     cd libav-9.13
-    ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264
+    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus
     make -s V=0
     make install
     cd $CURRENT_DIR
@@ -92,10 +104,10 @@ install_mediadeps_nogpl(){
   sudo apt-get install yasm libvpx.
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O https://www.libav.org/releases/libav-9.9.tar.gz
-    tar -zxvf libav-9.9.tar.gz
-    cd libav-9.9
-    ./configure --prefix=$PREFIX_DIR --enable-shared --enable-libvpx
+    curl -O https://www.libav.org/releases/libav-9.13.tar.gz
+    tar -zxvf libav-9.13.tar.gz
+    cd libav-9.13
+    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus
     make -s V=0
     make install
     cd $CURRENT_DIR
@@ -140,6 +152,9 @@ install_libnice
 
 pause "Installing libsrtp library...  [press Enter]"
 install_libsrtp
+
+pause "Installing opus library...  [press Enter]"
+install_opus
 
 if [ "$ENABLE_GPL" = "true" ]; then
   pause "GPL libraries enabled"

--- a/scripts/installUbuntuDepsUnattended.sh
+++ b/scripts/installUbuntuDepsUnattended.sh
@@ -71,14 +71,26 @@ install_libnice(){
   fi
 }
 
+install_opus(){
+  [ -d $LIB_DIR ] || mkdir -p $LIB_DIR
+  cd $LIB_DIR
+  curl -O http://downloads.xiph.org/releases/opus/opus-1.1.tar.gz
+  tar -zxvf opus-1.1.tar.gz
+  cd opus-1.1
+  ./configure --prefix=$PREFIX_DIR
+  make -s V=0
+  make install
+  cd $CURRENT_DIR
+}
+
 install_mediadeps(){
   sudo apt-get -qq install yasm libvpx. libx264.
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O https://www.libav.org/releases/libav-9.9.tar.gz
-    tar -zxvf libav-9.9.tar.gz
-    cd libav-9.9
-    ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264
+    curl -O https://www.libav.org/releases/libav-9.13.tar.gz
+    tar -zxvf libav-9.13.tar.gz
+    cd libav-9.13
+    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus
     make -s V=0
     make install
     cd $CURRENT_DIR
@@ -93,10 +105,10 @@ install_mediadeps_nogpl(){
   sudo apt-get -qq install yasm libvpx.
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O https://www.libav.org/releases/libav-9.9.tar.gz
-    tar -zxvf libav-9.9.tar.gz
-    cd libav-9.9
-    ./configure --prefix=$PREFIX_DIR --enable-shared --enable-libvpx
+    curl -O https://www.libav.org/releases/libav-9.13.tar.gz
+    tar -zxvf libav-9.13.tar.gz
+    cd libav-9.13
+    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus
     make -s V=0
     make install
     cd $CURRENT_DIR
@@ -134,6 +146,7 @@ install_openssl
 install_libnice
 install_libsrtp
 
+install_opus
 if [ "$ENABLE_GPL" = "true" ]; then
   install_mediadeps
 else


### PR DESCRIPTION
While this doesn't add opus support in Licode itself, it does add opus support to libav and moves to libav-9.13 so that we can write opus in an mkv container.
