### PR TITLE
Log segfaults in native modules.

### DIFF
--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -88,10 +88,6 @@ var controller = require('./roomController');
 // Logger
 var log = logger.getLogger("ErizoController");
 
-// Log segfaults
-var SegfaultHandler = require('segfault-handler');
-SegfaultHandler.registerHandler();
-
 server.listen(8080);
 
 io.set('log level', 0);

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -7,6 +7,10 @@ var rpc = require('./../common/rpc');
 // Logger
 var log = logger.getLogger("ErizoJSController");
 
+// Log segfaults
+var SegfaultHandler = require('segfault-handler');
+SegfaultHandler.registerHandler();
+
 exports.ErizoJSController = function (spec) {
     "use strict";
 


### PR DESCRIPTION
When native code crashes, we don't get any kind of stack trace to help
us debug. At least dump a stack trace now.

Note: this uses a specific git commit of node-segfault-handler because
the released version does not work correctly with node 0.10.x.
