### PR TITLE
fixed issue with crashing erizoJS not recognized by controller

### DIFF
--- a/erizo_controller/erizoController/roomController.js
+++ b/erizo_controller/erizoController/roomController.js
@@ -30,7 +30,7 @@ exports.RoomController = function (spec) {
     var callbackFor = function(erizo_id, publisher_id) {
         return function(ok) {
             if (ok !== true) {
-                dispatchEvent("unpublish", erizo_id);
+                dispatchEvent("unpublish", publisher_id);
                 rpc.callRpc("ErizoAgent", "deleteErizoJS", [erizo_id], {callback: function(){
                     delete erizos[publisher_id];
                 }});


### PR DESCRIPTION
When an ErizoJS crashes or is kill'ed, the roomController already sends a message to erizoController. ErizoController requires the publisher_id, though.
