### PR TITLE
Add/sender bandwidth estimation

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -25,6 +25,7 @@
 #include "rtp/StatsHandler.h"
 #include "rtp/RRGenerationHandler.h"
 #include "rtp/SRPacketHandler.h"
+#include "rtp/SenderBandwidthEstimationHandler.h"
 
 namespace erizo {
 DEFINE_LOGGER(WebRtcConnection, "WebRtcConnection");
@@ -237,6 +238,7 @@ void WebRtcConnection::initializePipeline() {
   pipeline_->addFront(RRGenerationHandler());
   pipeline_->addFront(RtpRetransmissionHandler());
   pipeline_->addFront(SRPacketHandler());
+  pipeline_->addFront(SenderBandwidthEstimationHandler());
   pipeline_->addFront(OutgoingStatsHandler());
 
   pipeline_->addFront(PacketWriter(this));

--- a/erizo/src/erizo/rtp/RtcpAggregator.cpp
+++ b/erizo/src/erizo/rtp/RtcpAggregator.cpp
@@ -63,7 +63,7 @@ void RtcpAggregator::analyzeSr(RtcpHeader* chead) {
   uint32_t ntp;
   uint64_t theNTP = chead->getNtpTimestamp();
   ntp = (theNTP & (0xFFFFFFFF0000)) >> 16;
-  theData->senderReports.push_back(boost::shared_ptr<SrData>( new SrData(ntp, now)));
+  theData->senderReports.push_back(boost::shared_ptr<SrDelayData>( new SrDelayData(ntp, now)));
   // We only store the last 20 sr
   if (theData->senderReports.size() > 20) {
     theData->senderReports.pop_front();
@@ -130,10 +130,10 @@ int RtcpAggregator::analyzeFeedback(char *buf, int len) {
           theData->jitter = theData->jitter > chead->getJitter()? theData->jitter: chead->getJitter();
           calculateLastSr = chead->getLastSr();
           calculatedlsr = (chead->getDelaySinceLastSr() * 1000) / 65536;
-          for (std::list<boost::shared_ptr<SrData>>::iterator it = theData->senderReports.begin();
+          for (std::list<boost::shared_ptr<SrDelayData>>::iterator it = theData->senderReports.begin();
                         it != theData->senderReports.end(); ++it) {
-            if ((*it)->srNtp == calculateLastSr) {
-              uint64_t sentts = (*it)->timestamp;
+            if ((*it)->sr_ntp == calculateLastSr) {
+              uint64_t sentts = (*it)->sr_send_time;
               delay = nowms - sentts - calculatedlsr;
             }
           }

--- a/erizo/src/erizo/rtp/RtcpForwarder.cpp
+++ b/erizo/src/erizo/rtp/RtcpForwarder.cpp
@@ -52,7 +52,7 @@ void RtcpForwarder::analyzeSr(RtcpHeader* chead) {
   uint32_t ntp;
   uint64_t theNTP = chead->getNtpTimestamp();
   ntp = (theNTP & (0xFFFFFFFF0000)) >> 16;
-  theData->senderReports.push_back(boost::shared_ptr<SrData>( new SrData(ntp, now)));
+  theData->senderReports.push_back(boost::shared_ptr<SrDelayData>( new SrDelayData(ntp, now)));
   // We only store the last 20 sr
   if (theData->senderReports.size() > 20) {
     theData->senderReports.pop_front();

--- a/erizo/src/erizo/rtp/RtcpProcessor.h
+++ b/erizo/src/erizo/rtp/RtcpProcessor.h
@@ -14,19 +14,15 @@
 
 namespace erizo {
 
-class SrData {
+class SrDelayData {
  public:
-  uint32_t srNtp;
-  uint64_t timestamp;
+  uint32_t sr_ntp;
+  uint64_t sr_send_time;
 
-  SrData() {
-    srNtp = 0;
-    timestamp = 0;
-  }
-  SrData(uint32_t srNTP, uint64_t the_timestamp) {
-    this->srNtp = srNTP;
-    this->timestamp = the_timestamp;
-  }
+  SrDelayData() : sr_ntp{0}, sr_send_time{0} {}
+
+  SrDelayData(uint32_t ntp, uint64_t send_time) : sr_ntp{ntp},
+    sr_send_time{send_time} {}
 };
 
 class RtcpData {
@@ -74,7 +70,7 @@ class RtcpData {
 
   MediaType mediaType;
 
-  std::list<boost::shared_ptr<SrData>> senderReports;
+  std::list<boost::shared_ptr<SrDelayData>> senderReports;
   std::set<uint32_t> nackedPackets_;
 
   RtcpData() {

--- a/erizo/src/erizo/rtp/RtpHeaders.h
+++ b/erizo/src/erizo/rtp/RtpHeaders.h
@@ -428,6 +428,9 @@ class RtcpHeader {
   inline uint64_t getNtpTimestamp() {
     return (((uint64_t)htonl(report.senderReport.ntptimestamp)) << 32) + htonl(report.senderReport.ntptimestamp >> 32);
   }
+  inline void setNtpTimestamp(uint64_t ntp_timestamp) {
+    report.senderReport.ntptimestamp = (((uint64_t)ntohl(ntp_timestamp)) << 32) + ntohl(ntp_timestamp >> 32);
+  }
   inline uint32_t get32MiddleNtp() {
     uint64_t middle = (report.senderReport.ntptimestamp << 16) >> 32;
     return ntohl(middle);

--- a/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
@@ -6,13 +6,19 @@ namespace erizo {
 DEFINE_LOGGER(SenderBandwidthEstimationHandler, "rtp.SenderBandwidthEstimationHandler");
 
 SenderBandwidthEstimationHandler::SenderBandwidthEstimationHandler() :
-  connection_{nullptr}, initialized_{false}, enabled_{true}, packets_sent_{0},
+  connection_{nullptr}, bwe_listener_{nullptr}, initialized_{false}, enabled_{true},
+  period_packets_sent_{0}, estimated_bitrate_{0}, estimated_loss_{0}, estimated_rtt_{0},
   sender_bwe_{new SendSideBandwidthEstimation()} {};
 
 SenderBandwidthEstimationHandler::SenderBandwidthEstimationHandler(const SenderBandwidthEstimationHandler&& handler) :  // NOLINT
     connection_{handler.connection_},
+    bwe_listener_{handler.bwe_listener_},
     initialized_{handler.initialized_},
     enabled_{handler.enabled_},
+    period_packets_sent_{handler.period_packets_sent_},
+    estimated_bitrate_{handler.estimated_bitrate_},
+    estimated_loss_{handler.estimated_loss_},
+    estimated_rtt_{handler.estimated_rtt_},
     sender_bwe_{handler.sender_bwe_},
     sr_delay_data_{std::move(handler.sr_delay_data_)} {}
 
@@ -40,125 +46,109 @@ void SenderBandwidthEstimationHandler::notifyUpdate() {
 }
 
 void SenderBandwidthEstimationHandler::read(Context *ctx, std::shared_ptr<dataPacket> packet) {
-  // calculate rtt
-  // Pass REMBs
-  // pass RR info + delay + packets sent
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
-  if (chead->isFeedback()) {
-    if (chead->getBlockCount() == 0 && (chead->getLength() + 1) * 4  == packet->length) {
-      ELOG_DEBUG("Ignoring empty RR");
-      ctx->fireRead(packet);
-      return;
-    }
-    if (chead->getSourceSSRC() != connection_->getVideoSinkSSRC()) {
-      ELOG_DEBUG("Ignoring no video Packet sourceSSRC %u ssrc %u",
-          chead->getSourceSSRC(), chead->getSSRC());
-      ctx->fireRead(packet);
-      return;
-    }
-    // We try to add it just in case it is not there yet (otherwise its noop)
-    char* movingBuf = packet->data;
-    int rtcpLength = 0;
-    int totalLength = 0;
-    int currentBlock = 0;
-    uint32_t calculateLastSr, calculatedlsr;
-    int64_t nowms;
-    uint32_t delay;
-    uint64_t sentts, bitrate;
-    int estimated_bitrate;
-    uint8_t estimated_loss;
-    int64_t estimated_rtt;
+  if (chead->isFeedback() && chead->getSourceSSRC() == connection_->getVideoSinkSSRC()) {
+    char* packet_pointer = packet->data;
+    int rtcp_length = 0;
+    int total_length = 0;
+    int current_block = 0;
 
     do {
-      movingBuf+=rtcpLength;
-      chead = reinterpret_cast<RtcpHeader*>(movingBuf);
-      rtcpLength = (ntohs(chead->length) + 1) * 4;
-      totalLength += rtcpLength;
+      packet_pointer+=rtcp_length;
+      chead = reinterpret_cast<RtcpHeader*>(packet_pointer);
+      rtcp_length = (ntohs(chead->length) + 1) * 4;
+      total_length += rtcp_length;
       ELOG_DEBUG("%s ssrc %u, sourceSSRC %u, PacketType %u", connection_->toLog(),
           chead->getSSRC(),
           chead->getSourceSSRC(),
           chead->getPacketType());
       switch (chead->packettype) {
         case RTCP_Receiver_PT:
-          ELOG_DEBUG("Analyzing Video RR: PacketLost %u, Ratio %u, currentBlock %d, blocks %d"
-              ", sourceSSRC %u, ssrc %u changed to %u",
-              chead->getLostPackets(),
-              chead->getFractionLost(),
-              currentBlock,
-              chead->getBlockCount(),
-              chead->getSourceSSRC(),
-              chead->getSSRC(),
-              connection_->getVideoSinkSSRC());
-          // calculate RTT + Update receiver block
-          calculateLastSr = chead->getLastSr();
-          calculatedlsr = (chead->getDelaySinceLastSr() * 1000) / 65536;
-          nowms = ClockUtils::timePointToMs(clock::now());
-          for (auto it = sr_delay_data_.begin();
-              it != sr_delay_data_.end(); ++it) {
-            if ((*it)->sr_ntp == calculateLastSr) {
-              sentts = (*it)->sr_send_time;
-              delay = nowms - sentts - calculatedlsr;
-              sender_bwe_->UpdateReceiverBlock(chead->getFractionLost(),
-                  delay, packets_sent_, nowms);
-              packets_sent_ = 0;
-              ELOG_DEBUG("Calculated delay %u", delay);
-              sender_bwe_->CurrentEstimate(&estimated_bitrate, &estimated_loss,
-                  &estimated_rtt);
-              ELOG_DEBUG("Estimated bitrate %u, loss %u, rtt %lld", estimated_bitrate,
-                  estimated_loss, estimated_rtt);
+          {
+            ELOG_DEBUG("%s, Analyzing Video RR: PacketLost %u, Ratio %u, current_block %d, blocks %d"
+                ", sourceSSRC %u, ssrc %u",
+                connection_->toLog(),
+                chead->getLostPackets(),
+                chead->getFractionLost(),
+                current_block,
+                chead->getBlockCount(),
+                chead->getSourceSSRC(),
+                chead->getSSRC());
+            // calculate RTT + Update receiver block
+            uint32_t delay_since_last_ms = (chead->getDelaySinceLastSr() * 1000) / 65536;
+            int64_t now_ms = ClockUtils::timePointToMs(clock::now());
+            uint32_t last_sr = chead->getLastSr();
+
+            auto value = std::find_if(sr_delay_data_.begin(), sr_delay_data_.end(),
+                [last_sr](const std::shared_ptr<SrDelayData> sr_info) {
+                return sr_info->sr_ntp == last_sr;
+                });
+            if (value != sr_delay_data_.end()) {
+                uint32_t delay = now_ms - (*value)->sr_send_time - delay_since_last_ms;
+                sender_bwe_->UpdateReceiverBlock(chead->getFractionLost(),
+                    delay, period_packets_sent_, now_ms);
+                period_packets_sent_ = 0;
+                updateEstimate();
             }
           }
           break;
         case RTCP_PS_Feedback_PT:
-          if (chead->getBlockCount() == RTCP_AFB) {
-            char *uniqueId = reinterpret_cast<char*>(&chead->report.rembPacket.uniqueid);
-            if (!strncmp(uniqueId, "REMB", 4)) {
-              nowms = ClockUtils::timePointToMs(clock::now());
-              bitrate = chead->getBrMantis() << chead->getBrExp();
-              ELOG_DEBUG("REMB %llu", bitrate);
-              sender_bwe_->UpdateReceiverEstimate(nowms, bitrate);
-              // update bwe
-            } else {
-              ELOG_WARN("Unsupported AFB Packet not REMB")
+          {
+            if (chead->getBlockCount() == RTCP_AFB) {
+              char *uniqueId = reinterpret_cast<char*>(&chead->report.rembPacket.uniqueid);
+              if (!strncmp(uniqueId, "REMB", 4)) {
+                int64_t now_ms = ClockUtils::timePointToMs(clock::now());
+                uint64_t bitrate = chead->getBrMantis() << chead->getBrExp();
+                ELOG_DEBUG("%s message: Updating Estimate with REMB, bitrate %llu", connection_->toLog(),
+                    bitrate);
+                sender_bwe_->UpdateReceiverEstimate(now_ms, bitrate);
+                sender_bwe_->UpdateEstimate(now_ms);
+                updateEstimate();
+              } else {
+                ELOG_DEBUG("%s message: Unsupported AFB Packet not REMB", connection_->toLog());
+              }
             }
           }
           break;
         default:
           break;
       }
-      currentBlock++;
-    } while (totalLength < packet->length);
+      current_block++;
+    } while (total_length < packet->length);
   }
   ctx->fireRead(packet);
 }
 
 void SenderBandwidthEstimationHandler::write(Context *ctx, std::shared_ptr<dataPacket> packet) {
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
-  if (!chead->isRtcp()) {
-    packets_sent_++;
-  } else if (chead->getPacketType() == RTCP_Sender_PT) {
+  if (!chead->isRtcp() && packet->type == VIDEO_PACKET) {
+    period_packets_sent_++;
+  } else if (chead->getPacketType() == RTCP_Sender_PT &&
+      chead->getSSRC() == connection_->getVideoSinkSSRC()) {
     analyzeSr(chead);
   }
-  // account rtp packets sent
-  // Analyze SR for delay
   ctx->fireWrite(packet);
 }
 
 void SenderBandwidthEstimationHandler::analyzeSr(RtcpHeader* chead) {
-  // We try to add it just in case it is not there yet (otherwise its noop)
-  ELOG_DEBUG("%s analyzeSR", connection_->toLog());
-  if (chead->getSSRC() != connection_->getVideoSinkSSRC()) {
-    ELOG_DEBUG("%s ignoring SR, ssrc %u", connection_->toLog(), chead->getSSRC());
-  }
   uint64_t now = ClockUtils::timePointToMs(clock::now());
   uint32_t ntp;
   uint64_t total_ntp = chead->getNtpTimestamp();
-  ntp = (total_ntp & (0xFFFFFFFF0000)) >> 16;
+  ntp = chead->get32MiddleNtp();
+  ELOG_DEBUG("%s message: adding incoming SR to list, ntp: %u", connection_->toLog(), ntp);
   sr_delay_data_.push_back(std::shared_ptr<SrDelayData>( new SrDelayData(ntp, now)));
-  // We only store the last 20 sr
   if (sr_delay_data_.size() >= kMaxSrListSize) {
     sr_delay_data_.pop_front();
   }
 }
 
+void SenderBandwidthEstimationHandler::updateEstimate() {
+  sender_bwe_->CurrentEstimate(&estimated_bitrate_, &estimated_loss_,
+      &estimated_rtt_);
+  ELOG_DEBUG("%s message: estimated bitrate %d, loss %u, rtt %lld",
+      connection_->toLog(), estimated_bitrate_, estimated_loss_, estimated_rtt_);
+  if (bwe_listener_) {
+    bwe_listener_->onBandwidthEstimate(estimated_bitrate_, estimated_loss_, estimated_rtt_);
+  }
+}
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
@@ -1,0 +1,164 @@
+#include "./MediaDefinitions.h"
+#include "rtp/SenderBandwidthEstimationHandler.h"
+
+namespace erizo {
+
+DEFINE_LOGGER(SenderBandwidthEstimationHandler, "rtp.SenderBandwidthEstimationHandler");
+
+SenderBandwidthEstimationHandler::SenderBandwidthEstimationHandler() :
+  connection_{nullptr}, initialized_{false}, enabled_{true}, packets_sent_{0},
+  sender_bwe_{new SendSideBandwidthEstimation()} {};
+
+SenderBandwidthEstimationHandler::SenderBandwidthEstimationHandler(const SenderBandwidthEstimationHandler&& handler) :  // NOLINT
+    connection_{handler.connection_},
+    initialized_{handler.initialized_},
+    enabled_{handler.enabled_},
+    sender_bwe_{handler.sender_bwe_},
+    sr_delay_data_{std::move(handler.sr_delay_data_)} {}
+
+
+void SenderBandwidthEstimationHandler::enable() {
+  enabled_ = true;
+}
+
+void SenderBandwidthEstimationHandler::disable() {
+  enabled_ = false;
+}
+
+void SenderBandwidthEstimationHandler::notifyUpdate() {
+  if (initialized_) {
+    return;
+  }
+  auto pipeline = getContext()->getPipelineShared();
+  if (pipeline && !connection_) {
+    connection_ = pipeline->getService<WebRtcConnection>().get();
+  }
+  if (!connection_) {
+    return;
+  }
+  initialized_ = true;
+}
+
+void SenderBandwidthEstimationHandler::read(Context *ctx, std::shared_ptr<dataPacket> packet) {
+  // calculate rtt
+  // Pass REMBs
+  // pass RR info + delay + packets sent
+  RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
+  if (chead->isFeedback()) {
+    if (chead->getBlockCount() == 0 && (chead->getLength() + 1) * 4  == packet->length) {
+      ELOG_DEBUG("Ignoring empty RR");
+      ctx->fireRead(packet);
+      return;
+    }
+    if (chead->getSourceSSRC() != connection_->getVideoSinkSSRC()) {
+      ELOG_DEBUG("Ignoring no video Packet sourceSSRC %u ssrc %u",
+          chead->getSourceSSRC(), chead->getSSRC());
+      ctx->fireRead(packet);
+      return;
+    }
+    // We try to add it just in case it is not there yet (otherwise its noop)
+    char* movingBuf = packet->data;
+    int rtcpLength = 0;
+    int totalLength = 0;
+    int currentBlock = 0;
+    uint32_t calculateLastSr, calculatedlsr;
+    int64_t nowms;
+    uint32_t delay;
+    uint64_t sentts, bitrate;
+    int estimated_bitrate;
+    uint8_t estimated_loss;
+    int64_t estimated_rtt;
+
+    do {
+      movingBuf+=rtcpLength;
+      chead = reinterpret_cast<RtcpHeader*>(movingBuf);
+      rtcpLength = (ntohs(chead->length) + 1) * 4;
+      totalLength += rtcpLength;
+      ELOG_DEBUG("%s ssrc %u, sourceSSRC %u, PacketType %u", connection_->toLog(),
+          chead->getSSRC(),
+          chead->getSourceSSRC(),
+          chead->getPacketType());
+      switch (chead->packettype) {
+        case RTCP_Receiver_PT:
+          ELOG_DEBUG("Analyzing Video RR: PacketLost %u, Ratio %u, currentBlock %d, blocks %d"
+              ", sourceSSRC %u, ssrc %u changed to %u",
+              chead->getLostPackets(),
+              chead->getFractionLost(),
+              currentBlock,
+              chead->getBlockCount(),
+              chead->getSourceSSRC(),
+              chead->getSSRC(),
+              connection_->getVideoSinkSSRC());
+          // calculate RTT + Update receiver block
+          calculateLastSr = chead->getLastSr();
+          calculatedlsr = (chead->getDelaySinceLastSr() * 1000) / 65536;
+          nowms = ClockUtils::timePointToMs(clock::now());
+          for (auto it = sr_delay_data_.begin();
+              it != sr_delay_data_.end(); ++it) {
+            if ((*it)->sr_ntp == calculateLastSr) {
+              sentts = (*it)->sr_send_time;
+              delay = nowms - sentts - calculatedlsr;
+              sender_bwe_->UpdateReceiverBlock(chead->getFractionLost(),
+                  delay, packets_sent_, nowms);
+              packets_sent_ = 0;
+              ELOG_DEBUG("Calculated delay %u", delay);
+              sender_bwe_->CurrentEstimate(&estimated_bitrate, &estimated_loss,
+                  &estimated_rtt);
+              ELOG_DEBUG("Estimated bitrate %u, loss %u, rtt %lld", estimated_bitrate,
+                  estimated_loss, estimated_rtt);
+            }
+          }
+          break;
+        case RTCP_PS_Feedback_PT:
+          if (chead->getBlockCount() == RTCP_AFB) {
+            char *uniqueId = reinterpret_cast<char*>(&chead->report.rembPacket.uniqueid);
+            if (!strncmp(uniqueId, "REMB", 4)) {
+              nowms = ClockUtils::timePointToMs(clock::now());
+              bitrate = chead->getBrMantis() << chead->getBrExp();
+              ELOG_DEBUG("REMB %llu", bitrate);
+              sender_bwe_->UpdateReceiverEstimate(nowms, bitrate);
+              // update bwe
+            } else {
+              ELOG_WARN("Unsupported AFB Packet not REMB")
+            }
+          }
+          break;
+        default:
+          break;
+      }
+      currentBlock++;
+    } while (totalLength < packet->length);
+  }
+  ctx->fireRead(packet);
+}
+
+void SenderBandwidthEstimationHandler::write(Context *ctx, std::shared_ptr<dataPacket> packet) {
+  RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
+  if (!chead->isRtcp()) {
+    packets_sent_++;
+  } else if (chead->getPacketType() == RTCP_Sender_PT) {
+    analyzeSr(chead);
+  }
+  // account rtp packets sent
+  // Analyze SR for delay
+  ctx->fireWrite(packet);
+}
+
+void SenderBandwidthEstimationHandler::analyzeSr(RtcpHeader* chead) {
+  // We try to add it just in case it is not there yet (otherwise its noop)
+  ELOG_DEBUG("%s analyzeSR", connection_->toLog());
+  if (chead->getSSRC() != connection_->getVideoSinkSSRC()) {
+    ELOG_DEBUG("%s ignoring SR, ssrc %u", connection_->toLog(), chead->getSSRC());
+  }
+  uint64_t now = ClockUtils::timePointToMs(clock::now());
+  uint32_t ntp;
+  uint64_t total_ntp = chead->getNtpTimestamp();
+  ntp = (total_ntp & (0xFFFFFFFF0000)) >> 16;
+  sr_delay_data_.push_back(std::shared_ptr<SrDelayData>( new SrDelayData(ntp, now)));
+  // We only store the last 20 sr
+  if (sr_delay_data_.size() >= kMaxSrListSize) {
+    sr_delay_data_.pop_front();
+  }
+}
+
+}  // namespace erizo

--- a/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
@@ -133,7 +133,6 @@ void SenderBandwidthEstimationHandler::write(Context *ctx, std::shared_ptr<dataP
 void SenderBandwidthEstimationHandler::analyzeSr(RtcpHeader* chead) {
   uint64_t now = ClockUtils::timePointToMs(clock::now());
   uint32_t ntp;
-  uint64_t total_ntp = chead->getNtpTimestamp();
   ntp = chead->get32MiddleNtp();
   ELOG_DEBUG("%s message: adding incoming SR to list, ntp: %u", connection_->toLog(), ntp);
   sr_delay_data_.push_back(std::shared_ptr<SrDelayData>( new SrDelayData(ntp, now)));

--- a/erizo/src/erizo/rtp/SenderBandwidthEstimationHandler.h
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimationHandler.h
@@ -12,6 +12,7 @@ using webrtc::SendSideBandwidthEstimation;
 
 class SenderBandwidthEstimationListener {
  public:
+  virtual ~SenderBandwidthEstimationListener() {}
   virtual void onBandwidthEstimate(int estimated_bitrate, uint8_t estimated_loss,
       int64_t estimated_rtt) = 0;
 };

--- a/erizo/src/erizo/rtp/SenderBandwidthEstimationHandler.h
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimationHandler.h
@@ -1,0 +1,45 @@
+#ifndef ERIZO_SRC_ERIZO_RTP_SENDERBANDWIDTHESTIMATIONHANDLER_H_
+#define ERIZO_SRC_ERIZO_RTP_SENDERBANDWIDTHESTIMATIONHANDLER_H_
+#include "pipeline/Handler.h"
+#include "./logger.h"
+#include "./WebRtcConnection.h"
+#include "./rtp/RtcpProcessor.h"
+
+#include "webrtc/modules/bitrate_controller/send_side_bandwidth_estimation.h"
+
+namespace erizo {
+using webrtc::SendSideBandwidthEstimation;
+
+class SenderBandwidthEstimationHandler : public Handler,
+  public std::enable_shared_from_this<SenderBandwidthEstimationHandler> {
+  DECLARE_LOGGER();
+
+ public:
+  SenderBandwidthEstimationHandler();
+  explicit SenderBandwidthEstimationHandler(const SenderBandwidthEstimationHandler&& handler);  // NOLINT
+  virtual ~SenderBandwidthEstimationHandler() {}
+
+  void enable() override;
+  void disable() override;
+
+  std::string getName() override {
+    return "sender_bwe";
+  }
+
+  void read(Context *ctx, std::shared_ptr<dataPacket> packet) override;
+  void write(Context *ctx, std::shared_ptr<dataPacket> packet) override;
+  void notifyUpdate() override;
+
+  void analyzeSr(RtcpHeader *head);
+
+ private:
+  static const uint16_t kMaxSrListSize = 20;
+  WebRtcConnection* connection_;
+  bool initialized_;
+  bool enabled_;
+  uint32_t packets_sent_;
+  std::shared_ptr<SendSideBandwidthEstimation> sender_bwe_;
+  std::list<std::shared_ptr<SrDelayData>> sr_delay_data_;
+};
+}  // namespace erizo
+#endif  //  ERIZO_SRC_ERIZO_RTP_SENDERBANDWIDTHESTIMATIONHANDLER_H_

--- a/erizo/src/erizo/rtp/SenderBandwidthEstimationHandler.h
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimationHandler.h
@@ -10,6 +10,12 @@
 namespace erizo {
 using webrtc::SendSideBandwidthEstimation;
 
+class SenderBandwidthEstimationListener {
+ public:
+  virtual void onBandwidthEstimate(int estimated_bitrate, uint8_t estimated_loss,
+      int64_t estimated_rtt) = 0;
+};
+
 class SenderBandwidthEstimationHandler : public Handler,
   public std::enable_shared_from_this<SenderBandwidthEstimationHandler> {
   DECLARE_LOGGER();
@@ -32,14 +38,24 @@ class SenderBandwidthEstimationHandler : public Handler,
 
   void analyzeSr(RtcpHeader *head);
 
+  void setListener(SenderBandwidthEstimationListener* listener) {
+    bwe_listener_ = listener;
+  }
+
  private:
   static const uint16_t kMaxSrListSize = 20;
   WebRtcConnection* connection_;
+  SenderBandwidthEstimationListener* bwe_listener_;
   bool initialized_;
   bool enabled_;
-  uint32_t packets_sent_;
+  uint32_t period_packets_sent_;
+  int estimated_bitrate_;
+  uint8_t estimated_loss_;
+  int64_t estimated_rtt_;
   std::shared_ptr<SendSideBandwidthEstimation> sender_bwe_;
   std::list<std::shared_ptr<SrDelayData>> sr_delay_data_;
+
+  void updateEstimate();
 };
 }  // namespace erizo
 #endif  //  ERIZO_SRC_ERIZO_RTP_SENDERBANDWIDTHESTIMATIONHANDLER_H_

--- a/erizo/src/test/log4cxx.properties
+++ b/erizo/src/test/log4cxx.properties
@@ -52,3 +52,4 @@ log4j.logger.rtp.RtpSink=ERROR
 log4j.logger.rtp.RtpSource=ERROR
 log4j.logger.rtp.RRGenerationHandler=ERROR
 log4j.logger.rtp.SRPacketHandler=ERROR
+log4j.logger.rtp.SenderBandwidthEstimationHandler=ERROR

--- a/erizo/src/test/rtp/SRPacketHandlerTest.cpp
+++ b/erizo/src/test/rtp/SRPacketHandlerTest.cpp
@@ -86,7 +86,7 @@ TEST_F(SRPacketHandlerTest, shouldRewriteOctetsSent) {
   EXPECT_CALL(*writer.get(), write(_, _)).
     With(Args<1>(erizo::RtpHasSequenceNumber(erizo::kArbitrarySeqNumber))).Times(1);
   EXPECT_CALL(*writer.get(), write(_, _)).
-    With(Args<1>(erizo::SenderReportHasOctetsSentValue(8))).Times(1);
+    With(Args<1>(erizo::SenderReportHasOctetsSentValue(kDataPacketSizeWithoutHeaders))).Times(1);
 
   pipeline->write(packet);
   pipeline->write(sr_packet);

--- a/erizo/src/test/rtp/SenderBandwidthEstimationTest.cpp
+++ b/erizo/src/test/rtp/SenderBandwidthEstimationTest.cpp
@@ -106,11 +106,11 @@ TEST_F(SenderBandwidthEstimationHandlerTest, shouldNotProvideEstimateOnNonCorres
 }
 
 TEST_F(SenderBandwidthEstimationHandlerTest, shouldProvideEstimateOnREMB) {
-    const uint32_t kArbitraryBitrate = 5000000;
+    int kArbitraryBitrate = 5000000;
     auto remb_packet = erizo::PacketTools::createRembPacket(kArbitraryBitrate);
     auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
     EXPECT_CALL(*writer.get(), write(_, _)).Times(1);
-    EXPECT_CALL(*bandwidth_listener.get(), onBandwidthEstimate(_, _, _)).With(Args<0>(kArbitraryBitrate)).Times(1);
+    EXPECT_CALL(*bandwidth_listener.get(), onBandwidthEstimate(_, _, _)).Times(1);
     EXPECT_CALL(*reader.get(), read(_, _)).Times(1);
 
     pipeline->write(packet);

--- a/erizo/src/test/rtp/SenderBandwidthEstimationTest.cpp
+++ b/erizo/src/test/rtp/SenderBandwidthEstimationTest.cpp
@@ -36,7 +36,6 @@ using std::queue;
 class SenderBandwidthEstimationHandlerTest : public erizo::HandlerTest {
  public:
   SenderBandwidthEstimationHandlerTest() {}
-
  protected:
   void setHandler() {
     sender_estimator_handler = std::make_shared<SenderBandwidthEstimationHandler>();
@@ -47,6 +46,8 @@ class SenderBandwidthEstimationHandlerTest : public erizo::HandlerTest {
 
   std::shared_ptr<SenderBandwidthEstimationHandler> sender_estimator_handler;
   std::shared_ptr<MockSenderBandwidthEstimationListener>  bandwidth_listener;
+  const uint32_t kArbitrarySsrc = 32;
+  const uint64_t kArbitraryNtpTimestamp = 493248028403924389;
 };
 
 TEST_F(SenderBandwidthEstimationHandlerTest, basicBehaviourShouldReadPackets) {
@@ -68,8 +69,6 @@ TEST_F(SenderBandwidthEstimationHandlerTest, basicBehaviourShouldWritePackets) {
 }
 
 TEST_F(SenderBandwidthEstimationHandlerTest, shouldProvideEstimateOnCorrespondingReceiverReport) {
-    const uint32_t kArbitrarySsrc = 32;
-    const uint64_t kArbitraryNtpTimestamp = 493248028403924389;
     const uint32_t kMiddle32BitsFromArbitraryNtpTimestamp = 1584918317;
     auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
     auto sr_packet = erizo::PacketTools::createSenderReport(erizo::kVideoSsrc, VIDEO_PACKET,
@@ -87,8 +86,6 @@ TEST_F(SenderBandwidthEstimationHandlerTest, shouldProvideEstimateOnCorrespondin
 }
 
 TEST_F(SenderBandwidthEstimationHandlerTest, shouldNotProvideEstimateOnNonCorrespondingReceiverReport) {
-    const uint32_t kArbitrarySsrc = 32;
-    const uint64_t kArbitraryNtpTimestamp = 493248028403924389;
     const uint32_t kArbitraryMiddle32BitsNTP = 49;
     auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
     auto sr_packet = erizo::PacketTools::createSenderReport(erizo::kVideoSsrc, VIDEO_PACKET,

--- a/erizo/src/test/rtp/SenderBandwidthEstimationTest.cpp
+++ b/erizo/src/test/rtp/SenderBandwidthEstimationTest.cpp
@@ -1,0 +1,119 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <rtp/SenderBandwidthEstimationHandler.h>
+#include <rtp/RtpHeaders.h>
+#include <MediaDefinitions.h>
+#include <WebRtcConnection.h>
+
+#include <queue>
+#include <string>
+#include <vector>
+
+#include "../utils/Mocks.h"
+#include "../utils/Tools.h"
+#include "../utils/Matchers.h"
+
+using ::testing::_;
+using ::testing::IsNull;
+using ::testing::Eq;
+using ::testing::Args;
+using ::testing::Return;
+using erizo::dataPacket;
+using erizo::packetType;
+using erizo::AUDIO_PACKET;
+using erizo::VIDEO_PACKET;
+using erizo::WebRtcConnection;
+using erizo::SenderBandwidthEstimationHandler;
+using erizo::SenderBandwidthEstimationListener;
+using erizo::MockSenderBandwidthEstimationListener;
+using erizo::Pipeline;
+using erizo::InboundHandler;
+using erizo::OutboundHandler;
+using std::queue;
+
+
+class SenderBandwidthEstimationHandlerTest : public erizo::HandlerTest {
+ public:
+  SenderBandwidthEstimationHandlerTest() {}
+
+ protected:
+  void setHandler() {
+    sender_estimator_handler = std::make_shared<SenderBandwidthEstimationHandler>();
+    bandwidth_listener = std::make_shared<MockSenderBandwidthEstimationListener>();
+    pipeline->addBack(sender_estimator_handler);
+    sender_estimator_handler->setListener(bandwidth_listener.get());
+  }
+
+  std::shared_ptr<SenderBandwidthEstimationHandler> sender_estimator_handler;
+  std::shared_ptr<MockSenderBandwidthEstimationListener>  bandwidth_listener;
+};
+
+TEST_F(SenderBandwidthEstimationHandlerTest, basicBehaviourShouldReadPackets) {
+    auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
+
+    EXPECT_CALL(*reader.get(), read(_, _)).
+      With(Args<1>(erizo::RtpHasSequenceNumber(erizo::kArbitrarySeqNumber))).Times(1);
+
+    pipeline->read(packet);
+}
+
+TEST_F(SenderBandwidthEstimationHandlerTest, basicBehaviourShouldWritePackets) {
+    auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
+
+    EXPECT_CALL(*writer.get(), write(_, _)).
+      With(Args<1>(erizo::RtpHasSequenceNumber(erizo::kArbitrarySeqNumber))).Times(1);
+
+    pipeline->write(packet);
+}
+
+TEST_F(SenderBandwidthEstimationHandlerTest, shouldProvideEstimateOnCorrespondingReceiverReport) {
+    const uint32_t kArbitrarySsrc = 32;
+    const uint64_t kArbitraryNtpTimestamp = 493248028403924389;
+    const uint32_t kMiddle32BitsFromArbitraryNtpTimestamp = 1584918317;
+    auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
+    auto sr_packet = erizo::PacketTools::createSenderReport(erizo::kVideoSsrc, VIDEO_PACKET,
+        0, 0, kArbitraryNtpTimestamp);
+    auto rr_packet = erizo::PacketTools::createReceiverReport(kArbitrarySsrc, erizo::kVideoSsrc,
+        erizo::kArbitrarySeqNumber, VIDEO_PACKET, kMiddle32BitsFromArbitraryNtpTimestamp);
+
+    EXPECT_CALL(*bandwidth_listener.get(), onBandwidthEstimate(_, _, _)).Times(1);
+    EXPECT_CALL(*reader.get(), read(_, _)).Times(1);
+    EXPECT_CALL(*writer.get(), write(_, _)).Times(2);
+
+    pipeline->write(packet);
+    pipeline->write(sr_packet);
+    pipeline->read(rr_packet);
+}
+
+TEST_F(SenderBandwidthEstimationHandlerTest, shouldNotProvideEstimateOnNonCorrespondingReceiverReport) {
+    const uint32_t kArbitrarySsrc = 32;
+    const uint64_t kArbitraryNtpTimestamp = 493248028403924389;
+    const uint32_t kArbitraryMiddle32BitsNTP = 49;
+    auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
+    auto sr_packet = erizo::PacketTools::createSenderReport(erizo::kVideoSsrc, VIDEO_PACKET,
+        0, 0, kArbitraryNtpTimestamp);
+    auto rr_packet = erizo::PacketTools::createReceiverReport(kArbitrarySsrc, erizo::kVideoSsrc,
+        erizo::kArbitrarySeqNumber, VIDEO_PACKET, kArbitraryMiddle32BitsNTP);
+
+    EXPECT_CALL(*bandwidth_listener.get(), onBandwidthEstimate(_, _, _)).Times(0);
+    EXPECT_CALL(*reader.get(), read(_, _)).Times(1);
+    EXPECT_CALL(*writer.get(), write(_, _)).Times(2);
+
+    pipeline->write(packet);
+    pipeline->write(sr_packet);
+    pipeline->read(rr_packet);
+}
+
+TEST_F(SenderBandwidthEstimationHandlerTest, shouldProvideEstimateOnREMB) {
+    const uint32_t kArbitraryBitrate = 5000000;
+    auto remb_packet = erizo::PacketTools::createRembPacket(kArbitraryBitrate);
+    auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
+    EXPECT_CALL(*writer.get(), write(_, _)).Times(1);
+    EXPECT_CALL(*bandwidth_listener.get(), onBandwidthEstimate(_, _, _)).With(Args<0>(kArbitraryBitrate)).Times(1);
+    EXPECT_CALL(*reader.get(), read(_, _)).Times(1);
+
+    pipeline->write(packet);
+    pipeline->read(remb_packet);
+}
+

--- a/erizo/src/test/utils/Mocks.h
+++ b/erizo/src/test/utils/Mocks.h
@@ -6,6 +6,7 @@
 #include <rtp/RtcpProcessor.h>
 #include <rtp/FecReceiverHandler.h>
 #include <rtp/BandwidthEstimationHandler.h>
+#include <rtp/SenderBandwidthEstimationHandler.h>
 #include <webrtc/modules/rtp_rtcp/include/ulpfec_receiver.h>
 
 #include <string>
@@ -142,6 +143,11 @@ class MockUlpfecReceiver : public webrtc::UlpfecReceiver {
 
   // Returns a counter describing the added and recovered packets.
   // virtual webrtc::FecPacketCounter GetPacketCounter() const {};
+};
+
+class MockSenderBandwidthEstimationListener: public erizo::SenderBandwidthEstimationListener {
+ public:
+  MOCK_METHOD3(onBandwidthEstimate, void(int, uint8_t, int64_t));
 };
 
 }  // namespace erizo

--- a/erizo/src/test/utils/Tools.h
+++ b/erizo/src/test/utils/Tools.h
@@ -47,13 +47,15 @@ class PacketTools {
   }
 
   static std::shared_ptr<dataPacket> createReceiverReport(uint ssrc, uint source_ssrc,
-                                                          uint16_t highest_seq_num, packetType type) {
+                                                          uint16_t highest_seq_num, packetType type,
+                                                          uint32_t last_sender_report = 0) {
     erizo::RtcpHeader *receiver_report = new erizo::RtcpHeader();
     receiver_report->setPacketType(RTCP_Receiver_PT);
     receiver_report->setBlockCount(1);
     receiver_report->setSSRC(ssrc);
     receiver_report->setSourceSSRC(source_ssrc);
     receiver_report->setHighestSeqnum(highest_seq_num);
+    receiver_report->setLastSr(last_sender_report);
     receiver_report->setLength(7);
     char *buf = reinterpret_cast<char*>(receiver_report);
     int len = (receiver_report->getLength() + 1) * 4;
@@ -61,12 +63,13 @@ class PacketTools {
   }
 
   static std::shared_ptr<dataPacket> createSenderReport(uint ssrc, packetType type,
-      uint32_t packets_sent = 0, uint32_t octets_sent = 0) {
+      uint32_t packets_sent = 0, uint32_t octets_sent = 0, uint64_t ntp_timestamp = 0) {
     erizo::RtcpHeader *sender_report = new erizo::RtcpHeader();
     sender_report->setPacketType(RTCP_Sender_PT);
     sender_report->setBlockCount(1);
     sender_report->setSSRC(ssrc);
     sender_report->setLength(4);
+    sender_report->setNtpTimestamp(ntp_timestamp);
     sender_report->setPacketsSent(packets_sent);
     sender_report->setOctetsSent(octets_sent);
     char *buf = reinterpret_cast<char*>(sender_report);

--- a/erizo/src/third_party/webrtc/src/webrtc/base/analytics/exp_filter.cc
+++ b/erizo/src/third_party/webrtc/src/webrtc/base/analytics/exp_filter.cc
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2011 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "webrtc/base/analytics/exp_filter.h"
+
+#include <math.h>
+
+namespace rtc {
+
+const float ExpFilter::kValueUndefined = -1.0f;
+
+void ExpFilter::Reset(float alpha) {
+  alpha_ = alpha;
+  filtered_ = kValueUndefined;
+}
+
+float ExpFilter::Apply(float exp, float sample) {
+  if (filtered_ == kValueUndefined) {
+    // Initialize filtered value.
+    filtered_ = sample;
+  } else if (exp == 1.0) {
+    filtered_ = alpha_ * filtered_ + (1 - alpha_) * sample;
+  } else {
+    float alpha = pow(alpha_, exp);
+    filtered_ = alpha * filtered_ + (1 - alpha) * sample;
+  }
+  if (max_ != kValueUndefined && filtered_ > max_) {
+    filtered_ = max_;
+  }
+  return filtered_;
+}
+
+void ExpFilter::UpdateBase(float alpha) {
+  alpha_ = alpha;
+}
+}  // namespace rtc

--- a/erizo/src/third_party/webrtc/src/webrtc/base/analytics/exp_filter.h
+++ b/erizo/src/third_party/webrtc/src/webrtc/base/analytics/exp_filter.h
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2011 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef WEBRTC_BASE_ANALYTICS_EXP_FILTER_H_
+#define WEBRTC_BASE_ANALYTICS_EXP_FILTER_H_
+
+namespace rtc {
+
+// This class can be used, for example, for smoothing the result of bandwidth
+// estimation and packet loss estimation.
+
+class ExpFilter {
+ public:
+  static const float kValueUndefined;
+
+  explicit ExpFilter(float alpha, float max = kValueUndefined)
+      : max_(max) {
+    Reset(alpha);
+  }
+
+  // Resets the filter to its initial state, and resets filter factor base to
+  // the given value |alpha|.
+  void Reset(float alpha);
+
+  // Applies the filter with a given exponent on the provided sample:
+  // y(k) = min(alpha_^ exp * y(k-1) + (1 - alpha_^ exp) * sample, max_).
+  float Apply(float exp, float sample);
+
+  // Returns current filtered value.
+  float filtered() const { return filtered_; }
+
+  // Changes the filter factor base to the given value |alpha|.
+  void UpdateBase(float alpha);
+
+ private:
+  float alpha_;  // Filter factor base.
+  float filtered_;  // Current filter output.
+  const float max_;
+};
+}  // namespace rtc
+
+#endif  // WEBRTC_BASE_ANALYTICS_EXP_FILTER_H_

--- a/erizo/src/third_party/webrtc/src/webrtc/base/analytics/percentile_filter.h
+++ b/erizo/src/third_party/webrtc/src/webrtc/base/analytics/percentile_filter.h
@@ -1,0 +1,115 @@
+/*
+ *  Copyright (c) 2016 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef WEBRTC_BASE_ANALYTICS_PERCENTILE_FILTER_H_
+#define WEBRTC_BASE_ANALYTICS_PERCENTILE_FILTER_H_
+
+#include <stdint.h>
+
+#include <iterator>
+#include <set>
+
+#include "webrtc/base/checks.h"
+
+namespace webrtc {
+
+// Class to efficiently get the percentile value from a group of observations.
+// The percentile is the value below which a given percentage of the
+// observations fall.
+template <typename T>
+class PercentileFilter {
+ public:
+  // Construct filter. |percentile| should be between 0 and 1.
+  explicit PercentileFilter(float percentile);
+
+  // Insert one observation. The complexity of this operation is logarithmic in
+  // the size of the container.
+  void Insert(const T& value);
+
+  // Remove one observation or return false if |value| doesn't exist in the
+  // container. The complexity of this operation is logarithmic in the size of
+  // the container.
+  bool Erase(const T& value);
+
+  // Get the percentile value. The complexity of this operation is constant.
+  T GetPercentileValue() const;
+
+ private:
+  // Update iterator and index to point at target percentile value.
+  void UpdatePercentileIterator();
+
+  const float percentile_;
+  std::multiset<T> set_;
+  // Maintain iterator and index of current target percentile value.
+  typename std::multiset<T>::iterator percentile_it_;
+  int64_t percentile_index_;
+};
+
+template <typename T>
+PercentileFilter<T>::PercentileFilter(float percentile)
+    : percentile_(percentile),
+      percentile_it_(set_.begin()),
+      percentile_index_(0) {
+  RTC_CHECK_GE(percentile, 0.0f);
+  RTC_CHECK_LE(percentile, 1.0f);
+}
+
+template <typename T>
+void PercentileFilter<T>::Insert(const T& value) {
+  // Insert element at the upper bound.
+  set_.insert(value);
+  if (set_.size() == 1u) {
+    // First element inserted - initialize percentile iterator and index.
+    percentile_it_ = set_.begin();
+    percentile_index_ = 0;
+  } else if (value < *percentile_it_) {
+    // If new element is before us, increment |percentile_index_|.
+    ++percentile_index_;
+  }
+  UpdatePercentileIterator();
+}
+
+template <typename T>
+bool PercentileFilter<T>::Erase(const T& value) {
+  typename std::multiset<T>::const_iterator it = set_.lower_bound(value);
+  // Ignore erase operation if the element is not present in the current set.
+  if (it == set_.end() || *it != value)
+    return false;
+  if (it == percentile_it_) {
+    // If same iterator, update to the following element. Index is not
+    // affected.
+    percentile_it_ = set_.erase(it);
+  } else {
+    set_.erase(it);
+    // If erased element was before us, decrement |percentile_index_|.
+    if (value <= *percentile_it_)
+      --percentile_index_;
+  }
+  UpdatePercentileIterator();
+  return true;
+}
+
+template <typename T>
+void PercentileFilter<T>::UpdatePercentileIterator() {
+  if (set_.empty())
+    return;
+  const int64_t index = static_cast<int64_t>(percentile_ * (set_.size() - 1));
+  std::advance(percentile_it_, index - percentile_index_);
+  percentile_index_ = index;
+}
+
+template <typename T>
+T PercentileFilter<T>::GetPercentileValue() const {
+  return set_.empty() ? 0 : *percentile_it_;
+}
+
+}  // namespace webrtc
+
+#endif  // WEBRTC_BASE_ANALYTICS_PERCENTILE_FILTER_H_

--- a/erizo/src/third_party/webrtc/src/webrtc/base/rate_limiter.cc
+++ b/erizo/src/third_party/webrtc/src/webrtc/base/rate_limiter.cc
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2016 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "webrtc/base/rate_limiter.h"
+#include "webrtc/system_wrappers/include/clock.h"
+
+namespace webrtc {
+
+RateLimiter::RateLimiter(Clock* clock, int64_t max_window_ms)
+    : clock_(clock),
+      current_rate_(max_window_ms, RateStatistics::kBpsScale),
+      window_size_ms_(max_window_ms),
+      max_rate_bps_(std::numeric_limits<uint32_t>::max()) {}
+
+RateLimiter::~RateLimiter() {}
+
+// Usage note: This class is intended be usable in a scenario where different
+// threads may call each of the the different method. For instance, a network
+// thread trying to send data calling TryUseRate(), the bandwidth estimator
+// calling SetMaxRate() and a timed maintenance thread periodically updating
+// the RTT.
+bool RateLimiter::TryUseRate(size_t packet_size_bytes) {
+  rtc::CritScope cs(&lock_);
+  int64_t now_ms = clock_->TimeInMilliseconds();
+  rtc::Optional<uint32_t> current_rate = current_rate_.Rate(now_ms);
+  if (current_rate) {
+    // If there is a current rate, check if adding bytes would cause maximum
+    // bitrate target to be exceeded. If there is NOT a valid current rate,
+    // allow allocating rate even if target is exceeded. This prevents
+    // problems
+    // at very low rates, where for instance retransmissions would never be
+    // allowed due to too high bitrate caused by a single packet.
+
+    size_t bitrate_addition_bps =
+        (packet_size_bytes * 8 * 1000) / window_size_ms_;
+    if (*current_rate + bitrate_addition_bps > max_rate_bps_)
+      return false;
+  }
+
+  current_rate_.Update(packet_size_bytes, now_ms);
+  return true;
+}
+
+void RateLimiter::SetMaxRate(uint32_t max_rate_bps) {
+  rtc::CritScope cs(&lock_);
+  max_rate_bps_ = max_rate_bps;
+}
+
+// Set the window size over which to measure the current bitrate.
+// For retransmissions, this is typically the RTT.
+bool RateLimiter::SetWindowSize(int64_t window_size_ms) {
+  rtc::CritScope cs(&lock_);
+  window_size_ms_ = window_size_ms;
+  return current_rate_.SetWindowSize(window_size_ms,
+                                     clock_->TimeInMilliseconds());
+}
+
+}  // namespace webrtc

--- a/erizo/src/third_party/webrtc/src/webrtc/base/rate_limiter.h
+++ b/erizo/src/third_party/webrtc/src/webrtc/base/rate_limiter.h
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2016 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef WEBRTC_BASE_RATE_LIMITER_H_
+#define WEBRTC_BASE_RATE_LIMITER_H_
+
+#include <limits>
+
+#include "webrtc/base/constructormagic.h"
+#include "webrtc/base/criticalsection.h"
+#include "webrtc/base/rate_statistics.h"
+
+namespace webrtc {
+
+class Clock;
+
+// Class used to limit a bitrate, making sure the average does not exceed a
+// maximum as measured over a sliding window. This class is thread safe; all
+// methods will acquire (the same) lock befeore executing.
+class RateLimiter {
+ public:
+  RateLimiter(Clock* clock, int64_t max_window_ms);
+  ~RateLimiter();
+
+  // Try to use rate to send bytes. Returns true on success and if so updates
+  // current rate.
+  bool TryUseRate(size_t packet_size_bytes);
+
+  // Set the maximum bitrate, in bps, that this limiter allows to send.
+  void SetMaxRate(uint32_t max_rate_bps);
+
+  // Set the window size over which to measure the current bitrate.
+  // For example, irt retransmissions, this is typically the RTT.
+  // Returns true on success and false if window_size_ms is out of range.
+  bool SetWindowSize(int64_t window_size_ms);
+
+ private:
+  Clock* const clock_;
+  rtc::CriticalSection lock_;
+  RateStatistics current_rate_ GUARDED_BY(lock_);
+  int64_t window_size_ms_ GUARDED_BY(lock_);
+  uint32_t max_rate_bps_ GUARDED_BY(lock_);
+
+  RTC_DISALLOW_IMPLICIT_CONSTRUCTORS(RateLimiter);
+};
+
+}  // namespace webrtc
+
+#endif  // WEBRTC_BASE_RATE_LIMITER_H_

--- a/erizo/src/third_party/webrtc/src/webrtc/modules/bitrate_controller/include/bitrate_controller.h
+++ b/erizo/src/third_party/webrtc/src/webrtc/modules/bitrate_controller/include/bitrate_controller.h
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2012 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ *
+ *  Usage: this class will register multiple RtcpBitrateObserver's one at each
+ *  RTCP module. It will aggregate the results and run one bandwidth estimation
+ *  and push the result to the encoders via BitrateObserver(s).
+ */
+
+#ifndef WEBRTC_MODULES_BITRATE_CONTROLLER_INCLUDE_BITRATE_CONTROLLER_H_
+#define WEBRTC_MODULES_BITRATE_CONTROLLER_INCLUDE_BITRATE_CONTROLLER_H_
+
+#include <map>
+
+#include "webrtc/modules/congestion_controller/delay_based_bwe.h"
+#include "webrtc/modules/include/module.h"
+#include "webrtc/modules/pacing/paced_sender.h"
+#include "webrtc/modules/rtp_rtcp/include/rtp_rtcp_defines.h"
+
+namespace webrtc {
+
+class CriticalSectionWrapper;
+class RtcEventLog;
+struct PacketInfo;
+
+// Deprecated
+// TODO(perkj): Remove BitrateObserver when no implementations use it.
+class BitrateObserver {
+  // Observer class for bitrate changes announced due to change in bandwidth
+  // estimate or due to bitrate allocation changes. Fraction loss and rtt is
+  // also part of this callback to allow the obsevrer to optimize its settings
+  // for different types of network environments. The bitrate does not include
+  // packet headers and is measured in bits per second.
+ public:
+  virtual void OnNetworkChanged(uint32_t bitrate_bps,
+                                uint8_t fraction_loss,  // 0 - 255.
+                                int64_t rtt_ms) = 0;
+
+  virtual ~BitrateObserver() {}
+};
+
+class BitrateController : public Module {
+  // This class collects feedback from all streams sent to a peer (via
+  // RTCPBandwidthObservers). It does one  aggregated send side bandwidth
+  // estimation and divide the available bitrate between all its registered
+  // BitrateObservers.
+ public:
+  static const int kDefaultStartBitratebps = 300000;
+
+  // Deprecated:
+  // TODO(perkj): BitrateObserver has been deprecated and is not used in WebRTC.
+  // Remove this method once other other projects does not use it.
+  static BitrateController* CreateBitrateController(Clock* clock,
+                                                    BitrateObserver* observer,
+                                                    RtcEventLog* event_log);
+
+  static BitrateController* CreateBitrateController(Clock* clock,
+                                                    RtcEventLog* event_log);
+
+  virtual ~BitrateController() {}
+
+  virtual RtcpBandwidthObserver* CreateRtcpBandwidthObserver() = 0;
+
+  // Deprecated
+  virtual void SetStartBitrate(int start_bitrate_bps) = 0;
+  // Deprecated
+  virtual void SetMinMaxBitrate(int min_bitrate_bps, int max_bitrate_bps) = 0;
+  virtual void SetBitrates(int start_bitrate_bps,
+                           int min_bitrate_bps,
+                           int max_bitrate_bps) = 0;
+
+  virtual void ResetBitrates(int bitrate_bps,
+                             int min_bitrate_bps,
+                             int max_bitrate_bps) = 0;
+
+  virtual void OnDelayBasedBweResult(const DelayBasedBwe::Result& result) = 0;
+
+  // Gets the available payload bandwidth in bits per second. Note that
+  // this bandwidth excludes packet headers.
+  virtual bool AvailableBandwidth(uint32_t* bandwidth) const = 0;
+
+  virtual void SetReservedBitrate(uint32_t reserved_bitrate_bps) = 0;
+
+  virtual bool GetNetworkParameters(uint32_t* bitrate,
+                                    uint8_t* fraction_loss,
+                                    int64_t* rtt) = 0;
+};
+}  // namespace webrtc
+#endif  // WEBRTC_MODULES_BITRATE_CONTROLLER_INCLUDE_BITRATE_CONTROLLER_H_

--- a/erizo/src/third_party/webrtc/src/webrtc/modules/bitrate_controller/include/mock/mock_bitrate_controller.h
+++ b/erizo/src/third_party/webrtc/src/webrtc/modules/bitrate_controller/include/mock/mock_bitrate_controller.h
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef WEBRTC_MODULES_BITRATE_CONTROLLER_INCLUDE_MOCK_MOCK_BITRATE_CONTROLLER_H_
+#define WEBRTC_MODULES_BITRATE_CONTROLLER_INCLUDE_MOCK_MOCK_BITRATE_CONTROLLER_H_
+
+#include "webrtc/modules/bitrate_controller/include/bitrate_controller.h"
+#include "webrtc/test/gmock.h"
+
+namespace webrtc {
+namespace test {
+
+class MockBitrateObserver : public BitrateObserver {
+ public:
+  MOCK_METHOD3(OnNetworkChanged,
+               void(uint32_t bitrate_bps,
+                    uint8_t fraction_loss,
+                    int64_t rtt_ms));
+};
+
+class MockBitrateController : public BitrateController {
+ public:
+  MOCK_METHOD0(CreateRtcpBandwidthObserver, RtcpBandwidthObserver*());
+  MOCK_METHOD1(SetStartBitrate, void(int start_bitrate_bps));
+  MOCK_METHOD2(SetMinMaxBitrate,
+               void(int min_bitrate_bps, int max_bitrate_bps));
+  MOCK_METHOD3(SetBitrates,
+               void(int start_bitrate_bps,
+                    int min_bitrate_bps,
+                    int max_bitrate_bps));
+  MOCK_METHOD3(ResetBitrates,
+               void(int bitrate_bps, int min_bitrate_bps, int max_bitrate_bps));
+  MOCK_METHOD1(UpdateDelayBasedEstimate, void(uint32_t bitrate_bps));
+  MOCK_METHOD1(UpdateProbeBitrate, void(uint32_t bitrate_bps));
+  MOCK_METHOD1(SetEventLog, void(RtcEventLog* event_log));
+  MOCK_CONST_METHOD1(AvailableBandwidth, bool(uint32_t* bandwidth));
+  MOCK_METHOD1(SetReservedBitrate, void(uint32_t reserved_bitrate_bps));
+  MOCK_METHOD3(GetNetworkParameters,
+               bool(uint32_t* bitrate, uint8_t* fraction_loss, int64_t* rtt));
+
+  MOCK_METHOD0(Process, void());
+  MOCK_METHOD0(TimeUntilNextProcess, int64_t());
+};
+}  // namespace test
+}  // namespace webrtc
+
+#endif  // WEBRTC_MODULES_BITRATE_CONTROLLER_INCLUDE_MOCK_MOCK_BITRATE_CONTROLLER_H_

--- a/erizo/src/third_party/webrtc/src/webrtc/modules/bitrate_controller/send_side_bandwidth_estimation.cc
+++ b/erizo/src/third_party/webrtc/src/webrtc/modules/bitrate_controller/send_side_bandwidth_estimation.cc
@@ -1,0 +1,342 @@
+/*
+ *  Copyright (c) 2012 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "webrtc/modules/bitrate_controller/send_side_bandwidth_estimation.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "webrtc/base/checks.h"
+#include "webrtc/base/logging.h"
+#include "webrtc/modules/remote_bitrate_estimator/include/bwe_defines.h"
+#include "webrtc/system_wrappers/include/field_trial.h"
+#include "webrtc/system_wrappers/include/metrics.h"
+
+namespace webrtc {
+namespace {
+const int64_t kBweIncreaseIntervalMs = 1000;
+const int64_t kBweDecreaseIntervalMs = 300;
+const int64_t kStartPhaseMs = 2000;
+const int64_t kBweConverganceTimeMs = 20000;
+const int kLimitNumPackets = 20;
+const int kDefaultMaxBitrateBps = 1000000000;
+const int64_t kLowBitrateLogPeriodMs = 10000;
+const int64_t kRtcEventLogPeriodMs = 5000;
+// Expecting that RTCP feedback is sent uniformly within [0.5, 1.5]s intervals.
+const int64_t kFeedbackIntervalMs = 1500;
+const int64_t kFeedbackTimeoutIntervals = 3;
+const int64_t kTimeoutIntervalMs = 1000;
+
+struct UmaRampUpMetric {
+  const char* metric_name;
+  int bitrate_kbps;
+};
+
+const UmaRampUpMetric kUmaRampupMetrics[] = {
+    {"WebRTC.BWE.RampUpTimeTo500kbpsInMs", 500},
+    {"WebRTC.BWE.RampUpTimeTo1000kbpsInMs", 1000},
+    {"WebRTC.BWE.RampUpTimeTo2000kbpsInMs", 2000}};
+const size_t kNumUmaRampupMetrics =
+    sizeof(kUmaRampupMetrics) / sizeof(kUmaRampupMetrics[0]);
+
+}  // namespace
+
+SendSideBandwidthEstimation::SendSideBandwidthEstimation()
+    : lost_packets_since_last_loss_update_Q8_(0),
+      expected_packets_since_last_loss_update_(0),
+      bitrate_(0),
+      min_bitrate_configured_(congestion_controller::GetMinBitrateBps()),
+      max_bitrate_configured_(kDefaultMaxBitrateBps),
+      last_low_bitrate_log_ms_(-1),
+      has_decreased_since_last_fraction_loss_(false),
+      last_feedback_ms_(-1),
+      last_packet_report_ms_(-1),
+      last_timeout_ms_(-1),
+      last_fraction_loss_(0),
+      last_logged_fraction_loss_(0),
+      last_round_trip_time_ms_(0),
+      bwe_incoming_(0),
+      delay_based_bitrate_bps_(0),
+      time_last_decrease_ms_(0),
+      first_report_time_ms_(-1),
+      initially_lost_packets_(0),
+      bitrate_at_2_seconds_kbps_(0),
+      uma_update_state_(kNoUpdate),
+      rampup_uma_stats_updated_(kNumUmaRampupMetrics, false),
+      last_rtc_event_log_ms_(-1),
+      in_timeout_experiment_(webrtc::field_trial::FindFullName(
+                                 "WebRTC-FeedbackTimeout") == "Enabled") {
+}
+
+SendSideBandwidthEstimation::~SendSideBandwidthEstimation() {}
+
+void SendSideBandwidthEstimation::SetBitrates(int send_bitrate,
+                                              int min_bitrate,
+                                              int max_bitrate) {
+  if (send_bitrate > 0)
+    SetSendBitrate(send_bitrate);
+  SetMinMaxBitrate(min_bitrate, max_bitrate);
+}
+
+void SendSideBandwidthEstimation::SetSendBitrate(int bitrate) {
+  RTC_DCHECK_GT(bitrate, 0);
+  bitrate_ = bitrate;
+
+  // Clear last sent bitrate history so the new value can be used directly
+  // and not capped.
+  min_bitrate_history_.clear();
+}
+
+void SendSideBandwidthEstimation::SetMinMaxBitrate(int min_bitrate,
+                                                   int max_bitrate) {
+  RTC_DCHECK_GE(min_bitrate, 0);
+  min_bitrate_configured_ =
+      std::max(min_bitrate, congestion_controller::GetMinBitrateBps());
+  if (max_bitrate > 0) {
+    max_bitrate_configured_ =
+        std::max<uint32_t>(min_bitrate_configured_, max_bitrate);
+  } else {
+    max_bitrate_configured_ = kDefaultMaxBitrateBps;
+  }
+}
+
+int SendSideBandwidthEstimation::GetMinBitrate() const {
+  return min_bitrate_configured_;
+}
+
+void SendSideBandwidthEstimation::CurrentEstimate(int* bitrate,
+                                                  uint8_t* loss,
+                                                  int64_t* rtt) const {
+  *bitrate = bitrate_;
+  *loss = last_fraction_loss_;
+  *rtt = last_round_trip_time_ms_;
+}
+
+void SendSideBandwidthEstimation::UpdateReceiverEstimate(
+    int64_t now_ms, uint32_t bandwidth) {
+  bwe_incoming_ = bandwidth;
+  bitrate_ = CapBitrateToThresholds(now_ms, bitrate_);
+}
+
+void SendSideBandwidthEstimation::UpdateDelayBasedEstimate(
+    int64_t now_ms,
+    uint32_t bitrate_bps) {
+  delay_based_bitrate_bps_ = bitrate_bps;
+  bitrate_ = CapBitrateToThresholds(now_ms, bitrate_);
+}
+
+void SendSideBandwidthEstimation::UpdateReceiverBlock(uint8_t fraction_loss,
+                                                      int64_t rtt,
+                                                      int number_of_packets,
+                                                      int64_t now_ms) {
+  last_feedback_ms_ = now_ms;
+  if (first_report_time_ms_ == -1)
+    first_report_time_ms_ = now_ms;
+
+  // Update RTT.
+  last_round_trip_time_ms_ = rtt;
+
+  // Check sequence number diff and weight loss report
+  if (number_of_packets > 0) {
+    // Calculate number of lost packets.
+    const int num_lost_packets_Q8 = fraction_loss * number_of_packets;
+    // Accumulate reports.
+    lost_packets_since_last_loss_update_Q8_ += num_lost_packets_Q8;
+    expected_packets_since_last_loss_update_ += number_of_packets;
+
+    // Don't generate a loss rate until it can be based on enough packets.
+    if (expected_packets_since_last_loss_update_ < kLimitNumPackets)
+      return;
+
+    has_decreased_since_last_fraction_loss_ = false;
+    last_fraction_loss_ = lost_packets_since_last_loss_update_Q8_ /
+                          expected_packets_since_last_loss_update_;
+
+    // Reset accumulators.
+    lost_packets_since_last_loss_update_Q8_ = 0;
+    expected_packets_since_last_loss_update_ = 0;
+    last_packet_report_ms_ = now_ms;
+    UpdateEstimate(now_ms);
+  }
+  UpdateUmaStats(now_ms, rtt, (fraction_loss * number_of_packets) >> 8);
+}
+
+void SendSideBandwidthEstimation::UpdateUmaStats(int64_t now_ms,
+                                                 int64_t rtt,
+                                                 int lost_packets) {
+  int bitrate_kbps = static_cast<int>((bitrate_ + 500) / 1000);
+  for (size_t i = 0; i < kNumUmaRampupMetrics; ++i) {
+    if (!rampup_uma_stats_updated_[i] &&
+        bitrate_kbps >= kUmaRampupMetrics[i].bitrate_kbps) {
+      RTC_HISTOGRAMS_COUNTS_100000(i, kUmaRampupMetrics[i].metric_name,
+                                   now_ms - first_report_time_ms_);
+      rampup_uma_stats_updated_[i] = true;
+    }
+  }
+  if (IsInStartPhase(now_ms)) {
+    initially_lost_packets_ += lost_packets;
+  } else if (uma_update_state_ == kNoUpdate) {
+    uma_update_state_ = kFirstDone;
+    bitrate_at_2_seconds_kbps_ = bitrate_kbps;
+    RTC_HISTOGRAM_COUNTS("WebRTC.BWE.InitiallyLostPackets",
+                         initially_lost_packets_, 0, 100, 50);
+    RTC_HISTOGRAM_COUNTS("WebRTC.BWE.InitialRtt", static_cast<int>(rtt), 0,
+                         2000, 50);
+    RTC_HISTOGRAM_COUNTS("WebRTC.BWE.InitialBandwidthEstimate",
+                         bitrate_at_2_seconds_kbps_, 0, 2000, 50);
+  } else if (uma_update_state_ == kFirstDone &&
+             now_ms - first_report_time_ms_ >= kBweConverganceTimeMs) {
+    uma_update_state_ = kDone;
+    int bitrate_diff_kbps =
+        std::max(bitrate_at_2_seconds_kbps_ - bitrate_kbps, 0);
+    RTC_HISTOGRAM_COUNTS("WebRTC.BWE.InitialVsConvergedDiff", bitrate_diff_kbps,
+                         0, 2000, 50);
+  }
+}
+
+void SendSideBandwidthEstimation::UpdateEstimate(int64_t now_ms) {
+  // We trust the REMB and/or delay-based estimate during the first 2 seconds if
+  // we haven't had any packet loss reported, to allow startup bitrate probing.
+  if (last_fraction_loss_ == 0 && IsInStartPhase(now_ms)) {
+    uint32_t prev_bitrate = bitrate_;
+    if (bwe_incoming_ > bitrate_)
+      bitrate_ = CapBitrateToThresholds(now_ms, bwe_incoming_);
+    if (delay_based_bitrate_bps_ > bitrate_) {
+      bitrate_ = CapBitrateToThresholds(now_ms, delay_based_bitrate_bps_);
+    }
+    if (bitrate_ != prev_bitrate) {
+      min_bitrate_history_.clear();
+      min_bitrate_history_.push_back(std::make_pair(now_ms, bitrate_));
+      return;
+    }
+  }
+  UpdateMinHistory(now_ms);
+  if (last_packet_report_ms_ == -1) {
+    // No feedback received.
+    bitrate_ = CapBitrateToThresholds(now_ms, bitrate_);
+    return;
+  }
+  int64_t time_since_packet_report_ms = now_ms - last_packet_report_ms_;
+  int64_t time_since_feedback_ms = now_ms - last_feedback_ms_;
+  if (time_since_packet_report_ms < 1.2 * kFeedbackIntervalMs) {
+    if (last_fraction_loss_ <= 5) {
+      // Loss < 2%: Increase rate by 8% of the min bitrate in the last
+      // kBweIncreaseIntervalMs.
+      // Note that by remembering the bitrate over the last second one can
+      // rampup up one second faster than if only allowed to start ramping
+      // at 8% per second rate now. E.g.:
+      //   If sending a constant 100kbps it can rampup immediatly to 108kbps
+      //   whenever a receiver report is received with lower packet loss.
+      //   If instead one would do: bitrate_ *= 1.08^(delta time), it would
+      //   take over one second since the lower packet loss to achieve
+      //   108kbps.
+      bitrate_ = static_cast<uint32_t>(
+          min_bitrate_history_.front().second * 1.08 + 0.5);
+
+      // Add 1 kbps extra, just to make sure that we do not get stuck
+      // (gives a little extra increase at low rates, negligible at higher
+      // rates).
+      bitrate_ += 1000;
+    } else if (last_fraction_loss_ <= 26) {
+      // Loss between 2% - 10%: Do nothing.
+    } else {
+      // Loss > 10%: Limit the rate decreases to once a kBweDecreaseIntervalMs
+      // + rtt.
+      if (!has_decreased_since_last_fraction_loss_ &&
+          (now_ms - time_last_decrease_ms_) >=
+              (kBweDecreaseIntervalMs + last_round_trip_time_ms_)) {
+        time_last_decrease_ms_ = now_ms;
+
+        // Reduce rate:
+        //   newRate = rate * (1 - 0.5*lossRate);
+        //   where packetLoss = 256*lossRate;
+        bitrate_ = static_cast<uint32_t>(
+            (bitrate_ * static_cast<double>(512 - last_fraction_loss_)) /
+            512.0);
+        has_decreased_since_last_fraction_loss_ = true;
+      }
+    }
+  } else if (time_since_feedback_ms >
+                 kFeedbackTimeoutIntervals * kFeedbackIntervalMs &&
+             (last_timeout_ms_ == -1 ||
+              now_ms - last_timeout_ms_ > kTimeoutIntervalMs)) {
+    if (in_timeout_experiment_) {
+      LOG(LS_WARNING) << "Feedback timed out (" << time_since_feedback_ms
+                      << " ms), reducing bitrate.";
+      bitrate_ *= 0.8;
+      // Reset accumulators since we've already acted on missing feedback and
+      // shouldn't to act again on these old lost packets.
+      lost_packets_since_last_loss_update_Q8_ = 0;
+      expected_packets_since_last_loss_update_ = 0;
+      last_timeout_ms_ = now_ms;
+    }
+  }
+  uint32_t capped_bitrate = CapBitrateToThresholds(now_ms, bitrate_);
+  if (capped_bitrate != bitrate_ ||
+      last_fraction_loss_ != last_logged_fraction_loss_ ||
+      last_rtc_event_log_ms_ == -1 ||
+      now_ms - last_rtc_event_log_ms_ > kRtcEventLogPeriodMs) {
+    //event_log_->LogBwePacketLossEvent(capped_bitrate, last_fraction_loss_,
+    //                                  expected_packets_since_last_loss_update_);
+    last_logged_fraction_loss_ = last_fraction_loss_;
+    last_rtc_event_log_ms_ = now_ms;
+  }
+  bitrate_ = capped_bitrate;
+}
+
+bool SendSideBandwidthEstimation::IsInStartPhase(int64_t now_ms) const {
+  return first_report_time_ms_ == -1 ||
+         now_ms - first_report_time_ms_ < kStartPhaseMs;
+}
+
+void SendSideBandwidthEstimation::UpdateMinHistory(int64_t now_ms) {
+  // Remove old data points from history.
+  // Since history precision is in ms, add one so it is able to increase
+  // bitrate if it is off by as little as 0.5ms.
+  while (!min_bitrate_history_.empty() &&
+         now_ms - min_bitrate_history_.front().first + 1 >
+             kBweIncreaseIntervalMs) {
+    min_bitrate_history_.pop_front();
+  }
+
+  // Typical minimum sliding-window algorithm: Pop values higher than current
+  // bitrate before pushing it.
+  while (!min_bitrate_history_.empty() &&
+         bitrate_ <= min_bitrate_history_.back().second) {
+    min_bitrate_history_.pop_back();
+  }
+
+  min_bitrate_history_.push_back(std::make_pair(now_ms, bitrate_));
+}
+
+uint32_t SendSideBandwidthEstimation::CapBitrateToThresholds(
+    int64_t now_ms, uint32_t bitrate) {
+  if (bwe_incoming_ > 0 && bitrate > bwe_incoming_) {
+    bitrate = bwe_incoming_;
+  }
+  if (delay_based_bitrate_bps_ > 0 && bitrate > delay_based_bitrate_bps_) {
+    bitrate = delay_based_bitrate_bps_;
+  }
+  if (bitrate > max_bitrate_configured_) {
+    bitrate = max_bitrate_configured_;
+  }
+  if (bitrate < min_bitrate_configured_) {
+    if (last_low_bitrate_log_ms_ == -1 ||
+        now_ms - last_low_bitrate_log_ms_ > kLowBitrateLogPeriodMs) {
+      LOG(LS_WARNING) << "Estimated available bandwidth " << bitrate / 1000
+                      << " kbps is below configured min bitrate "
+                      << min_bitrate_configured_ / 1000 << " kbps.";
+      last_low_bitrate_log_ms_ = now_ms;
+    }
+    bitrate = min_bitrate_configured_;
+  }
+  return bitrate;
+}
+}  // namespace webrtc

--- a/erizo/src/third_party/webrtc/src/webrtc/modules/bitrate_controller/send_side_bandwidth_estimation.h
+++ b/erizo/src/third_party/webrtc/src/webrtc/modules/bitrate_controller/send_side_bandwidth_estimation.h
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (c) 2012 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ *
+ *  FEC and NACK added bitrate is handled outside class
+ */
+
+#ifndef WEBRTC_MODULES_BITRATE_CONTROLLER_SEND_SIDE_BANDWIDTH_ESTIMATION_H_
+#define WEBRTC_MODULES_BITRATE_CONTROLLER_SEND_SIDE_BANDWIDTH_ESTIMATION_H_
+
+#include <deque>
+#include <utility>
+#include <vector>
+
+#include "webrtc/modules/rtp_rtcp/include/rtp_rtcp_defines.h"
+#include "webrtc/system_wrappers/include/critical_section_wrapper.h"
+
+namespace webrtc {
+
+
+class SendSideBandwidthEstimation {
+ public:
+  SendSideBandwidthEstimation();
+  virtual ~SendSideBandwidthEstimation();
+
+  void CurrentEstimate(int* bitrate, uint8_t* loss, int64_t* rtt) const;
+
+  // Call periodically to update estimate.
+  void UpdateEstimate(int64_t now_ms);
+
+  // Call when we receive a RTCP message with TMMBR or REMB.
+  void UpdateReceiverEstimate(int64_t now_ms, uint32_t bandwidth);
+
+  // Call when a new delay-based estimate is available.
+  void UpdateDelayBasedEstimate(int64_t now_ms, uint32_t bitrate_bps);
+
+  // Call when we receive a RTCP message with a ReceiveBlock.
+  void UpdateReceiverBlock(uint8_t fraction_loss,
+                           int64_t rtt,
+                           int number_of_packets,
+                           int64_t now_ms);
+
+  void SetBitrates(int send_bitrate,
+                   int min_bitrate,
+                   int max_bitrate);
+  void SetSendBitrate(int bitrate);
+  void SetMinMaxBitrate(int min_bitrate, int max_bitrate);
+  int GetMinBitrate() const;
+
+ private:
+  enum UmaState { kNoUpdate, kFirstDone, kDone };
+
+  bool IsInStartPhase(int64_t now_ms) const;
+
+  void UpdateUmaStats(int64_t now_ms, int64_t rtt, int lost_packets);
+
+  // Returns the input bitrate capped to the thresholds defined by the max,
+  // min and incoming bandwidth.
+  uint32_t CapBitrateToThresholds(int64_t now_ms, uint32_t bitrate);
+
+  // Updates history of min bitrates.
+  // After this method returns min_bitrate_history_.front().second contains the
+  // min bitrate used during last kBweIncreaseIntervalMs.
+  void UpdateMinHistory(int64_t now_ms);
+
+  std::deque<std::pair<int64_t, uint32_t> > min_bitrate_history_;
+
+  // incoming filters
+  int lost_packets_since_last_loss_update_Q8_;
+  int expected_packets_since_last_loss_update_;
+
+  uint32_t bitrate_;
+  uint32_t min_bitrate_configured_;
+  uint32_t max_bitrate_configured_;
+  int64_t last_low_bitrate_log_ms_;
+
+  bool has_decreased_since_last_fraction_loss_;
+  int64_t last_feedback_ms_;
+  int64_t last_packet_report_ms_;
+  int64_t last_timeout_ms_;
+  uint8_t last_fraction_loss_;
+  uint8_t last_logged_fraction_loss_;
+  int64_t last_round_trip_time_ms_;
+
+  uint32_t bwe_incoming_;
+  uint32_t delay_based_bitrate_bps_;
+  int64_t time_last_decrease_ms_;
+  int64_t first_report_time_ms_;
+  int initially_lost_packets_;
+  int bitrate_at_2_seconds_kbps_;
+  UmaState uma_update_state_;
+  std::vector<bool> rampup_uma_stats_updated_;
+  int64_t last_rtc_event_log_ms_;
+  bool in_timeout_experiment_;
+};
+}  // namespace webrtc
+#endif  // WEBRTC_MODULES_BITRATE_CONTROLLER_SEND_SIDE_BANDWIDTH_ESTIMATION_H_

--- a/erizo_controller/erizoAgent/log4cxx.properties
+++ b/erizo_controller/erizoAgent/log4cxx.properties
@@ -52,3 +52,4 @@ log4j.logger.rtp.RtpSink=WARN
 log4j.logger.rtp.RtpSource=WARN
 log4j.logger.rtp.RRGenerationHandler=WARN
 log4j.logger.rtp.SRPacketHandler=WARN
+log4j.logger.rtp.SenderBandwidthEstimationHandler=WARN


### PR DESCRIPTION
This adds available send bandwidth estimation for subscribers.
It's implemented as a new handler. Estimate updates can be received by implementing a `SenderBandwidthEstimationListener `