### PR TITLE
Fix a crash in the destructor of external output.

### DIFF
--- a/erizo/src/erizo/media/ExternalOutput.cpp
+++ b/erizo/src/erizo/media/ExternalOutput.cpp
@@ -72,14 +72,15 @@ ExternalOutput::~ExternalOutput(){
     delete inputProcessor_;
     inputProcessor_ = NULL;
 
-    if (context_ != NULL)
+    if (audio_stream_ != NULL && video_stream_ != NULL && context_ != NULL){
         av_write_trailer(context_);
+    }
 
-    if (video_stream_->codec != NULL){
+    if (video_stream_ && video_stream_->codec != NULL){
         avcodec_close(video_stream_->codec);
     }
 
-    if (audio_stream_->codec != NULL){
+    if (audio_stream_ && audio_stream_->codec != NULL){
         avcodec_close(audio_stream_->codec);
     }
 


### PR DESCRIPTION
Two issues:
1. calling av_write_trailer() without having called avformat_write_header is a party foul
2. dereferencing audio_stream_/video_stream_ without checking for null is also a party foul.
