### PR TITLE
fixed issue with firefox publisher delivering black screens

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -281,13 +281,23 @@ namespace erizo {
       } else if (transport->mediaType == VIDEO_TYPE) {
         if (videoSink_ != NULL) {
           RtpHeader *head = reinterpret_cast<RtpHeader*> (buf);
-          // Firefox does not send SSRC in SDP
+          RtcpHeader *chead = reinterpret_cast<RtcpHeader*> (buf);
+           // Firefox does not send SSRC in SDP
           if (this->getVideoSourceSSRC() == 0) {
-            ELOG_DEBUG("Video Source SSRC is %u", head->getSSRC());
-            this->setVideoSourceSSRC(head->getSSRC());
+            unsigned int recvSSRC;
+            if (chead->packettype == RTCP_Sender_PT) { //Sender Report
+              recvSSRC = chead->getSSRC();
+            } else {
+              recvSSRC = head->getSSRC();
+            }
+            ELOG_DEBUG("Video Source SSRC is %u", recvSSRC);
+            this->setVideoSourceSSRC(recvSSRC);
             //this->updateState(TRANSPORT_READY, transport);
           }
-          head->setSSRC(this->getVideoSinkSSRC());
+          // change ssrc for RTP packets, don't touch here if RTCP
+          if (chead->packettype != RTCP_Sender_PT) {
+            head->setSSRC(this->getVideoSinkSSRC());
+          }
           videoSink_->deliverVideoData(buf, length);
         }
       }


### PR DESCRIPTION
Added a fix for Firefox publishers who failed to retrieve proper video SSRC.

WebRtcConnection read the video SSRC from RTP packets when the source was a firefox publisher. It also cast RTCP packets as RTP packets for this. The result is that the bytes 12 to 15 of a RTCP Sender Report were interpreted as SSRC despite those being part of a timestamp. When the first packet was RTP, the algorithm actually had the right video SSRC, but when the first packet was RTCP the wrong video SSRC was retrieved.

This resulted in Firefox publish streams not properly reacting to RTCP feedback because a wrong video SSRC was used. The cause for black screens was that Firefox rejected the Picture Loss Indicator (PLI) because it was sent for a wrong video SSRC.

The fix addresses the issue by checking the packet type for RTCP and reading the video SSRC from the correct position. It also prevents overwriting the timestamp in RTCP packets and only sets the video SSRC if the packet is RTP.

The fix might solve a lot more issues with Firefox since it now uses the correct video SSRC. Chrome publishers were never affected since they provide the video SSRC in the SDP.
