### PR TITLE
add timestamp to startRecording callback

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -526,18 +526,18 @@ Erizo.Room = function (spec) {
         }
     };
 
-    // Returns callback(id, error)
+    // Returns callback(id, error, timestamp)
     that.startRecording = function (stream, callback) {
         L.Logger.debug("Start Recording stream: " + stream.getID());
-        sendMessageSocket('startRecorder', {to: stream.getID()}, function(id, error){
-            if (id === null){
+        sendMessageSocket('startRecorder', {to: stream.getID()}, function(result, error){
+            if (result && result.id){
+                L.Logger.info('Start recording', result.id);
+                if (callback) callback(result.id, undefined, result.timestamp);
+            } else {
                 L.Logger.error('Error on start recording', error);
-                if (callback) callback(undefined, error);
+                if (callback) callback(undefined, error, undefined);
                 return;
             }
-
-            L.Logger.info('Start recording', id);
-            if (callback) callback(id);
         });
     }
 

--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -644,9 +644,10 @@ var listen = function () {
 
             if (socket.room.streams[streamId].hasAudio() || socket.room.streams[streamId].hasVideo() || socket.room.streams[streamId].hasScreen()) {
                 socket.room.controller.addExternalOutput(streamId, url, function (result) {
+                    var timestamp = new Date().getTime();
                     if (result === 'success') {
                         log.info("erizoController.js: Recorder Started");
-                        callback(recordingId);
+                        callback({id: recordingId, timestamp: timestamp}, null);
                     } else {
                         callback(null, 'Unable to subscribe to stream for recording, publisher not present');
                     }


### PR DESCRIPTION
This change adds a timestamp of the moment the recording has been started. It should offer backward compatibility to clients that are already using `startRecording` function and his callback since it just adds a third param with the timestamp value.
