### PR TITLE
Memory leak fix

### DIFF
--- a/erizo/src/erizo/SdesTransport.cpp
+++ b/erizo/src/erizo/SdesTransport.cpp
@@ -34,7 +34,6 @@ SdesTransport::SdesTransport(MediaType med, const std::string &transport_name, b
 
     cryptoLocal_.cipherSuite = std::string("AES_CM_128_HMAC_SHA1_80");
     cryptoLocal_.mediaType = med;
-    //std::string keyv = SrtpChannel::generateBase64Key();
     std::string keyv = "eUMxlV2Ib6U8qeZot/wEKHw9iMzfKUYpOPJrNnu3";
     ELOG_DEBUG("Key generated: %s", keyv.c_str());
     cryptoLocal_.keyParams = keyv;

--- a/erizo/src/erizo/SrtpChannel.cpp
+++ b/erizo/src/erizo/SrtpChannel.cpp
@@ -108,14 +108,6 @@ int SrtpChannel::unprotectRtcp(char* buffer, int *len) {
     }
 }
 
-std::string SrtpChannel::generateBase64Key() {
-
-    unsigned char key[30];
-    crypto_get_random(key, 30);
-    gchar* base64key = g_base64_encode((guchar*) key, 30);
-    return std::string(base64key);
-}
-
 bool SrtpChannel::configureSrtpSession(srtp_t *session, const char* key,
         enum TransmissionType type) {
     srtp_policy_t policy;
@@ -144,6 +136,7 @@ bool SrtpChannel::configureSrtpSession(srtp_t *session, const char* key,
     if (res!=0){
       ELOG_ERROR("Failed to create srtp session with %s, %d", octet_string_hex_string(akey, 16), res);
     }
+    g_free(akey); akey = NULL;
     return res!=0? false:true;
 }
 

--- a/erizo/src/erizo/SrtpChannel.h
+++ b/erizo/src/erizo/SrtpChannel.h
@@ -72,11 +72,6 @@ public:
 	 * @return true if everything is ok
 	 */
 	bool setRtcpParams(char* sendingKey, char* receivingKey);
-	/**
-	 * Generates a valid key and encodes it in Base64
-	 * @return The new key
-	 */
-	static std::string generateBase64Key();
 
 private:
 	enum TransmissionType {

--- a/erizo/src/erizo/dtls/DtlsClient.cpp
+++ b/erizo/src/erizo/dtls/DtlsClient.cpp
@@ -86,9 +86,15 @@ void DtlsSocketContext::handshakeCompleted()
     memcpy ( sKey, keys->serverMasterKey, keys->serverMasterKeyLen );
     memcpy ( sKey + keys->serverMasterKeyLen, keys->serverMasterSalt, keys->serverMasterSaltLen );
 
+    // g_base64_encode must be free'd with g_free.  Also, std::string's assignment operator does *not* take
+    // ownership of the passed in ptr; under the hood it copies up to the first null character.
+    gchar* temp = g_base64_encode((const guchar*)cKey, keys->clientMasterKeyLen + keys->clientMasterSaltLen);
+    std::string clientKey = temp;
+    g_free(temp); temp = NULL;
 
-    std::string clientKey = g_base64_encode((const guchar*)cKey, keys->clientMasterKeyLen + keys->clientMasterSaltLen);
-    std::string serverKey = g_base64_encode((const guchar*)sKey, keys->serverMasterKeyLen + keys->serverMasterSaltLen);
+    temp = g_base64_encode((const guchar*)sKey, keys->serverMasterKeyLen + keys->serverMasterSaltLen);
+    std::string serverKey = temp;
+    g_free(temp); temp = NULL;
 
     ELOG_DEBUG("ClientKey: %s", clientKey.c_str());
     ELOG_DEBUG("ServerKey: %s", serverKey.c_str());


### PR DESCRIPTION
1. Fix a leak with g_base64 encode/decode use.
2. Remove unused generateBase64Key() call.
