### PR TITLE
Fix for bundled SDP

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -122,14 +122,29 @@ namespace erizo {
   std::string WebRtcConnection::getLocalSdp() {
     boost::mutex::scoped_lock lock(updateStateMutex_);
     ELOG_DEBUG("Getting SDP");
-    if (videoTransport_ != NULL) {
-      videoTransport_->processLocalSdp(&localSdp_);
+    if(bundle_) {
+        ELOG_DEBUG("Bundled Transports!")
+        if( videoTransport_ != NULL) {
+            videoTransport_->processLocalSdp(&localSdp_);
+            ELOG_DEBUG("Video SDP done.");
+        } else if( audioTransport_ != NULL) {
+            audioTransport_->processLocalSdp(&localSdp_);
+            ELOG_DEBUG("Audio SDP done.");
+        }
+        else {
+            ELOG_WARN("Bundle mode, but no audio or video transports?");
+        }
+    } else {
+        if (videoTransport_ != NULL) {
+            videoTransport_->processLocalSdp(&localSdp_);
+            ELOG_DEBUG("Video SDP done.");
+        }
+        if (audioTransport_ != NULL) {
+            audioTransport_->processLocalSdp(&localSdp_);
+            ELOG_DEBUG("Video SDP done.");
+        }
     }
-    ELOG_DEBUG("Video SDP done.");
-    if (!bundle_ && audioTransport_ != NULL) {
-      audioTransport_->processLocalSdp(&localSdp_);
-    }
-    ELOG_DEBUG("Audio SDP done.");
+
     localSdp_.profile = remoteSdp_.profile;
     return localSdp_.getSdp();
   }


### PR DESCRIPTION
Licode was assuming if we had BUNDLE sdp that there was a video transport--this breaks if we're doing audio only because it only looks at the video transport's SDP in bundle mode. Change it so if we're bundled, we'll just use the first transport available to us to generate our candidates. If non-bundle, we have to generate candidates for each transport individually.
