### PR TITLE
Add/use data packets

### DIFF
--- a/erizo/src/erizo/DtlsTransport.cpp
+++ b/erizo/src/erizo/DtlsTransport.cpp
@@ -14,7 +14,6 @@
 
 using erizo::Resender;
 using erizo::DtlsTransport;
-using erizo::packetPtr;
 using dtls::DtlsSocketContext;
 
 DEFINE_LOGGER(DtlsTransport, "DtlsTransport");

--- a/erizo/src/erizo/MediaDefinitions.h
+++ b/erizo/src/erizo/MediaDefinitions.h
@@ -47,11 +47,11 @@ class Monitor {
 class FeedbackSink {
  public:
     virtual ~FeedbackSink() {}
-    int deliverFeedback(char* buf, int len) {
-        return this->deliverFeedback_(buf, len);
+    int deliverFeedback(std::shared_ptr<dataPacket> data_packet) {
+        return this->deliverFeedback_(data_packet);
     }
  private:
-    virtual int deliverFeedback_(char* buf, int len) = 0;
+    virtual int deliverFeedback_(std::shared_ptr<dataPacket> data_packet) = 0;
 };
 
 
@@ -76,11 +76,11 @@ class MediaSink: public virtual Monitor {
     FeedbackSource* sinkfbSource_;
 
  public:
-    int deliverAudioData(char* buf, int len) {
-        return this->deliverAudioData_(buf, len);
+    int deliverAudioData(std::shared_ptr<dataPacket> data_packet) {
+        return this->deliverAudioData_(data_packet);
     }
-    int deliverVideoData(char* buf, int len) {
-        return this->deliverVideoData_(buf, len);
+    int deliverVideoData(std::shared_ptr<dataPacket> data_packet) {
+        return this->deliverVideoData_(data_packet);
     }
     unsigned int getVideoSinkSSRC() {
         boost::mutex::scoped_lock lock(myMonitor_);
@@ -108,8 +108,8 @@ class MediaSink: public virtual Monitor {
     virtual void close() = 0;
 
  private:
-    virtual int deliverAudioData_(char* buf, int len) = 0;
-    virtual int deliverVideoData_(char* buf, int len) = 0;
+    virtual int deliverAudioData_(std::shared_ptr<dataPacket> data_packet) = 0;
+    virtual int deliverVideoData_(std::shared_ptr<dataPacket> data_packet) = 0;
 };
 
 /**
@@ -161,15 +161,6 @@ class MediaSource: public virtual Monitor {
     virtual ~MediaSource() {}
 
     virtual void close() = 0;
-};
-
-/**
- * A NiceReceiver is any class that can receive data from a nice connection.
- */
-class NiceReceiver {
- public:
-    virtual int receiveNiceData(char* buf, int len, NiceConnection* nice) = 0;
-    virtual ~NiceReceiver() {}
 };
 
 }  // namespace erizo

--- a/erizo/src/erizo/OneToManyProcessor.h
+++ b/erizo/src/erizo/OneToManyProcessor.h
@@ -52,9 +52,9 @@ class OneToManyProcessor : public MediaSink, public FeedbackSink {
   typedef std::shared_ptr<MediaSink> sink_ptr;
   FeedbackSink* feedbackSink_;
 
-  int deliverAudioData_(char* buf, int len) override;
-  int deliverVideoData_(char* buf, int len) override;
-  int deliverFeedback_(char* buf, int len) override;
+  int deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) override;
+  int deliverVideoData_(std::shared_ptr<dataPacket> video_packet) override;
+  int deliverFeedback_(std::shared_ptr<dataPacket> fb_packet) override;
   void closeAll();
 };
 

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -347,12 +347,12 @@ int WebRtcConnection::deliverAudioData_(std::shared_ptr<dataPacket> audio_packet
   if (bundle_) {
     if (videoTransport_.get() != NULL) {
       if (audioEnabled_ == true) {
-        sendPacketAsync(audio_packet);
+        sendPacketAsync(std::make_shared<dataPacket>(*audio_packet));
       }
     }
   } else if (audioTransport_.get() != NULL) {
     if (audioEnabled_ == true) {
-        sendPacketAsync(audio_packet);
+        sendPacketAsync(std::make_shared<dataPacket>(*audio_packet));
     }
   }
   return audio_packet->length;
@@ -361,7 +361,7 @@ int WebRtcConnection::deliverAudioData_(std::shared_ptr<dataPacket> audio_packet
 int WebRtcConnection::deliverVideoData_(std::shared_ptr<dataPacket> video_packet) {
   if (videoTransport_.get() != NULL) {
     if (videoEnabled_ == true) {
-      sendPacketAsync(video_packet);
+      sendPacketAsync(std::make_shared<dataPacket>(*video_packet));
     }
   }
   return video_packet->length;
@@ -733,7 +733,7 @@ void WebRtcConnection::sendPacket(std::shared_ptr<dataPacket> p) {
   uint32_t partial_bitrate = 0;
   uint64_t sentVideoBytes = 0;
   uint64_t lastSecondVideoBytes = 0;
-  ELOG_DEBUG("Trying to send %u", p->length);
+
   if (rateControl_ && !slide_show_mode_) {
     if (p->type == VIDEO_PACKET) {
       if (rateControl_ == 1) {

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -100,10 +100,6 @@ class WebRtcConnection: public MediaSink, public MediaSource, public FeedbackSin
    */
   std::string getLocalSdp();
 
-  int deliverAudioData(char* buf, int len);
-  int deliverVideoData(char* buf, int len);
-  int deliverFeedback(char* buf, int len);
-
   /**
    * Sends a PLI Packet
    * @return the size of the data sent
@@ -175,9 +171,9 @@ class WebRtcConnection: public MediaSink, public MediaSource, public FeedbackSin
 
  private:
   void sendPacket(std::shared_ptr<dataPacket> packet);
-  int deliverAudioData_(char* buf, int len) override;
-  int deliverVideoData_(char* buf, int len) override;
-  int deliverFeedback_(char* buf, int len) override;
+  int deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) override;
+  int deliverVideoData_(std::shared_ptr<dataPacket> video_packet) override;
+  int deliverFeedback_(std::shared_ptr<dataPacket> fb_packet) override;
   void initializePipeline();
 
   // Utils

--- a/erizo/src/erizo/media/ExternalInput.cpp
+++ b/erizo/src/erizo/media/ExternalInput.cpp
@@ -10,8 +10,6 @@
 
 #include "./WebRtcConnection.h"
 
-using std::memcpy;
-
 namespace erizo {
 DEFINE_LOGGER(ExternalInput, "media.ExternalInput");
 ExternalInput::ExternalInput(const std::string& inputUrl):url_(inputUrl) {
@@ -165,10 +163,10 @@ int ExternalInput::sendPLI() {
 }
 
 
-void ExternalInput::receiveRtpData(unsigned char*rtpdata, int len) {
+void ExternalInput::receiveRtpData(unsigned char* rtpdata, int len) {
   if (videoSink_ != NULL) {
-    memcpy(sendVideoBuffer_, rtpdata, len);
-    videoSink_->deliverVideoData(sendVideoBuffer_, len);
+    std::shared_ptr<dataPacket> packet = std::make_shared<dataPacket>(0, reinterpret_cast<char*>(rtpdata), len, VIDEO_PACKET);
+    videoSink_->deliverVideoData(packet);
   }
 }
 
@@ -214,7 +212,9 @@ void ExternalInput::receiveLoop() {
         lastAudioPts_ = avpacket_.pts;
         length = op_->packageAudio(avpacket_.data, avpacket_.size, decodedBuffer_.get(), avpacket_.pts);
         if (length > 0) {
-          audioSink_->deliverAudioData(reinterpret_cast<char*>(decodedBuffer_.get()), length);
+          std::shared_ptr<dataPacket> packet = std::make_shared<dataPacket>(0,
+              reinterpret_cast<char*>(decodedBuffer_.get()), length, AUDIO_PACKET);
+          audioSink_->deliverAudioData(packet);
         }
       }
     }

--- a/erizo/src/erizo/media/ExternalInput.cpp
+++ b/erizo/src/erizo/media/ExternalInput.cpp
@@ -165,7 +165,8 @@ int ExternalInput::sendPLI() {
 
 void ExternalInput::receiveRtpData(unsigned char* rtpdata, int len) {
   if (videoSink_ != NULL) {
-    std::shared_ptr<dataPacket> packet = std::make_shared<dataPacket>(0, reinterpret_cast<char*>(rtpdata), len, VIDEO_PACKET);
+    std::shared_ptr<dataPacket> packet = std::make_shared<dataPacket>(0, reinterpret_cast<char*>(rtpdata),
+        len, VIDEO_PACKET);
     videoSink_->deliverVideoData(packet);
   }
 }

--- a/erizo/src/erizo/media/ExternalInput.h
+++ b/erizo/src/erizo/media/ExternalInput.h
@@ -39,7 +39,6 @@ class ExternalInput : public MediaSource, public RTPDataReceiver {
   boost::scoped_ptr<OutputProcessor> op_;
   VideoDecoder inCodec_;
   boost::scoped_array<unsigned char> decodedBuffer_;
-  char sendVideoBuffer_[2000];
 
   std::string url_;
   bool running_;

--- a/erizo/src/erizo/media/ExternalOutput.cpp
+++ b/erizo/src/erizo/media/ExternalOutput.cpp
@@ -327,16 +327,18 @@ void ExternalOutput::writeVideoData(char* buf, int len) {
 }
 
 int ExternalOutput::deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) {
-  this->queueData(audio_packet->data, audio_packet->length, AUDIO_PACKET);
+  std::shared_ptr<dataPacket> copied_packet = std::make_shared<dataPacket>(*audio_packet);
+  this->queueData(copied_packet->data, copied_packet->length, AUDIO_PACKET);
   return 0;
 }
 
 int ExternalOutput::deliverVideoData_(std::shared_ptr<dataPacket> video_packet) {
+  std::shared_ptr<dataPacket> copied_packet = std::make_shared<dataPacket>(*video_packet);
   if (videoSourceSsrc_ == 0) {
-    RtpHeader* h = reinterpret_cast<RtpHeader*>(video_packet->data);
+    RtpHeader* h = reinterpret_cast<RtpHeader*>(copied_packet->data);
     videoSourceSsrc_ = h->getSSRC();
   }
-  this->queueData(video_packet->data, video_packet->length, VIDEO_PACKET);
+  this->queueData(copied_packet->data, copied_packet->length, VIDEO_PACKET);
   return 0;
 }
 

--- a/erizo/src/erizo/media/ExternalOutput.h
+++ b/erizo/src/erizo/media/ExternalOutput.h
@@ -60,7 +60,6 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
   int unpackagedSize_;
   uint32_t videoSourceSsrc_;
   unsigned char* unpackagedBufferpart_;
-  unsigned char deliverMediaBuffer_[3000];
   unsigned char unpackagedBuffer_[UNPACKAGE_BUFFER_SIZE];
 
   // Timestamping strategy: we use the RTP timestamps so we don't have to restamp and we're not
@@ -103,8 +102,8 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
   int sendFirPacket();
   void queueData(char* buffer, int length, packetType type);
   void sendLoop();
-  int deliverAudioData_(char* buf, int len) override;
-  int deliverVideoData_(char* buf, int len) override;
+  int deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) override;
+  int deliverVideoData_(std::shared_ptr<dataPacket> video_packet) override;
   void writeAudioData(char* buf, int len);
   void writeVideoData(char* buf, int len);
   bool bufferCheck(RTPPayloadVP8* payload);

--- a/erizo/src/erizo/media/MediaProcessor.cpp
+++ b/erizo/src/erizo/media/MediaProcessor.cpp
@@ -72,8 +72,9 @@ int InputProcessor::init(const MediaInfo& info, RawDataReceiver* receiver) {
 
 int InputProcessor::deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) {
   if (audioDecoder && audioUnpackager) {
+    std::shared_ptr<dataPacket> copied_packet = std::make_shared<dataPacket>(*audio_packet);
     ELOG_DEBUG("Decoding audio");
-    int unp = unpackageAudio((unsigned char*) audio_packet->data, audio_packet->length,
+    int unp = unpackageAudio((unsigned char*) copied_packet->data, copied_packet->length,
         unpackagedAudioBuffer_);
     int a = decodeAudio(unpackagedAudioBuffer_, unp, decodedAudioBuffer_);
     ELOG_DEBUG("DECODED AUDIO a %d", a);
@@ -88,7 +89,8 @@ int InputProcessor::deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) 
 }
 int InputProcessor::deliverVideoData_(std::shared_ptr<dataPacket> video_packet) {
   if (videoUnpackager && videoDecoder) {
-    int ret = unpackageVideo(reinterpret_cast<unsigned char*>(video_packet->data), video_packet->length,
+    std::shared_ptr<dataPacket> copied_packet = std::make_shared<dataPacket>(*video_packet);
+    int ret = unpackageVideo(reinterpret_cast<unsigned char*>(copied_packet->data), copied_packet->length,
         unpackagedBufferPtr_, &gotUnpackagedFrame_);
     if (ret < 0)
       return 0;

--- a/erizo/src/erizo/media/MediaProcessor.cpp
+++ b/erizo/src/erizo/media/MediaProcessor.cpp
@@ -70,10 +70,10 @@ int InputProcessor::init(const MediaInfo& info, RawDataReceiver* receiver) {
   return 0;
 }
 
-int InputProcessor::deliverAudioData_(char* buf, int len) {
+int InputProcessor::deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) {
   if (audioDecoder && audioUnpackager) {
     ELOG_DEBUG("Decoding audio");
-    int unp = unpackageAudio((unsigned char*) buf, len,
+    int unp = unpackageAudio((unsigned char*) audio_packet->data, audio_packet->length,
         unpackagedAudioBuffer_);
     int a = decodeAudio(unpackagedAudioBuffer_, unp, decodedAudioBuffer_);
     ELOG_DEBUG("DECODED AUDIO a %d", a);
@@ -86,9 +86,10 @@ int InputProcessor::deliverAudioData_(char* buf, int len) {
   }
   return 0;
 }
-int InputProcessor::deliverVideoData_(char* buf, int len) {
+int InputProcessor::deliverVideoData_(std::shared_ptr<dataPacket> video_packet) {
   if (videoUnpackager && videoDecoder) {
-    int ret = unpackageVideo(reinterpret_cast<unsigned char*>(buf), len, unpackagedBufferPtr_, &gotUnpackagedFrame_);
+    int ret = unpackageVideo(reinterpret_cast<unsigned char*>(video_packet->data), video_packet->length,
+        unpackagedBufferPtr_, &gotUnpackagedFrame_);
     if (ret < 0)
       return 0;
     upackagedSize_ += ret;

--- a/erizo/src/erizo/media/MediaProcessor.h
+++ b/erizo/src/erizo/media/MediaProcessor.h
@@ -29,6 +29,7 @@ enum ProcessorType {
   RTP_ONLY, AVF, PACKAGE_ONLY
 };
 
+
 enum DataType {
   VIDEO, AUDIO
 };
@@ -89,7 +90,7 @@ class InputProcessor: public MediaSink {
   int unpackageAudio(unsigned char* inBuff, int inBuffLen, unsigned char* outBuff);
 
   void closeSink();
-  void close();
+  void close() override;
 
  private:
   int audioDecoder;
@@ -133,8 +134,8 @@ class InputProcessor: public MediaSink {
 
   bool initAudioUnpackager();
   bool initVideoUnpackager();
-  int deliverAudioData_(char* buf, int len);
-  int deliverVideoData_(char* buf, int len);
+  int deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) override;
+  int deliverVideoData_(std::shared_ptr<dataPacket> video_packet) override;
 
   int decodeAudio(unsigned char* inBuff, int inBuffLen, unsigned char* outBuff);
 };

--- a/erizo/src/erizo/media/OneToManyTranscoder.cpp
+++ b/erizo/src/erizo/media/OneToManyTranscoder.cpp
@@ -53,30 +53,28 @@ OneToManyTranscoder::~OneToManyTranscoder() {
   delete op_; op_ = NULL;
 }
 
-int OneToManyTranscoder::deliverAudioData_(char* buf, int len) {
-  if (subscribers.empty() || len <= 0)
+int OneToManyTranscoder::deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) {
+  if (subscribers.empty() || audio_packet->length <= 0)
   return 0;
 
   std::map<std::string, MediaSink*>::iterator it;
   for (it = subscribers.begin(); it != subscribers.end(); it++) {
-    memcpy(sendAudioBuffer_, buf, len);
-    (*it).second->deliverAudioData(sendAudioBuffer_, len);
+    (*it).second->deliverAudioData(audio_packet);
   }
 
   return 0;
 }
 
-int OneToManyTranscoder::deliverVideoData_(char* buf, int len) {
-  memcpy(sendVideoBuffer_, buf, len);
-
-  RtpHeader* theHead = reinterpret_cast<RtpHeader*>(buf);
+int OneToManyTranscoder::deliverVideoData_(std::shared_ptr<dataPacket> video_packet) {
+  RtpHeader* theHead = reinterpret_cast<RtpHeader*>(video_packet->data);
   // ELOG_DEBUG("extension %d pt %u", theHead->getExtension(),
   // theHead->getPayloadType());
 
   if (theHead->getPayloadType() == 100) {
-    ip_->deliverVideoData(sendVideoBuffer_, len);
+    ip_->deliverVideoData(video_packet);
   } else {
-    this->receiveRtpData((unsigned char*) buf, len);
+    memcpy(sendVideoBuffer_, video_packet->data, video_packet->length);
+    this->receiveRtpData((unsigned char*) sendVideoBuffer_, video_packet->length);
   }
 
   sentPackets_++;
@@ -89,14 +87,13 @@ void OneToManyTranscoder::receiveRawData(const RawDataPacket& pkt) {
 }
 
 void OneToManyTranscoder::receiveRtpData(unsigned char*rtpdata, int len) {
-  ELOG_DEBUG("Received rtp data %d", len);
-  memcpy(sendVideoBuffer_, rtpdata, len);
-
   if (subscribers.empty() || len <= 0)
   return;
   std::map<std::string, MediaSink*>::iterator it;
+  std::shared_ptr<dataPacket> data_packet = std::make_shared<dataPacket>(0,
+      reinterpret_cast<char*>(rtpdata), len, VIDEO_PACKET);
   for (it = subscribers.begin(); it != subscribers.end(); it++) {
-    (*it).second->deliverVideoData(sendVideoBuffer_, len);
+    (*it).second->deliverVideoData(data_packet);
   }
   sentPackets_++;
 }

--- a/erizo/src/erizo/media/OneToManyTranscoder.h
+++ b/erizo/src/erizo/media/OneToManyTranscoder.h
@@ -62,8 +62,8 @@ class OneToManyTranscoder : public MediaSink, public RawDataReceiver, public RTP
   void sendHead(WebRtcConnection* conn);
   RtpVP8Parser pars;
   unsigned int sentPackets_;
-  int deliverAudioData_(char* buf, int len);
-  int deliverVideoData_(char* buf, int len);
+  int deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) override;
+  int deliverVideoData_(std::shared_ptr<dataPacket> video_packet) override;
   /**
   * Closes all the subscribers and the publisher, the object is useless after this
   */

--- a/erizo/src/erizo/media/SyntheticInput.cpp
+++ b/erizo/src/erizo/media/SyntheticInput.cpp
@@ -136,7 +136,7 @@ void SyntheticInput::sendVideoframe(bool is_keyframe, bool is_marker, uint32_t s
     keyframe_requested_ = false;
   }
   if (videoSink_) {
-    videoSink_->deliverVideoData(packet_buffer, size);
+    videoSink_->deliverVideoData(std::make_shared<dataPacket>(0, packet_buffer, size, VIDEO_PACKET));
   }
   delete header;
 }
@@ -152,7 +152,7 @@ void SyntheticInput::sendAudioFrame(uint32_t size) {
   memset(packet_buffer, 0, size);
   memcpy(packet_buffer, reinterpret_cast<char*>(header), header->getHeaderLength());
   if (audioSink_) {
-    audioSink_->deliverAudioData(packet_buffer, size);
+    audioSink_->deliverAudioData(std::make_shared<dataPacket>(0, packet_buffer, size, AUDIO_PACKET));
   }
   delete header;
 }
@@ -175,13 +175,13 @@ void SyntheticInput::calculateSizeAndPeriod(uint32_t video_bitrate, uint32_t aud
   audio_frame_size_ = audio_period.count() * audio_bitrate / 8000;
 }
 
-int SyntheticInput::deliverFeedback_(char* buf, int len) {
-  RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(buf);
+int SyntheticInput::deliverFeedback_(std::shared_ptr<dataPacket> fb_packet) {
+  RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(fb_packet->data);
   if (chead->isFeedback()) {
-    if (chead->getBlockCount() == 0 && (chead->getLength()+1) * 4  == len) {
+    if (chead->getBlockCount() == 0 && (chead->getLength()+1) * 4  == fb_packet->length) {
       return 0;
     }
-    char* moving_buf = buf;
+    char* moving_buf = fb_packet->data;
     int rtcp_length = 0;
     int total_length = 0;
     do {
@@ -209,7 +209,7 @@ int SyntheticInput::deliverFeedback_(char* buf, int len) {
               break;
           }
       }
-    } while (total_length < len);
+    } while (total_length < fb_packet->length);
   }
   return 0;
 }

--- a/erizo/src/erizo/media/SyntheticInput.h
+++ b/erizo/src/erizo/media/SyntheticInput.h
@@ -48,7 +48,7 @@ class SyntheticInput : public MediaSource, public FeedbackSink, public std::enab
  private:
   void tick();
   void calculateSizeAndPeriod(uint32_t video_bitrate, uint32_t audio_bitrate);
-  int deliverFeedback_(char* buf, int len) override;
+  int deliverFeedback_(std::shared_ptr<dataPacket> fb_packet) override;
   void sendVideoframe(bool is_keyframe, bool is_marker, uint32_t size);
   void sendAudioFrame(uint32_t size);
   uint32_t getRandomValue(uint32_t average, uint32_t variation);

--- a/erizo/src/erizo/media/mixers/VideoMixer.cpp
+++ b/erizo/src/erizo/media/mixers/VideoMixer.cpp
@@ -38,11 +38,11 @@ VideoMixer::~VideoMixer() {
   delete op; op = NULL;
 }
 
-int VideoMixer::deliverAudioData(char* buf, int len) {
+int VideoMixer::deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) {
   return 0;
 }
 
-int VideoMixer::deliverVideoData(char* buf, int len) {
+int VideoMixer::deliverVideoData_(std::shared_ptr<dataPacket> video_packet) {
   return 0;
 }
 

--- a/erizo/src/erizo/media/mixers/VideoMixer.h
+++ b/erizo/src/erizo/media/mixers/VideoMixer.h
@@ -17,10 +17,6 @@ namespace erizo {
 class WebRtcConnection;
 class RTPSink;
 
-/**
-* Represents a One to Many connection.
-* Receives media from one publisher and retransmits it to every subscriber.
-*/
 class VideoMixer : public MediaSink, public RawDataReceiver, public RTPDataReceiver {
   DECLARE_LOGGER();
 
@@ -46,8 +42,9 @@ class VideoMixer : public MediaSink, public RawDataReceiver, public RTPDataRecei
   * @param peerId the peerId
   */
   void removePublisher(int peerSSRC);
-  int deliverAudioData(char* buf, int len);
-  int deliverVideoData(char* buf, int len);
+  int deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) override;
+  int deliverVideoData_(std::shared_ptr<dataPacket> video_packet) override;
+
   void receiveRawData(const RawDataPacket& packet);
   void receiveRtpData(unsigned char* rtpdata, int len);
 

--- a/erizo/src/erizo/rtp/RtcpAggregator.cpp
+++ b/erizo/src/erizo/rtp/RtcpAggregator.cpp
@@ -340,9 +340,11 @@ void RtcpAggregator::checkRtcpFb() {
         }
       }
       if  (sourceSsrc == rtcpSource_->getVideoSourceSSRC()) {
-        rtcpSink_->deliverVideoData(reinterpret_cast<char*>(packet_), length);
+        rtcpSink_->deliverVideoData(std::make_shared<dataPacket>(0, reinterpret_cast<char*>(packet_),
+              length, VIDEO_PACKET));
       } else {
-        rtcpSink_->deliverAudioData(reinterpret_cast<char*>(packet_), length);
+        rtcpSink_->deliverAudioData(std::make_shared<dataPacket>(0, reinterpret_cast<char*>(packet_),
+              length, AUDIO_PACKET));
       }
       rtcpData->last_rr_sent = now;
       if (dt_scheduled > rtcpData->nextPacketInMs) {  // Every scheduled packet we reset

--- a/erizo/src/erizo/rtp/RtpSink.cpp
+++ b/erizo/src/erizo/rtp/RtpSink.cpp
@@ -38,13 +38,13 @@ namespace erizo {
     receive_Thread_.join();
   }
 
-  int RtpSink::deliverVideoData_(char* buf, int len) {
-    this->queueData(buf, len, VIDEO_PACKET);
+  int RtpSink::deliverVideoData_(std::shared_ptr<dataPacket> video_packet) {
+    this->queueData(video_packet->data, video_packet->length, VIDEO_PACKET);
     return 0;
   }
 
-  int RtpSink::deliverAudioData_(char* buf, int len) {
-    this->queueData(buf, len, AUDIO_PACKET);
+  int RtpSink::deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) {
+    this->queueData(audio_packet->data, audio_packet->length, AUDIO_PACKET);
     return 0;
   }
 
@@ -89,7 +89,8 @@ namespace erizo {
 
   void RtpSink::handleReceive(const::boost::system::error_code& error, size_t bytes_recvd) {  // NOLINT
     if (bytes_recvd > 0 && this->fbSink_) {
-      this->fbSink_->deliverFeedback(reinterpret_cast<char*>(buffer_), static_cast<int>(bytes_recvd));
+      this->fbSink_->deliverFeedback(std::make_shared<dataPacket>(0, reinterpret_cast<char*>(buffer_),
+            static_cast<int>(bytes_recvd), OTHER_PACKET));
     }
   }
 

--- a/erizo/src/erizo/rtp/RtpSink.h
+++ b/erizo/src/erizo/rtp/RtpSink.h
@@ -44,8 +44,8 @@ class RtpSink: public MediaSink, public FeedbackSource {
   static const int LENGTH = 1500;
   char* buffer_[LENGTH];
 
-  int deliverAudioData_(char* buf, int len);
-  int deliverVideoData_(char* buf, int len);
+  int deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) override;
+  int deliverVideoData_(std::shared_ptr<dataPacket> video_packet) override;
   int sendData(char* buffer, int len);
   void sendLoop();
   void serviceLoop();

--- a/erizo/src/erizo/rtp/RtpSource.cpp
+++ b/erizo/src/erizo/rtp/RtpSource.cpp
@@ -33,14 +33,15 @@ RtpSource::~RtpSource() {
   rtpSource_thread_.join();
 }
 
-int RtpSource::deliverFeedback_(char* buf, int len) {
-  fbSocket_->send_to(boost::asio::buffer(buf, len), *iterator_);
-  return len;
+int RtpSource::deliverFeedback_(std::shared_ptr<dataPacket> fb_packet) {
+  fbSocket_->send_to(boost::asio::buffer(fb_packet->data, fb_packet->length), *iterator_);
+  return fb_packet->length;
 }
 
 void RtpSource::handleReceive(const::boost::system::error_code& error, size_t bytes_recvd) { // NOLINT
   if (bytes_recvd > 0 && this->videoSink_) {
-    this->videoSink_->deliverVideoData(reinterpret_cast<char*>(buffer_), static_cast<int>(bytes_recvd));
+    this->videoSink_->deliverVideoData(std::make_shared<dataPacket>(0, reinterpret_cast<char*>(buffer_),
+          static_cast<int>(bytes_recvd), OTHER_PACKET));
   }
 }
 

--- a/erizo/src/erizo/rtp/RtpSource.h
+++ b/erizo/src/erizo/rtp/RtpSource.h
@@ -35,10 +35,9 @@ class RtpSource: public MediaSource, public FeedbackSink {
   boost::asio::io_service io_service_;
   boost::thread rtpSource_thread_;
   char* buffer_[LENGTH];
-  bool running_;
   void handleReceive(const::boost::system::error_code& error, size_t bytes_recvd); // NOLINT
   void eventLoop();
-  int deliverFeedback_(char* buf, int len);
+  int deliverFeedback_(std::shared_ptr<dataPacket> fb_packet) override;
 };
 
 

--- a/erizo/src/test/media/SyntheticInputTest.cpp
+++ b/erizo/src/test/media/SyntheticInputTest.cpp
@@ -35,7 +35,7 @@ class SyntheticInputTest : public ::testing::Test {
         input{std::make_shared<SyntheticInput>(config, worker, clock)}
         {
     auto packet = erizo::PacketTools::createRembPacket(30000);
-    input->deliverFeedback(packet->data, packet->length);
+    input->deliverFeedback(packet);
   }
 
  protected:
@@ -177,7 +177,7 @@ TEST_F(SyntheticInputTest, firstVideoFrame_shouldBeAKeyframe) {
 
 TEST_F(SyntheticInputTest, shouldWriteFragmentedKeyFrames_whenExpected) {
   auto packet = erizo::PacketTools::createRembPacket(300000);
-  input->deliverFeedback(packet->data, packet->length);
+  input->deliverFeedback(packet);
   EXPECT_CALL(sink, deliverAudioDataInternal(_, _)).Times(4);
   EXPECT_CALL(sink, deliverVideoDataInternal(_, _)).With(Args<0>(erizo::IsKeyframeFirstPacket())).Times(1);
   EXPECT_CALL(sink, deliverVideoDataInternal(_, _)).With(Args<0>(Not(erizo::IsKeyframeFirstPacket()))).Times(2);
@@ -192,7 +192,7 @@ TEST_F(SyntheticInputTest, shouldWriteKeyFrames_whenPliIsReceived) {
 
   executeTasksInNextMs(80);
 
-  input->deliverFeedback(packet->data, packet->length);
+  input->deliverFeedback(packet);
 
   executeTasksInNextMs(60);
 }

--- a/erizo/src/test/utils/Mocks.h
+++ b/erizo/src/test/utils/Mocks.h
@@ -32,12 +32,12 @@ class MockMediaSink : public MediaSink {
   MOCK_METHOD2(deliverVideoDataInternal, void(char*, int));
 
  private:
-  int deliverAudioData_(char* buf, int len) override {
-    deliverAudioDataInternal(buf, len);
+  int deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) override {
+    deliverAudioDataInternal(audio_packet->data, audio_packet->length);
     return 0;
   }
-  int deliverVideoData_(char* buf, int len) override {
-    deliverVideoDataInternal(buf, len);
+  int deliverVideoData_(std::shared_ptr<dataPacket> video_packet) override {
+    deliverVideoDataInternal(video_packet->data, video_packet->length);
     return 0;
   }
 };


### PR DESCRIPTION
Replaced `(char*, int)` with `std::shared_ptr<dataPacket>` in the MediaSink interface.
