### PR TITLE
Fixed SR stats in the subscriber

### DIFF
--- a/erizo/src/erizo/Stats.cpp
+++ b/erizo/src/erizo/Stats.cpp
@@ -43,6 +43,7 @@ namespace erizo {
     uint32_t ssrc = head->getSSRC();
     if (!isSinkSSRC(ssrc) && !isSourceSSRC(ssrc)) {
       ELOG_DEBUG("message: Unknown SSRC in processRtpPacket, ssrc: %u, PT: %u", ssrc, head->getPayloadType());
+      return;
     }
     if (bitrate_bytes_map.find(ssrc) == bitrate_bytes_map.end()) {
       bitrate_bytes_map[ssrc] = 0;
@@ -75,13 +76,11 @@ namespace erizo {
     if (chead->isFeedback()) {
       ssrc = chead->getSourceSSRC();
       if (!isSinkSSRC(ssrc)) {
-        ELOG_DEBUG("message: Unknown SSRC in processRtcpPacket, ssrc %u, PT %u", ssrc, chead->getPacketType());
         return;
       }
     } else {
       ssrc = chead->getSSRC();
           if (!isSourceSSRC(ssrc)) {
-            ELOG_DEBUG("message: Unknown SSRC in processRtcpPacket, ssrc %u, PT %u", ssrc, chead->getPacketType());
             return;
           }
     }

--- a/erizo/src/erizo/rtp/StatsHandler.cpp
+++ b/erizo/src/erizo/rtp/StatsHandler.cpp
@@ -28,7 +28,7 @@ void IncomingStatsHandler::read(Context *ctx, std::shared_ptr<dataPacket> packet
   if (chead->isRtcp()) {
     connection_->getStats().processRtcpPacket(packet->data, packet->length);
   } else {
-    connection_->getStats().processRtpPacket(packet->data, packet->length);  // Take into account ALL RTP traffic
+    connection_->getStats().processRtpPacket(packet->data, packet->length);
   }
 
   ctx->fireRead(packet);
@@ -50,7 +50,12 @@ void OutgoingStatsHandler::notifyUpdate() {
 }
 
 void OutgoingStatsHandler::write(Context *ctx, std::shared_ptr<dataPacket> packet) {
-  connection_->getStats().processRtpPacket(packet->data, packet->length);
+  RtcpHeader *chead = reinterpret_cast<RtcpHeader*> (packet->data);
+  if (chead->isRtcp()) {
+    connection_->getStats().processRtcpPacket(packet->data, packet->length);
+  } else {
+    connection_->getStats().processRtpPacket(packet->data, packet->length);
+  }
   ctx->fireWrite(packet);
 }
 


### PR DESCRIPTION
Stats was incorrectly analyzing SR packets as RTP:
I've taken into account that RTCP should now be analyzed on write also. In this case, failing the SSRC checks does not mean the SSRC is unknown, it means that we don't want to account for that packet in that part of the path, thus I've removed the log message.
