### PR TITLE
Propagate transport fail state (e.g. 500)

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -346,7 +346,7 @@ namespace erizo {
 
     if (state == TRANSPORT_FAILED) {
       temp = CONN_FAILED;
-      globalState_ = CONN_FAILED;
+      //globalState_ = CONN_FAILED;
       sending_ = false;
       ELOG_INFO("WebRtcConnection failed, stopped sending");
       boost::unique_lock<boost::mutex> lock(receiveVideoMutex_);


### PR DESCRIPTION
When the state 'TRANSPORT_FAILED' is raised it is propagated to the listener. This would allow to subscribe to an onError callback in javascript for example:
https://github.com/ging/licode/blob/master/erizo_controller/erizoJS/erizoJSController.js

```
wrtc.init( function (newStatus){
          var localSdp, answer;
          log.info("webrtc Addon status" + newStatus );
          if (newStatus === 102 && !sdpDelivered) {
            localSdp = wrtc.getLocalSdp();
            answer = getRoap(localSdp, roap);
            callback('callback', answer);
            sdpDelivered = true;

          }
          if (newStatus === 103) {
            callback('onReady');
          }
         if (newStatus === 500) {
            callback('onError');
          }
        });
```
