### PR TITLE
Add the stream when ice negotiation finishes.

### DIFF
--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -447,6 +447,11 @@ var listen = function () {
                         answer = answer.replace(privateRegexp, publicIP);
                         callback(answer, id);
                     }, function() {
+                        st = new ST.Stream({id: id, audio: options.audio, video: options.video, data: options.data, screen: options.screen, attributes: options.attributes});
+                        socket.state = 'sleeping';
+                        socket.streams.push(id);
+                        socket.room.streams[id] = st;
+
                         if (socket.room.streams[id] !== undefined) {
                             sendMsgToRoom(socket.room, 'onAddStream', socket.room.streams[id].getPublicStream());
                         }
@@ -456,10 +461,6 @@ var listen = function () {
                     });
 
                 } else if (options.state === 'ok' && socket.state === 'waitingOk') {
-                    st = new ST.Stream({id: options.streamId, socket: socket.id, audio: options.audio, video: options.video, data: options.data, screen: options.screen, attributes: options.attributes});
-                    socket.state = 'sleeping';
-                    socket.streams.push(options.streamId);
-                    socket.room.streams[options.streamId] = st;
                 }
             } else if (options.state === 'p2pSignaling') {
                 io.sockets.socket(options.subsSocket).emit('onPublishP2P', {sdp: sdp, streamId: options.streamId}, function(answer) {


### PR DESCRIPTION
When it takes longer to send the 'ok' message over socket.io than it
takes to move the ice connection into the complete state, we end up
failing to notify everyone else in the room that there is another
stream.

Instead of waiting for the 'ok' message, create the stream when the ice
connection moves into the complete state. This eliminates the race
condition and ensures that a connected stream is always fully published.

The other side effect here is that the 'ok' message is no longer needed.
I left it for compatibility, but it can easily be removed.
