### PR TITLE
Create services in Pipeline to help handlers

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -48,17 +48,22 @@ WebRtcConnection::WebRtcConnection(std::shared_ptr<Worker> worker, const std::st
 
   rtcp_processor_ = std::make_shared<RtcpForwarder>(static_cast<MediaSink*>(this), static_cast<MediaSource*>(this));
 
+  pipeline_->addService(this);
+  pipeline_->addService(rtcp_processor_);
+
   // TODO(pedro): consider creating the pipeline on setRemoteSdp or createOffer
   pipeline_->addFront(PacketReader(this));
-  pipeline_->addFront(RtcpProcessorHandler(this, rtcp_processor_));
-  pipeline_->addFront(IncomingStatsHandler(this));
-  pipeline_->addFront(FecReceiverHandler(this));
-  pipeline_->addFront(RtpAudioMuteHandler(this));
-  pipeline_->addFront(RtpSlideShowHandler(this));
-  pipeline_->addFront(std::make_shared<BandwidthEstimationHandler>(this, worker_));
-  pipeline_->addFront(RRGenerationHandler(this));
-  pipeline_->addFront(RtpRetransmissionHandler(this));
-  pipeline_->addFront(OutgoingStatsHandler(this));
+
+  pipeline_->addFront(RtcpProcessorHandler());
+  pipeline_->addFront(IncomingStatsHandler());
+  pipeline_->addFront(FecReceiverHandler());
+  pipeline_->addFront(RtpAudioMuteHandler());
+  pipeline_->addFront(RtpSlideShowHandler());
+  pipeline_->addFront(BandwidthEstimationHandler());
+  pipeline_->addFront(RRGenerationHandler());
+  pipeline_->addFront(RtpRetransmissionHandler());
+  pipeline_->addFront(OutgoingStatsHandler());
+
   pipeline_->addFront(PacketWriter(this));
   pipeline_->finalize();
 

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -18,6 +18,7 @@
 #include "rtp/RtpExtensionProcessor.h"
 #include "lib/Clock.h"
 #include "pipeline/Handler.h"
+#include "pipeline/Service.h"
 
 namespace erizo {
 
@@ -56,7 +57,7 @@ class WebRtcConnectionStatsListener {
  */
 class WebRtcConnection: public MediaSink, public MediaSource, public FeedbackSink,
                         public FeedbackSource, public TransportListener, public LogContext,
-                        public std::enable_shared_from_this<WebRtcConnection> {
+                        public std::enable_shared_from_this<WebRtcConnection>, public Service {
   DECLARE_LOGGER();
 
  public:
@@ -161,6 +162,8 @@ class WebRtcConnection: public MediaSink, public MediaSource, public FeedbackSin
   bool isSlideShowModeEnabled() { return slide_show_mode_; }
 
   RtpExtensionProcessor& getRtpExtensionProcessor() { return extProcessor_; }
+
+  std::shared_ptr<Worker> getWorker() { return worker_; }
 
   Stats& getStats() {
     return stats_;

--- a/erizo/src/erizo/pipeline/Pipeline-inl.h
+++ b/erizo/src/erizo/pipeline/Pipeline-inl.h
@@ -27,7 +27,7 @@ PipelineBase& PipelineBase::addBack(H&& handler) {
 
 template <class H>
 PipelineBase& PipelineBase::addBack(H* handler) {
-  return addBack(std::shared_ptr<H>(handler, [](H*){}));
+  return addBack(std::shared_ptr<H>(handler, [](H*){}));  // NOLINT
 }
 
 template <class H>
@@ -45,7 +45,7 @@ PipelineBase& PipelineBase::addFront(H&& handler) {
 
 template <class H>
 PipelineBase& PipelineBase::addFront(H* handler) {
-  return addFront(std::shared_ptr<H>(handler, [](H*){}));
+  return addFront(std::shared_ptr<H>(handler, [](H*){}));  // NOLINT
 }
 
 template <class H>
@@ -124,12 +124,12 @@ bool PipelineBase::setOwner(H* handler) {
 
 template <class Context>
 void PipelineBase::addContextFront(Context* ctx) {
-  addHelper(std::shared_ptr<Context>(ctx, [](Context*){}), true);
+  addHelper(std::shared_ptr<Context>(ctx, [](Context*){}), true);  // NOLINT
 }
 
 template <class Context>
 PipelineBase& PipelineBase::addHelper(
-    std::shared_ptr<Context>&& ctx,
+    std::shared_ptr<Context>&& ctx,  // NOLINT
     bool front) {
   ctxs_.insert(front ? ctxs_.begin() : ctxs_.end(), ctx);
   if (Context::dir == HandlerDir::BOTH || Context::dir == HandlerDir::IN) {
@@ -140,6 +140,63 @@ PipelineBase& PipelineBase::addHelper(
   }
   return *this;
 }
+
+template <class S>
+void PipelineBase::addService(std::shared_ptr<S> service) {
+  typedef typename ServiceContextType<S>::type Context;
+  service_ctxs_.push_back(std::make_shared<Context>(shared_from_this(), std::move(service)));
+}
+
+template <class S>
+void PipelineBase::addService(S&& service) {
+  addService(std::make_shared<S>(std::forward<S>(service)));
+}
+
+template <class S>
+void PipelineBase::addService(S* service) {
+  addService(std::shared_ptr<S>(service, [](S*){}));  // NOLINT
+}
+
+template <class S>
+typename ServiceContextType<S>::type* PipelineBase::getServiceContext() {
+  for (auto pipeline_service_ctx : service_ctxs_) {
+    auto ctx = dynamic_cast<typename ServiceContextType<S>::type*>(pipeline_service_ctx.get());
+    if (ctx) {
+      return ctx;
+    }
+  }
+  return nullptr;
+}
+
+template <class S>
+std::shared_ptr<S> PipelineBase::getService() {
+  auto ctx = getServiceContext<S>();
+  return ctx ? ctx->getService() : std::shared_ptr<S>();
+}
+
+template <class S>
+void PipelineBase::removeService() {
+  typedef typename ServiceContextType<S>::type Context;
+  bool removed = false;
+  for (auto it = service_ctxs_.begin(); it != service_ctxs_.end(); it++) {
+    auto ctx = std::dynamic_pointer_cast<Context>(*it);
+    if (ctx) {
+      (*it)->detachPipeline();
+      it = service_ctxs_.erase(it);
+      removed = true;
+      if (it == service_ctxs_.end()) {
+        break;
+      }
+    }
+  }
+
+  if (!removed) {
+    throw std::invalid_argument("No such handler in pipeline");
+  }
+
+  return *this;
+}
+
 
 }  // namespace erizo
 

--- a/erizo/src/erizo/pipeline/Pipeline.cpp
+++ b/erizo/src/erizo/pipeline/Pipeline.cpp
@@ -126,6 +126,10 @@ void Pipeline::finalize() {
   for (auto it = ctxs_.rbegin(); it != ctxs_.rend(); it++) {
     (*it)->attachPipeline();
   }
+
+  for (auto it = service_ctxs_.rbegin(); it != service_ctxs_.rend(); it++) {
+    (*it)->attachPipeline();
+  }
 }
 
 void Pipeline::notifyUpdate() {

--- a/erizo/src/erizo/pipeline/Pipeline.h
+++ b/erizo/src/erizo/pipeline/Pipeline.h
@@ -14,11 +14,13 @@
 #include <vector>
 
 #include "pipeline/HandlerContext.h"
+#include "pipeline/ServiceContext.h"
 #include "./MediaDefinitions.h"
 
 namespace erizo {
 
 class PipelineBase;
+class WebRtcConnection;
 
 class PipelineManager {
  public:
@@ -85,6 +87,24 @@ class PipelineBase : public std::enable_shared_from_this<PipelineBase> {
   template <class H>
   typename ContextType<H>::type* getContext();
 
+  template <class S>
+  void addService(std::shared_ptr<S> service);
+
+  template <class S>
+  void addService(S&& service);
+
+  template <class S>
+  void addService(S* service);
+
+  template <class S>
+  void removeService();
+
+  template <class S>
+  typename ServiceContextType<S>::type* getServiceContext();
+
+  template <class S>
+  std::shared_ptr<S> getService();
+
   // If one of the handlers owns the pipeline itself, use setOwner to ensure
   // that the pipeline doesn't try to detach the handler during destruction,
   // lest destruction ordering issues occur.
@@ -104,11 +124,13 @@ class PipelineBase : public std::enable_shared_from_this<PipelineBase> {
   std::vector<PipelineContext*> inCtxs_;
   std::vector<PipelineContext*> outCtxs_;
 
+  std::vector<std::shared_ptr<PipelineServiceContext>> service_ctxs_;
+
  private:
   PipelineManager* manager_{nullptr};
 
   template <class Context>
-  PipelineBase& addHelper(std::shared_ptr<Context>&& ctx, bool front);
+  PipelineBase& addHelper(std::shared_ptr<Context>&& ctx, bool front);  // NOLINT
 
   template <class H>
   PipelineBase& removeHelper(H* handler, bool checkEqual);

--- a/erizo/src/erizo/pipeline/Service.h
+++ b/erizo/src/erizo/pipeline/Service.h
@@ -1,0 +1,35 @@
+#ifndef ERIZO_SRC_ERIZO_PIPELINE_SERVICE_H_
+#define ERIZO_SRC_ERIZO_PIPELINE_SERVICE_H_
+
+#include "pipeline/Pipeline.h"
+
+namespace erizo {
+
+class PipelineBase;
+
+template <class Context>
+class ServiceBase {
+ public:
+  virtual ~ServiceBase() = default;
+
+  virtual void attachPipeline(Context* /*ctx*/) {}
+  virtual void detachPipeline(Context* /*ctx*/) {}
+
+  Context* getContext() {
+    if (attach_count_ != 1) {
+      return nullptr;
+    }
+    assert(service_ctx_);
+    return service_ctx_;
+  }
+
+ private:
+  friend PipelineServiceContext;
+  uint64_t attach_count_{0};
+  Context* service_ctx_{nullptr};
+};
+
+class Service : public ServiceBase<ServiceContext> {
+};
+}  // namespace erizo
+#endif  // ERIZO_SRC_ERIZO_PIPELINE_SERVICE_H_

--- a/erizo/src/erizo/pipeline/ServiceContext-inl.h
+++ b/erizo/src/erizo/pipeline/ServiceContext-inl.h
@@ -1,0 +1,98 @@
+#ifndef ERIZO_SRC_ERIZO_PIPELINE_SERVICECONTEXT_INL_H_
+#define ERIZO_SRC_ERIZO_PIPELINE_SERVICECONTEXT_INL_H_
+
+namespace erizo {
+
+class PipelineServiceContext {
+ public:
+  virtual ~PipelineServiceContext() = default;
+
+  virtual void attachPipeline() = 0;
+  virtual void detachPipeline() = 0;
+
+  template <class S, class Context>
+  void attachContext(S* service, Context* ctx) {
+    if (++service->attach_count_ == 1) {
+      service->service_ctx_ = ctx;
+    } else {
+      service->service_ctx_ = nullptr;
+    }
+  }
+};
+
+template <class S, class Context>
+class ServiceContextImplBase : public PipelineServiceContext {
+ public:
+  ~ServiceContextImplBase() = default;
+
+  std::shared_ptr<S> getService() {
+    return service_;
+  }
+
+  void initialize(
+      std::weak_ptr<PipelineBase> pipeline,
+      std::shared_ptr<S> service) {
+    pipeline_weak_ = pipeline;
+    pipeline_raw_ = pipeline.lock().get();
+    service_ = std::move(service);
+  }
+
+  // PipelineContext overrides
+  void attachPipeline() override {
+    if (!attached_) {
+      attachContext(service_.get(), impl_);
+      service_->attachPipeline(impl_);
+      attached_ = true;
+    }
+  }
+
+  void detachPipeline() override {
+    service_->detachPipeline(impl_);
+    attached_ = false;
+  }
+
+ protected:
+  Context* impl_;
+  std::weak_ptr<PipelineBase> pipeline_weak_;
+  PipelineBase* pipeline_raw_;
+  std::shared_ptr<S> service_;
+
+ private:
+  bool attached_{false};
+};
+
+template <class S>
+class ServiceContextImpl
+  : public ServiceContext,
+    public ServiceContextImplBase<S, ServiceContext> {
+ public:
+  explicit ServiceContextImpl(
+      std::weak_ptr<PipelineBase> pipeline,
+      std::shared_ptr<S> service) {
+    this->impl_ = this;
+    this->initialize(pipeline, std::move(service));
+  }
+
+  // For StaticPipeline
+  ServiceContextImpl() {
+    this->impl_ = this;
+  }
+
+  ~ServiceContextImpl() = default;
+
+  PipelineBase* getPipeline() override {
+    return this->pipeline_raw_;
+  }
+
+  std::shared_ptr<PipelineBase> getPipelineShared() override {
+    return this->pipeline_weak_.lock();
+  }
+};
+
+template <class Service>
+struct ServiceContextType {
+  typedef ServiceContextImpl<Service> type;
+};
+
+}  // namespace erizo
+#endif  // ERIZO_SRC_ERIZO_PIPELINE_SERVICECONTEXT_INL_H_

--- a/erizo/src/erizo/pipeline/ServiceContext.h
+++ b/erizo/src/erizo/pipeline/ServiceContext.h
@@ -1,0 +1,20 @@
+#ifndef ERIZO_SRC_ERIZO_PIPELINE_SERVICECONTEXT_H_
+#define ERIZO_SRC_ERIZO_PIPELINE_SERVICECONTEXT_H_
+
+namespace erizo {
+
+class PipelineBase;
+
+class ServiceContext {
+ public:
+  virtual ~ServiceContext() = default;
+
+  virtual PipelineBase* getPipeline() = 0;
+  virtual std::shared_ptr<PipelineBase> getPipelineShared() = 0;
+};
+
+}  // namespace erizo
+
+#include <pipeline/ServiceContext-inl.h>
+
+#endif  // ERIZO_SRC_ERIZO_PIPELINE_SERVICECONTEXT_H_

--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.h
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.h
@@ -38,7 +38,7 @@ class BandwidthEstimationHandler: public Handler, public RemoteBitrateObserver,
  public:
   static const uint32_t kRembMinimumBitrate;
 
-  explicit BandwidthEstimationHandler(WebRtcConnection *connection, std::shared_ptr<Worker> worker,
+  explicit BandwidthEstimationHandler(
     std::shared_ptr<RemoteBitrateEstimatorPicker> picker = std::make_shared<RemoteBitrateEstimatorPicker>());
 
   void OnReceiveBitrateChanged(const std::vector<uint32_t>& ssrcs,
@@ -56,8 +56,6 @@ class BandwidthEstimationHandler: public Handler, public RemoteBitrateObserver,
   void notifyUpdate() override;
 
   void updateExtensionMaps(std::array<RTPExtensions, 10> video_map, std::array<RTPExtensions, 10> audio_map);
-
-  uint32_t getLastSendBitrate();
 
  private:
   void process();
@@ -82,7 +80,7 @@ class BandwidthEstimationHandler: public Handler, public RemoteBitrateObserver,
   RtpHeaderExtensionMap ext_map_audio_, ext_map_video_;
   Context *temp_ctx_;
   uint32_t bitrate_;
-  std::atomic<uint32_t> last_send_bitrate_;
+  uint32_t last_send_bitrate_;
   uint64_t last_remb_time_;
   bool running_;
   bool active_;

--- a/erizo/src/erizo/rtp/FecReceiverHandler.cpp
+++ b/erizo/src/erizo/rtp/FecReceiverHandler.cpp
@@ -6,8 +6,8 @@ namespace erizo {
 
 DEFINE_LOGGER(FecReceiverHandler, "rtp.FecReceiverHandler");
 
-FecReceiverHandler::FecReceiverHandler(WebRtcConnection *connection) :
-    connection_{connection}, enabled_{false} {
+FecReceiverHandler::FecReceiverHandler() :
+    enabled_{false} {
   fec_receiver_.reset(webrtc::UlpfecReceiver::Create(this));
 }
 
@@ -24,8 +24,16 @@ void FecReceiverHandler::disable() {
 }
 
 void FecReceiverHandler::notifyUpdate() {
-  SdpInfo &remote_sdp = connection_->getRemoteSdpInfo();
-  bool is_slide_show_mode_active = connection_->isSlideShowModeEnabled();
+  auto pipeline = getContext()->getPipelineShared();
+  if (!pipeline) {
+    return;
+  }
+  std::shared_ptr<WebRtcConnection> connection = pipeline->getService<WebRtcConnection>();
+  if (!connection) {
+    return;
+  }
+  SdpInfo &remote_sdp = connection->getRemoteSdpInfo();
+  bool is_slide_show_mode_active = connection->isSlideShowModeEnabled();
   if (!remote_sdp.supportPayloadType(RED_90000_PT) || is_slide_show_mode_active) {
     enable();
   } else {

--- a/erizo/src/erizo/rtp/FecReceiverHandler.h
+++ b/erizo/src/erizo/rtp/FecReceiverHandler.h
@@ -15,7 +15,7 @@ class FecReceiverHandler: public OutboundHandler, public webrtc::RtpData {
   DECLARE_LOGGER();
 
  public:
-  explicit FecReceiverHandler(WebRtcConnection* connection);
+  FecReceiverHandler();
 
   void setFecReceiver(std::unique_ptr<webrtc::UlpfecReceiver>&& fec_receiver);  // NOLINT
 
@@ -35,7 +35,6 @@ class FecReceiverHandler: public OutboundHandler, public webrtc::RtpData {
   bool OnRecoveredPacket(const uint8_t* packet, size_t packet_length) override;
 
  private:
-  WebRtcConnection* connection_;
   bool enabled_;
   std::unique_ptr<webrtc::UlpfecReceiver> fec_receiver_;
 };

--- a/erizo/src/erizo/rtp/RRGenerationHandler.h
+++ b/erizo/src/erizo/rtp/RRGenerationHandler.h
@@ -18,7 +18,7 @@ class RRGenerationHandler: public Handler {
 
 
  public:
-  explicit RRGenerationHandler(WebRtcConnection *connection);
+  RRGenerationHandler();
 
   void enable() override;
   void disable() override;
@@ -50,7 +50,6 @@ class RRGenerationHandler: public Handler {
     double jitter;
   };
 
-  Context *temp_ctx_;
   uint8_t packet_[128];
   bool enabled_;
   RRPackets audio_rr_, video_rr_;

--- a/erizo/src/erizo/rtp/RtcpProcessor.h
+++ b/erizo/src/erizo/rtp/RtcpProcessor.h
@@ -10,6 +10,7 @@
 #include "./MediaDefinitions.h"
 #include "./SdpInfo.h"
 #include "rtp/RtpHeaders.h"
+#include "pipeline/Service.h"
 
 namespace erizo {
 
@@ -110,7 +111,7 @@ class RtcpData {
   boost::mutex dataLock;
 };
 
-class RtcpProcessor{
+class RtcpProcessor : public Service {
  public:
   RtcpProcessor(MediaSink* msink, MediaSource* msource, uint32_t maxVideoBw = 300000):
     rtcpSink_(msink), rtcpSource_(msource) {}

--- a/erizo/src/erizo/rtp/RtcpProcessorHandler.cpp
+++ b/erizo/src/erizo/rtp/RtcpProcessorHandler.cpp
@@ -6,8 +6,7 @@ namespace erizo {
 
 DEFINE_LOGGER(RtcpProcessorHandler, "rtp.RtcpProcessorHandler");
 
-RtcpProcessorHandler::RtcpProcessorHandler(WebRtcConnection *connection, std::shared_ptr<RtcpProcessor> processor) :
-    connection_{connection}, processor_{processor} {
+RtcpProcessorHandler::RtcpProcessorHandler() : connection_{nullptr} {
 }
 
 void RtcpProcessorHandler::enable() {
@@ -44,5 +43,10 @@ void RtcpProcessorHandler::write(Context *ctx, std::shared_ptr<dataPacket> packe
 }
 
 void RtcpProcessorHandler::notifyUpdate() {
+  auto pipeline = getContext()->getPipelineShared();
+  if (pipeline && !connection_) {
+    connection_ = pipeline->getService<WebRtcConnection>().get();
+    processor_ = pipeline->getService<RtcpProcessor>();
+  }
 }
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/RtcpProcessorHandler.h
+++ b/erizo/src/erizo/rtp/RtcpProcessorHandler.h
@@ -15,7 +15,7 @@ class RtcpProcessorHandler: public Handler {
   DECLARE_LOGGER();
 
  public:
-  explicit RtcpProcessorHandler(WebRtcConnection* connection, std::shared_ptr<RtcpProcessor> processor);
+  RtcpProcessorHandler();
 
   void enable() override;
   void disable() override;

--- a/erizo/src/erizo/rtp/RtpAudioMuteHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpAudioMuteHandler.cpp
@@ -6,8 +6,8 @@ namespace erizo {
 
 DEFINE_LOGGER(RtpAudioMuteHandler, "rtp.RtpAudioMuteHandler");
 
-RtpAudioMuteHandler::RtpAudioMuteHandler(WebRtcConnection *connection) :
-  last_original_seq_num_{-1}, seq_num_offset_{0}, mute_is_active_{false}, connection_{connection} {}
+RtpAudioMuteHandler::RtpAudioMuteHandler() :
+  last_original_seq_num_{-1}, seq_num_offset_{0}, mute_is_active_{false}, connection_{nullptr} {}
 
 
 void RtpAudioMuteHandler::enable() {
@@ -17,6 +17,10 @@ void RtpAudioMuteHandler::disable() {
 }
 
 void RtpAudioMuteHandler::notifyUpdate() {
+  auto pipeline = getContext()->getPipelineShared();
+  if (pipeline && !connection_) {
+    connection_ = pipeline->getService<WebRtcConnection>().get();
+  }
   muteAudio(connection_->isAudioMuted());
 }
 

--- a/erizo/src/erizo/rtp/RtpAudioMuteHandler.h
+++ b/erizo/src/erizo/rtp/RtpAudioMuteHandler.h
@@ -14,7 +14,7 @@ class RtpAudioMuteHandler: public Handler {
   DECLARE_LOGGER();
 
  public:
-  explicit RtpAudioMuteHandler(WebRtcConnection* connection);
+  RtpAudioMuteHandler();
   void muteAudio(bool active);
 
   void enable() override;

--- a/erizo/src/erizo/rtp/RtpRetransmissionHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpRetransmissionHandler.cpp
@@ -4,10 +4,10 @@ namespace erizo {
 
 DEFINE_LOGGER(RtpRetransmissionHandler, "rtp.RtpRetransmissionHandler");
 
-RtpRetransmissionHandler::RtpRetransmissionHandler(WebRtcConnection *connection)
-  : connection_{connection},
-  audio_{kRetransmissionsBufferSize},
-  video_{kRetransmissionsBufferSize} {}
+RtpRetransmissionHandler::RtpRetransmissionHandler()
+  : connection_{nullptr},
+    audio_{kRetransmissionsBufferSize},
+    video_{kRetransmissionsBufferSize} {}
 
 
 void RtpRetransmissionHandler::enable() {
@@ -17,6 +17,10 @@ void RtpRetransmissionHandler::disable() {
 }
 
 void RtpRetransmissionHandler::notifyUpdate() {
+  auto pipeline = getContext()->getPipelineShared();
+  if (pipeline && !connection_) {
+    connection_ = pipeline->getService<WebRtcConnection>().get();
+  }
 }
 
 void RtpRetransmissionHandler::read(Context *ctx, std::shared_ptr<dataPacket> packet) {

--- a/erizo/src/erizo/rtp/RtpRetransmissionHandler.h
+++ b/erizo/src/erizo/rtp/RtpRetransmissionHandler.h
@@ -15,7 +15,7 @@ class RtpRetransmissionHandler : public Handler {
  public:
   DECLARE_LOGGER();
 
-  explicit RtpRetransmissionHandler(WebRtcConnection *connection);
+  RtpRetransmissionHandler();
 
   void enable() override;
   void disable() override;

--- a/erizo/src/erizo/rtp/RtpSlideShowHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpSlideShowHandler.cpp
@@ -5,9 +5,11 @@ namespace erizo {
 
 DEFINE_LOGGER(RtpSlideShowHandler, "rtp.RtpSlideShowHandler");
 
-RtpSlideShowHandler::RtpSlideShowHandler(WebRtcConnection *connection) : connection_(connection),
-  slideshow_seq_num_{-1}, last_original_seq_num_{-1}, seq_num_offset_{0}, slideshow_is_active_{false},
-  sending_keyframe_ {false} {}
+RtpSlideShowHandler::RtpSlideShowHandler()
+  : connection_{nullptr},
+    slideshow_seq_num_{-1}, last_original_seq_num_{-1}, seq_num_offset_{0},
+    slideshow_is_active_{false},
+    sending_keyframe_ {false} {}
 
 
 void RtpSlideShowHandler::enable() {
@@ -17,6 +19,10 @@ void RtpSlideShowHandler::disable() {
 }
 
 void RtpSlideShowHandler::notifyUpdate() {
+  auto pipeline = getContext()->getPipelineShared();
+  if (pipeline && !connection_) {
+    connection_ = pipeline->getService<WebRtcConnection>().get();
+  }
   setSlideShowMode(connection_->isSlideShowModeEnabled());
 }
 

--- a/erizo/src/erizo/rtp/RtpSlideShowHandler.h
+++ b/erizo/src/erizo/rtp/RtpSlideShowHandler.h
@@ -14,7 +14,7 @@ class RtpSlideShowHandler : public Handler {
   DECLARE_LOGGER();
 
  public:
-  explicit RtpSlideShowHandler(WebRtcConnection* connection);
+  RtpSlideShowHandler();
 
   void enable() override;
   void disable() override;

--- a/erizo/src/erizo/rtp/StatsHandler.cpp
+++ b/erizo/src/erizo/rtp/StatsHandler.cpp
@@ -7,8 +7,7 @@ namespace erizo {
 DEFINE_LOGGER(IncomingStatsHandler, "rtp.IncomingStatsHandler");
 DEFINE_LOGGER(OutgoingStatsHandler, "rtp.OutgoingStatsHandler");
 
-IncomingStatsHandler::IncomingStatsHandler(WebRtcConnection *connection) :
-  connection_{connection} {}
+IncomingStatsHandler::IncomingStatsHandler() : connection_{nullptr} {}
 
 
 void IncomingStatsHandler::enable() {
@@ -18,6 +17,10 @@ void IncomingStatsHandler::disable() {
 }
 
 void IncomingStatsHandler::notifyUpdate() {
+  auto pipeline = getContext()->getPipelineShared();
+  if (pipeline && !connection_) {
+    connection_ = pipeline->getService<WebRtcConnection>().get();
+  }
 }
 
 void IncomingStatsHandler::read(Context *ctx, std::shared_ptr<dataPacket> packet) {
@@ -31,8 +34,7 @@ void IncomingStatsHandler::read(Context *ctx, std::shared_ptr<dataPacket> packet
   ctx->fireRead(packet);
 }
 
-OutgoingStatsHandler::OutgoingStatsHandler(WebRtcConnection *connection) :
-  connection_{connection} {}
+OutgoingStatsHandler::OutgoingStatsHandler() : connection_{nullptr} {}
 
 void OutgoingStatsHandler::enable() {
 }
@@ -41,6 +43,10 @@ void OutgoingStatsHandler::disable() {
 }
 
 void OutgoingStatsHandler::notifyUpdate() {
+  auto pipeline = getContext()->getPipelineShared();
+  if (pipeline && !connection_) {
+    connection_ = pipeline->getService<WebRtcConnection>().get();
+  }
 }
 
 void OutgoingStatsHandler::write(Context *ctx, std::shared_ptr<dataPacket> packet) {

--- a/erizo/src/erizo/rtp/StatsHandler.h
+++ b/erizo/src/erizo/rtp/StatsHandler.h
@@ -14,7 +14,7 @@ class IncomingStatsHandler: public InboundHandler {
   DECLARE_LOGGER();
 
  public:
-  explicit IncomingStatsHandler(WebRtcConnection* connection);
+  IncomingStatsHandler();
 
   void enable() override;
   void disable() override;
@@ -34,7 +34,7 @@ class OutgoingStatsHandler: public OutboundHandler {
   DECLARE_LOGGER();
 
  public:
-  explicit OutgoingStatsHandler(WebRtcConnection* connection);
+  OutgoingStatsHandler();
 
   void enable() override;
   void disable() override;

--- a/erizo/src/test/rtp/BandwidthEstimationHandlerTest.cpp
+++ b/erizo/src/test/rtp/BandwidthEstimationHandlerTest.cpp
@@ -47,7 +47,7 @@ class BandwidthEstimationHandlerTest : public erizo::HandlerTest {
     EXPECT_CALL(*picker.get(), pickEstimatorProxy(_, _, _))
       .WillRepeatedly(Return(new erizo::RemoteBitrateEstimatorProxy(&estimator)));
 
-    bwe_handler = std::make_shared<BandwidthEstimationHandler>(connection.get(), worker, picker);
+    bwe_handler = std::make_shared<BandwidthEstimationHandler>(picker);
     pipeline->addBack(bwe_handler);
   }
 
@@ -69,11 +69,9 @@ TEST_F(BandwidthEstimationHandlerTest, basicBehaviourShouldWritePackets) {
 TEST_F(BandwidthEstimationHandlerTest, basicBehaviourShouldReadPackets) {
   auto packet1 = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
   auto packet2 = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
-
   EXPECT_CALL(estimator, Process());
   EXPECT_CALL(estimator, TimeUntilNextProcess()).WillRepeatedly(Return(1000));
   EXPECT_CALL(estimator, IncomingPacket(_, _, _));
-
   EXPECT_CALL(*reader.get(), read(_, _)).
     With(Args<1>(erizo::RtpHasSequenceNumber(erizo::kArbitrarySeqNumber))).Times(2);
   pipeline->read(packet1);

--- a/erizo/src/test/rtp/FecReceiverHandlerTest.cpp
+++ b/erizo/src/test/rtp/FecReceiverHandlerTest.cpp
@@ -40,7 +40,7 @@ class FecReceiverHandlerTest : public erizo::HandlerTest {
 
  protected:
   void setHandler() {
-    fec_receiver_handler = std::make_shared<FecReceiverHandler>(connection.get());
+    fec_receiver_handler = std::make_shared<FecReceiverHandler>();
     fec_receiver = new MockUlpfecReceiver();
     fec_receiver_handler->setFecReceiver(std::unique_ptr<webrtc::UlpfecReceiver>(fec_receiver));
     pipeline->addBack(fec_receiver_handler);
@@ -65,19 +65,6 @@ TEST_F(FecReceiverHandlerTest, shouldNotCallFecReceiverWhenReceivingREDpacketsAn
     rtp_header->setPayloadType(RED_90000_PT);
 
     fec_receiver_handler->disable();
-
-    EXPECT_CALL(*fec_receiver, AddReceivedRedPacket(_, _, _, _)).Times(0);
-    EXPECT_CALL(*fec_receiver, ProcessReceivedFec()).Times(0);
-    EXPECT_CALL(*writer.get(), write(_, _)).
-      With(Args<1>(erizo::RtpHasSequenceNumber(erizo::kArbitrarySeqNumber))).Times(1);
-
-    pipeline->write(packet);
-}
-
-TEST_F(FecReceiverHandlerTest, shouldNotCallFecReceiverByDefaultWhenReceivingREDpackets) {
-    auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
-    RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
-    rtp_header->setPayloadType(RED_90000_PT);
 
     EXPECT_CALL(*fec_receiver, AddReceivedRedPacket(_, _, _, _)).Times(0);
     EXPECT_CALL(*fec_receiver, ProcessReceivedFec()).Times(0);

--- a/erizo/src/test/rtp/RRGenerationHandlerTest.cpp
+++ b/erizo/src/test/rtp/RRGenerationHandlerTest.cpp
@@ -38,7 +38,7 @@ class RRGenerationHandlerTest : public erizo::HandlerTest {
 
  protected:
   void setHandler() {
-    rr_handler = std::make_shared<RRGenerationHandler>(connection.get());
+    rr_handler = std::make_shared<RRGenerationHandler>();
     pipeline->addBack(rr_handler);
   }
 

--- a/erizo/src/test/rtp/RtcpProcessorHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtcpProcessorHandlerTest.cpp
@@ -41,13 +41,11 @@ class RtcpProcessorHandlerTest : public erizo::HandlerTest {
 
  protected:
   void setHandler() {
-    processor = std::make_shared<erizo::MockRtcpProcessor>();
-    processor_handler = std::make_shared<RtcpProcessorHandler>(connection.get(), processor);
+    processor_handler = std::make_shared<RtcpProcessorHandler>();
     pipeline->addBack(processor_handler);
   }
 
   std::shared_ptr<RtcpProcessorHandler> processor_handler;
-  std::shared_ptr<erizo::MockRtcpProcessor> processor;
 };
 
 TEST_F(RtcpProcessorHandlerTest, basicBehaviourShouldReadPackets) {

--- a/erizo/src/test/rtp/RtpAudioMuteHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpAudioMuteHandlerTest.cpp
@@ -39,7 +39,7 @@ class RtpAudioMuteHandlerTest : public erizo::HandlerTest {
 
  protected:
   void setHandler() {
-    audio_mute_handler = std::make_shared<RtpAudioMuteHandler>(connection.get());
+    audio_mute_handler = std::make_shared<RtpAudioMuteHandler>();
     pipeline->addBack(audio_mute_handler);
   }
 

--- a/erizo/src/test/rtp/RtpRetransmissionHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpRetransmissionHandlerTest.cpp
@@ -37,7 +37,7 @@ class RtpRetransmissionHandlerTest : public erizo::HandlerTest {
 
  protected:
   void setHandler() {
-    rtx_handler = std::make_shared<RtpRetransmissionHandler>(connection.get());
+    rtx_handler = std::make_shared<RtpRetransmissionHandler>();
     pipeline->addBack(rtx_handler);
   }
 

--- a/erizo/src/test/rtp/RtpSlideShowHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpSlideShowHandlerTest.cpp
@@ -43,7 +43,7 @@ class RtpSlideShowHandlerTest : public erizo::HandlerTest {
     std::vector<RtpMap>& payloads = connection->getRemoteSdpInfo().getPayloadInfos();
     payloads.push_back({96, "VP8"});
     payloads.push_back({98, "VP9"});
-    slideshow_handler = std::make_shared<RtpSlideShowHandler>(connection.get());
+    slideshow_handler = std::make_shared<RtpSlideShowHandler>();
     pipeline->addBack(slideshow_handler);
   }
 

--- a/erizo/src/test/rtp/StatsHandlerTest.cpp
+++ b/erizo/src/test/rtp/StatsHandlerTest.cpp
@@ -40,8 +40,8 @@ class StatsHandlerTest : public erizo::HandlerTest {
 
  protected:
   void setHandler() {
-    incoming_stats_handler = std::make_shared<IncomingStatsHandler>(connection.get());
-    outgoing_stats_handler = std::make_shared<OutgoingStatsHandler>(connection.get());
+    incoming_stats_handler = std::make_shared<IncomingStatsHandler>();
+    outgoing_stats_handler = std::make_shared<OutgoingStatsHandler>();
     pipeline->addBack(incoming_stats_handler);
     pipeline->addBack(outgoing_stats_handler);
   }


### PR DESCRIPTION
This will help us creating Handlers since:
1. They're more decoupled from core logic.
2. We can easily add new services and use them from Handlers. They don't have to even know from WebRtcConnection.