### PR TITLE
Fix disable default handlers

### DIFF
--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
@@ -212,7 +212,7 @@ void BandwidthEstimationHandler::sendREMBPacket() {
   remb_packet_.setREMBFeedSSRC(connection_->getVideoSourceSSRC());
   int remb_length = (remb_packet_.getLength() + 1) * 4;
   if (active_) {
-    ELOG_TRACE("BWE Estimation is %d", last_send_bitrate_);
+    ELOG_DEBUG("BWE Estimation is %d", last_send_bitrate_);
     getContext()->fireWrite(std::make_shared<dataPacket>(0,
       reinterpret_cast<char*>(&remb_packet_), remb_length, OTHER_PACKET));
   }

--- a/erizo_controller/erizoAgent/log4cxx.properties
+++ b/erizo_controller/erizoAgent/log4cxx.properties
@@ -52,4 +52,5 @@ log4j.logger.rtp.RtpSink=WARN
 log4j.logger.rtp.RtpSource=WARN
 log4j.logger.rtp.RRGenerationHandler=WARN
 log4j.logger.rtp.SRPacketHandler=WARN
+log4j.logger.rtp.BandwidthEstimationHandler=WARN
 log4j.logger.rtp.SenderBandwidthEstimationHandler=WARN

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -227,6 +227,13 @@ exports.ErizoJSController = function (threadPool) {
       }
     };
 
+    var disableDefaultHandlers = function(wrtc) {
+      var disabledHandlers = GLOBAL.config.erizo['disabled_handlers'];
+      for (var index in disabledHandlers) {
+        wrtc.disableHandler(disabledHandlers[index]);
+      }
+    };
+
     that.processSignaling = function (streamId, peerId, msg) {
         log.info('message: Process Signaling message, ' +
                  'streamId: ' + streamId + ', peerId: ' + peerId);
@@ -236,6 +243,7 @@ exports.ErizoJSController = function (threadPool) {
                 var subscriber = publisher.getSubscriber(peerId);
                 if (msg.type === 'offer') {
                     subscriber.setRemoteSdp(msg.sdp);
+                    disableDefaultHandlers(subscriber);
                 } else if (msg.type === 'candidate') {
                     subscriber.addRemoteCandidate(msg.candidate.sdpMid,
                                                                      msg.candidate.sdpMLineIndex,
@@ -257,6 +265,7 @@ exports.ErizoJSController = function (threadPool) {
             } else {
                 if (msg.type === 'offer') {
                     publisher.wrtc.setRemoteSdp(msg.sdp);
+                    disableDefaultHandlers(publisher.wrtc);
                 } else if (msg.type === 'candidate') {
                     publisher.wrtc.addRemoteCandidate(msg.candidate.sdpMid,
                                                                  msg.candidate.sdpMLineIndex,

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -19,10 +19,7 @@ function createWrtc(id, threadPool) {
                                     GLOBAL.config.erizo.turnusername,
                                     GLOBAL.config.erizo.turnpass,
                                     GLOBAL.config.erizo.networkinterface);
-  var disabledHandlers = GLOBAL.config.erizo['disabled_handlers'];
-  for (var index in disabledHandlers) {
-    wrtc.disableHandler(disabledHandlers[index]);
-  }
+
   return wrtc;
 }
 


### PR DESCRIPTION
The functionality for disabling handlers by default was broken before this PR because we moved the initialization of the pipeline to the moment when we receive a remote SDP. I've also fixed BWE logs.