### PR TITLE
[BUGFIX] subscribe on room in connecting state

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -726,6 +726,12 @@ Erizo.Room = function (spec) {
 
     // It subscribe to a remote stream and draws it inside the HTML tag given by the ID='elementID'
     that.subscribe = function (stream, options, callback) {
+        if (that.state !== CONNECTED) {
+            if (callback)
+                callback(undefined, 'Unable to subscribe. Room is not connected yet, retry');
+            L.Logger.error('Unable to subscribe. Room is not connected yet, retry');
+            return;
+        }
 
         options = options || {};
 


### PR DESCRIPTION
fix a bug where “stream-added” was called between the room.connect() method and its event callback “room-connected”.

this caused the subscribe method to try to open a peer connection but spec aren’t available yet (such as iceServers, maxVideoBW, etc.).
This is an issue when we have to rely on TURN, cause the iceServers list is empty and the peerconnection fails without notifying us.