### PR TITLE
Screen sharing fix.

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -312,7 +312,7 @@ Erizo.Room = function (spec) {
                         type = 'recording';
                         arg = stream.recording;
                     }
-                    sendSDPSocket('publish', {state: type, data: stream.hasData(), audio: stream.hasAudio(), video: stream.hasVideo(), attributes: stream.getAttributes()}, arg, function (answer, id) {
+                    sendSDPSocket('publish', {state: type, data: stream.hasData(), audio: stream.hasAudio(), video: stream.hasVideo(), screen: stream.hasScreen(), attributes: stream.getAttributes()}, arg, function (answer, id) {
 
                         if (answer === 'success') {
                             L.Logger.info('Stream published');
@@ -367,7 +367,7 @@ Erizo.Room = function (spec) {
                 } else {
 
                     stream.pc = Erizo.Connection({callback: function (offer) {
-                        sendSDPSocket('publish', {state: 'offer', data: stream.hasData(), audio: stream.hasAudio(), video: stream.hasVideo(), attributes: stream.getAttributes()}, offer, function (answer, id) {
+                        sendSDPSocket('publish', {state: 'offer', data: stream.hasData(), audio: stream.hasAudio(), video: stream.hasVideo(), screen: stream.hasScreen(), attributes: stream.getAttributes()}, offer, function (answer, id) {
                             if (answer === 'error') {
                                 if (callbackError)
                                     callbackError(answer);


### PR DESCRIPTION
The screen property was not transferring successfully.  When the client would go to subscribe to the stream, it would not know that it has screen content.  This fix seems to fix the problem, but I'm fairly new to the codebase.

When subscribing to the stream I would get the following in the console:
INFO Stream subscribed
INFO Subscribing to anything

Then nothing.

Same topic mentioned here: https://groups.google.com/forum/#!topic/lynckia/VbPreX20qrs
