### PR TITLE
Add/support for multiple video ssrcs

### DIFF
--- a/erizo/src/erizo/MediaDefinitions.h
+++ b/erizo/src/erizo/MediaDefinitions.h
@@ -5,6 +5,9 @@
 #ifndef ERIZO_SRC_ERIZO_MEDIADEFINITIONS_H_
 #define ERIZO_SRC_ERIZO_MEDIADEFINITIONS_H_
 #include <boost/thread/mutex.hpp>
+#include <vector>
+#include <algorithm>
+
 #include "lib/Clock.h"
 #include "lib/ClockUtils.h"
 
@@ -41,7 +44,7 @@ struct dataPacket {
 
 class Monitor {
  protected:
-    boost::mutex myMonitor_;
+    boost::mutex monitor_mutex_;
 };
 
 class FeedbackSink {
@@ -57,10 +60,12 @@ class FeedbackSink {
 
 class FeedbackSource {
  protected:
-    FeedbackSink* fbSink_;
+    FeedbackSink* fb_sink_;
  public:
+    FeedbackSource(): fb_sink_{nullptr} {}
+    virtual ~FeedbackSource() {}
     void setFeedbackSink(FeedbackSink* sink) {
-        fbSink_ = sink;
+        fb_sink_ = sink;
     }
 };
 
@@ -70,10 +75,10 @@ class FeedbackSource {
 class MediaSink: public virtual Monitor {
  protected:
     // SSRCs received by the SINK
-    uint32_t audioSinkSSRC_;
-    uint32_t videoSinkSSRC_;
+    uint32_t audio_sink_ssrc_;
+    uint32_t video_sink_ssrc_;
     // Is it able to provide Feedback
-    FeedbackSource* sinkfbSource_;
+    FeedbackSource* sink_fb_source_;
 
  public:
     int deliverAudioData(std::shared_ptr<dataPacket> data_packet) {
@@ -82,27 +87,33 @@ class MediaSink: public virtual Monitor {
     int deliverVideoData(std::shared_ptr<dataPacket> data_packet) {
         return this->deliverVideoData_(data_packet);
     }
-    unsigned int getVideoSinkSSRC() {
-        boost::mutex::scoped_lock lock(myMonitor_);
-        return videoSinkSSRC_;
+    uint32_t getVideoSinkSSRC() {
+        boost::mutex::scoped_lock lock(monitor_mutex_);
+        return video_sink_ssrc_;
     }
-    void setVideoSinkSSRC(unsigned int ssrc) {
-        boost::mutex::scoped_lock lock(myMonitor_);
-        videoSinkSSRC_ = ssrc;
+    void setVideoSinkSSRC(uint32_t ssrc) {
+        boost::mutex::scoped_lock lock(monitor_mutex_);
+        video_sink_ssrc_ = ssrc;
     }
-    unsigned int getAudioSinkSSRC() {
-        boost::mutex::scoped_lock lock(myMonitor_);
-        return audioSinkSSRC_;
+    uint32_t getAudioSinkSSRC() {
+        boost::mutex::scoped_lock lock(monitor_mutex_);
+        return audio_sink_ssrc_;
     }
-    void setAudioSinkSSRC(unsigned int ssrc) {
-        boost::mutex::scoped_lock lock(myMonitor_);
-        audioSinkSSRC_ = ssrc;
+    void setAudioSinkSSRC(uint32_t ssrc) {
+        boost::mutex::scoped_lock lock(monitor_mutex_);
+        audio_sink_ssrc_ = ssrc;
+    }
+    bool isVideoSinkSSRC(uint32_t ssrc) {
+      return ssrc == video_sink_ssrc_;
+    }
+    bool isAudioSinkSSRC(uint32_t ssrc) {
+      return ssrc == audio_sink_ssrc_;
     }
     FeedbackSource* getFeedbackSource() {
-        boost::mutex::scoped_lock lock(myMonitor_);
-        return sinkfbSource_;
+        boost::mutex::scoped_lock lock(monitor_mutex_);
+        return sink_fb_source_;
     }
-    MediaSink() : audioSinkSSRC_(0), videoSinkSSRC_(0), sinkfbSource_(NULL) {}
+    MediaSink() : audio_sink_ssrc_{0}, video_sink_ssrc_{0}, sink_fb_source_{nullptr} {}
     virtual ~MediaSink() {}
 
     virtual void close() = 0;
@@ -118,46 +129,67 @@ class MediaSink: public virtual Monitor {
 class MediaSource: public virtual Monitor {
  protected:
     // SSRCs coming from the source
-    uint32_t audioSourceSSRC_;
-    uint32_t videoSourceSSRC_;
-    MediaSink* videoSink_;
-    MediaSink* audioSink_;
+    uint32_t audio_source_ssrc_;
+    std::vector<uint32_t> video_source_ssrc_list_;
+    MediaSink* video_sink_;
+    MediaSink* audio_sink_;
     // can it accept feedback
-    FeedbackSink* sourcefbSink_;
+    FeedbackSink* source_fb_sink_;
 
  public:
-    void setAudioSink(MediaSink* audioSink) {
-        boost::mutex::scoped_lock lock(myMonitor_);
-        this->audioSink_ = audioSink;
+    void setAudioSink(MediaSink* audio_sink) {
+        boost::mutex::scoped_lock lock(monitor_mutex_);
+        this->audio_sink_ = audio_sink;
     }
-    void setVideoSink(MediaSink* videoSink) {
-        boost::mutex::scoped_lock lock(myMonitor_);
-        this->videoSink_ = videoSink;
+    void setVideoSink(MediaSink* video_sink) {
+        boost::mutex::scoped_lock lock(monitor_mutex_);
+        this->video_sink_ = video_sink;
     }
 
     FeedbackSink* getFeedbackSink() {
-        boost::mutex::scoped_lock lock(myMonitor_);
-        return sourcefbSink_;
+        boost::mutex::scoped_lock lock(monitor_mutex_);
+        return source_fb_sink_;
     }
     virtual int sendPLI() = 0;
-    unsigned int getVideoSourceSSRC() {
-        boost::mutex::scoped_lock lock(myMonitor_);
-        return videoSourceSSRC_;
+    uint32_t getVideoSourceSSRC() {
+        boost::mutex::scoped_lock lock(monitor_mutex_);
+        return video_source_ssrc_list_[0];
     }
-    void setVideoSourceSSRC(unsigned int ssrc) {
-        boost::mutex::scoped_lock lock(myMonitor_);
-        videoSourceSSRC_ = ssrc;
+    void setVideoSourceSSRC(uint32_t ssrc) {
+        boost::mutex::scoped_lock lock(monitor_mutex_);
+        video_source_ssrc_list_[0] = ssrc;
     }
-    unsigned int getAudioSourceSSRC() {
-        boost::mutex::scoped_lock lock(myMonitor_);
-        return audioSourceSSRC_;
+    std::vector<uint32_t> getVideoSourceSSRCList() {
+        boost::mutex::scoped_lock lock(monitor_mutex_);
+        return video_source_ssrc_list_;  //  return by copy to avoid concurrent access
     }
-    void setAudioSourceSSRC(unsigned int ssrc) {
-        boost::mutex::scoped_lock lock(myMonitor_);
-        audioSourceSSRC_ = ssrc;
+    void setVideoSourceSSRCList(const std::vector<uint32_t>& new_ssrc_list) {
+        boost::mutex::scoped_lock lock(monitor_mutex_);
+        video_source_ssrc_list_ = new_ssrc_list;
+    }
+    uint32_t getAudioSourceSSRC() {
+        boost::mutex::scoped_lock lock(monitor_mutex_);
+        return audio_source_ssrc_;
+    }
+    void setAudioSourceSSRC(uint32_t ssrc) {
+        boost::mutex::scoped_lock lock(monitor_mutex_);
+        audio_source_ssrc_ = ssrc;
     }
 
-    MediaSource() : audioSourceSSRC_{0}, videoSourceSSRC_{0}, sourcefbSink_{NULL} {}
+    bool isVideoSourceSSRC(uint32_t ssrc) {
+      auto found_ssrc = std::find_if(video_source_ssrc_list_.begin(), video_source_ssrc_list_.end(),
+          [ssrc](uint32_t known_ssrc) {
+          return known_ssrc == ssrc;
+          });
+      return (found_ssrc != video_source_ssrc_list_.end());
+    }
+
+    bool isAudioSourceSSRC(uint32_t ssrc) {
+      return audio_source_ssrc_ == ssrc;
+    }
+
+    MediaSource() : audio_source_ssrc_{0}, video_source_ssrc_list_{std::vector<uint32_t>(1, 0)},
+      video_sink_{nullptr}, audio_sink_{nullptr}, source_fb_sink_{nullptr} {}
     virtual ~MediaSource() {}
 
     virtual void close() = 0;

--- a/erizo/src/erizo/OneToManyProcessor.cpp
+++ b/erizo/src/erizo/OneToManyProcessor.cpp
@@ -12,9 +12,8 @@
 
 namespace erizo {
   DEFINE_LOGGER(OneToManyProcessor, "OneToManyProcessor");
-  OneToManyProcessor::OneToManyProcessor() {
+  OneToManyProcessor::OneToManyProcessor() : feedbackSink_{nullptr} {
     ELOG_DEBUG("OneToManyProcessor constructor");
-    feedbackSink_ = NULL;
   }
 
   OneToManyProcessor::~OneToManyProcessor() {
@@ -44,7 +43,7 @@ namespace erizo {
     RtcpHeader* head = reinterpret_cast<RtcpHeader*>(video_packet->data);
     if (head->isFeedback()) {
       ELOG_WARN("Receiving Feedback in wrong path: %d", head->packettype);
-      if (feedbackSink_ != NULL) {
+      if (feedbackSink_ != nullptr) {
         head->ssrc = htonl(publisher->getVideoSourceSSRC());
         feedbackSink_->deliverFeedback(video_packet);
       }
@@ -55,7 +54,7 @@ namespace erizo {
       return 0;
     std::map<std::string, std::shared_ptr<MediaSink>>::iterator it;
     for (it = subscribers.begin(); it != subscribers.end(); ++it) {
-      if ((*it).second != NULL) {
+      if ((*it).second != nullptr) {
         (*it).second->deliverVideoData(video_packet);
       }
     }
@@ -69,7 +68,7 @@ namespace erizo {
   }
 
   int OneToManyProcessor::deliverFeedback_(std::shared_ptr<dataPacket> fb_packet) {
-    if (feedbackSink_ != NULL) {
+    if (feedbackSink_ != nullptr) {
       feedbackSink_->deliverFeedback(fb_packet);
     }
     return 0;
@@ -87,7 +86,7 @@ namespace erizo {
                this->publisher->getAudioSourceSSRC() , this->publisher->getVideoSourceSSRC());
     FeedbackSource* fbsource = webRtcConn->getFeedbackSource();
 
-    if (fbsource != NULL) {
+    if (fbsource != nullptr) {
       ELOG_DEBUG("adding fbsource");
       fbsource->setFeedbackSink(this);
     }
@@ -109,7 +108,7 @@ namespace erizo {
 
   void OneToManyProcessor::closeAll() {
     ELOG_DEBUG("OneToManyProcessor closeAll");
-    feedbackSink_ = NULL;
+    feedbackSink_ = nullptr;
     if (publisher.get()) {
       publisher->close();
     }
@@ -117,11 +116,11 @@ namespace erizo {
     boost::unique_lock<boost::mutex> lock(monitor_mutex_);
     std::map<std::string, std::shared_ptr<MediaSink>>::iterator it = subscribers.begin();
     while (it != subscribers.end()) {
-      if ((*it).second != NULL) {
+      if ((*it).second != nullptr) {
         FeedbackSource* fbsource = (*it).second->getFeedbackSource();
         (*it).second->close();
-        if (fbsource != NULL) {
-          fbsource->setFeedbackSink(NULL);
+        if (fbsource != nullptr) {
+          fbsource->setFeedbackSink(nullptr);
         }
       }
       subscribers.erase(it++);

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -41,11 +41,11 @@ WebRtcConnection::WebRtcConnection(std::shared_ptr<Worker> worker, const std::st
       toLog(), iceConfig.stunServer.c_str(), iceConfig.stunPort, iceConfig.minPort, iceConfig.maxPort);
   setVideoSinkSSRC(55543);
   setAudioSinkSSRC(44444);
-  videoSink_ = NULL;
-  audioSink_ = NULL;
-  fbSink_ = NULL;
-  sourcefbSink_ = this;
-  sinkfbSource_ = this;
+  video_sink_ = nullptr;
+  audio_sink_ = nullptr;
+  fb_sink_ = nullptr;
+  source_fb_sink_ = this;
+  sink_fb_source_ = this;
   stats_ = std::make_shared<Stats>();
   globalState_ = CONN_INITIAL;
 
@@ -72,12 +72,12 @@ WebRtcConnection::~WebRtcConnection() {
     audioTransport_->close();
   }
   globalState_ = CONN_FINISHED;
-  if (connEventListener_ != NULL) {
-    connEventListener_ = NULL;
+  if (connEventListener_ != nullptr) {
+    connEventListener_ = nullptr;
   }
-  videoSink_ = NULL;
-  audioSink_ = NULL;
-  fbSink_ = NULL;
+  video_sink_ = nullptr;
+  audio_sink_ = nullptr;
+  fb_sink_ = nullptr;
   ELOG_DEBUG("%s message: Destructor ended", toLog());
 }
 
@@ -85,18 +85,18 @@ void WebRtcConnection::close() {
 }
 
 bool WebRtcConnection::init() {
-  if (connEventListener_ != NULL) {
+  if (connEventListener_ != nullptr) {
     connEventListener_->notifyEvent(globalState_, "");
   }
   return true;
 }
 
 bool WebRtcConnection::isSourceSSRC(uint32_t ssrc) {
-  return (ssrc == getVideoSourceSSRC() || ssrc == getAudioSourceSSRC());
+  return isVideoSourceSSRC(ssrc) || isAudioSourceSSRC(ssrc);
 }
 
 bool WebRtcConnection::isSinkSSRC(uint32_t ssrc) {
-  return (ssrc == getVideoSinkSSRC() || ssrc == getAudioSinkSSRC());
+  return isVideoSinkSSRC(ssrc) || isAudioSinkSSRC(ssrc);
 }
 
 
@@ -119,21 +119,21 @@ bool WebRtcConnection::createOffer(bool videoEnabled, bool audioEnabled, bool bu
     videoTransport_->copyLogContextFrom(this);
     videoTransport_->start();
   } else {
-    if (videoTransport_.get() == NULL && videoEnabled_) {
+    if (videoTransport_.get() == nullptr && videoEnabled_) {
       // For now we don't re/check transports, if they are already created we leave them there
       videoTransport_.reset(new DtlsTransport(VIDEO_TYPE, "video", connection_id_, bundle_, true,
                                               this, iceConfig_ , "", "", true, worker_));
       videoTransport_->copyLogContextFrom(this);
       videoTransport_->start();
     }
-    if (audioTransport_.get() == NULL && audioEnabled_) {
+    if (audioTransport_.get() == nullptr && audioEnabled_) {
       audioTransport_.reset(new DtlsTransport(AUDIO_TYPE, "audio", connection_id_, bundle_, true,
                                               this, iceConfig_, "", "", true, worker_));
       audioTransport_->copyLogContextFrom(this);
       audioTransport_->start();
     }
   }
-  if (connEventListener_ != NULL) {
+  if (connEventListener_ != nullptr) {
     std::string msg = this->getLocalSdp();
     connEventListener_->notifyEvent(globalState_, msg);
   }
@@ -150,25 +150,29 @@ bool WebRtcConnection::setRemoteSdp(const std::string &sdp) {
 
   localSdp_.updateSupportedExtensionMap(extProcessor_.getSupportedExtensionMap());
 
-  localSdp_.video_ssrc_list.push_back(this->getVideoSinkSSRC());
-  localSdp_.audio_ssrc = this->getAudioSinkSSRC();
+  localSdp_.video_ssrc_list.push_back(getVideoSinkSSRC());
+  localSdp_.audio_ssrc = getAudioSinkSSRC();
 
   if (remoteSdp_.dtlsRole == ACTPASS) {
     localSdp_.dtlsRole = ACTIVE;
   }
-  this->setVideoSourceSSRC(remoteSdp_.video_ssrc_list.at(0));
-  this->setAudioSourceSSRC(remoteSdp_.audio_ssrc);
-  this->audioEnabled_ = remoteSdp_.hasAudio;
-  this->videoEnabled_ = remoteSdp_.hasVideo;
-  rtcp_processor_->addSourceSsrc(this->getAudioSourceSSRC());
-  rtcp_processor_->addSourceSsrc(this->getVideoSourceSSRC());
+  setVideoSourceSSRCList(remoteSdp_.video_ssrc_list);
+  setAudioSourceSSRC(remoteSdp_.audio_ssrc);
+
+  audioEnabled_ = remoteSdp_.hasAudio;
+  videoEnabled_ = remoteSdp_.hasVideo;
+
+  rtcp_processor_->addSourceSsrc(getAudioSourceSSRC());
+  std::for_each(video_source_ssrc_list_.begin(), video_source_ssrc_list_.end(), [this] (uint32_t new_ssrc){
+      rtcp_processor_->addSourceSsrc(new_ssrc);
+  });
 
   if (remoteSdp_.profile == SAVPF) {
     if (remoteSdp_.isFingerprint) {
       if (remoteSdp_.hasVideo || bundle_) {
         std::string username = remoteSdp_.getUsername(VIDEO_TYPE);
         std::string password = remoteSdp_.getPassword(VIDEO_TYPE);
-        if (videoTransport_.get() == NULL) {
+        if (videoTransport_.get() == nullptr) {
           ELOG_DEBUG("%s message: Creating videoTransport, ufrag: %s, pass: %s",
                       toLog(), username.c_str(), password.c_str());
           videoTransport_.reset(new DtlsTransport(VIDEO_TYPE, "video", connection_id_, bundle_, remoteSdp_.isRtcpMux,
@@ -184,7 +188,7 @@ bool WebRtcConnection::setRemoteSdp(const std::string &sdp) {
       if (!bundle_ && remoteSdp_.hasAudio) {
         std::string username = remoteSdp_.getUsername(AUDIO_TYPE);
         std::string password = remoteSdp_.getPassword(AUDIO_TYPE);
-        if (audioTransport_.get() == NULL) {
+        if (audioTransport_.get() == nullptr) {
           ELOG_DEBUG("%s message: Creating audioTransport, ufrag: %s, pass: %s",
                       toLog(), username.c_str(), password.c_str());
           audioTransport_.reset(new DtlsTransport(AUDIO_TYPE, "audio", connection_id_, bundle_, remoteSdp_.isRtcpMux,
@@ -257,7 +261,7 @@ bool WebRtcConnection::addRemoteCandidate(const std::string &mid, int mLineIndex
   // TODO(pedro) Check type of transport.
   ELOG_DEBUG("%s message: Adding remote Candidate, candidate: %s, mid: %s, sdpMLine: %d",
               toLog(), sdp.c_str(), mid.c_str(), mLineIndex);
-  if (videoTransport_ == NULL) {
+  if (videoTransport_ == nullptr) {
     ELOG_WARN("%s message: addRemoteCandidate on NULL transport", toLog());
     return false;
   }
@@ -299,10 +303,10 @@ bool WebRtcConnection::addRemoteCandidate(const std::string &mid, int mLineIndex
 
 std::string WebRtcConnection::getLocalSdp() {
   ELOG_DEBUG("%s message: Getting Local Sdp", toLog());
-  if (videoTransport_ != NULL) {
+  if (videoTransport_ != nullptr) {
     videoTransport_->processLocalSdp(&localSdp_);
   }
-  if (!bundle_ && audioTransport_ != NULL) {
+  if (!bundle_ && audioTransport_ != nullptr) {
     audioTransport_->processLocalSdp(&localSdp_);
   }
   localSdp_.profile = remoteSdp_.profile;
@@ -352,12 +356,12 @@ void WebRtcConnection::onCandidate(const CandidateInfo& cand, Transport *transpo
 
 int WebRtcConnection::deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) {
   if (bundle_) {
-    if (videoTransport_.get() != NULL) {
+    if (videoTransport_.get() != nullptr) {
       if (audioEnabled_ == true) {
         sendPacketAsync(std::make_shared<dataPacket>(*audio_packet));
       }
     }
-  } else if (audioTransport_.get() != NULL) {
+  } else if (audioTransport_.get() != nullptr) {
     if (audioEnabled_ == true) {
         sendPacketAsync(std::make_shared<dataPacket>(*audio_packet));
     }
@@ -366,7 +370,7 @@ int WebRtcConnection::deliverAudioData_(std::shared_ptr<dataPacket> audio_packet
 }
 
 int WebRtcConnection::deliverVideoData_(std::shared_ptr<dataPacket> video_packet) {
-  if (videoTransport_.get() != NULL) {
+  if (videoTransport_.get() != nullptr) {
     if (videoEnabled_ == true) {
       sendPacketAsync(std::make_shared<dataPacket>(*video_packet));
     }
@@ -377,10 +381,10 @@ int WebRtcConnection::deliverVideoData_(std::shared_ptr<dataPacket> video_packet
 int WebRtcConnection::deliverFeedback_(std::shared_ptr<dataPacket> fb_packet) {
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(fb_packet->data);
   uint32_t recvSSRC = chead->getSourceSSRC();
-  if (recvSSRC == this->getVideoSourceSSRC()) {
+  if (isVideoSourceSSRC(recvSSRC)) {
     fb_packet->type = VIDEO_PACKET;
     sendPacketAsync(fb_packet);
-  } else if (recvSSRC == this->getAudioSourceSSRC()) {
+  } else if (isAudioSourceSSRC(recvSSRC)) {
     fb_packet->type = AUDIO_PACKET;
     sendPacketAsync(fb_packet);
   } else {
@@ -391,7 +395,7 @@ int WebRtcConnection::deliverFeedback_(std::shared_ptr<dataPacket> fb_packet) {
 }
 
 void WebRtcConnection::onTransportData(std::shared_ptr<dataPacket> packet, Transport *transport) {
-  if (audioSink_ == NULL && videoSink_ == NULL && fbSink_ == NULL) {
+  if (audio_sink_ == nullptr && video_sink_ == nullptr && fb_sink_ == nullptr) {
     return;
   }
   if (transport->mediaType == AUDIO_TYPE) {
@@ -405,9 +409,9 @@ void WebRtcConnection::onTransportData(std::shared_ptr<dataPacket> packet, Trans
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*> (buf);
   if (!chead->isRtcp()) {
     uint32_t recvSSRC = head->getSSRC();
-    if (recvSSRC == this->getVideoSourceSSRC()) {
+    if (isVideoSourceSSRC(recvSSRC)) {
       packet->type = VIDEO_PACKET;
-    } else if (recvSSRC == this->getAudioSourceSSRC()) {
+    } else if (isAudioSourceSSRC(this->getAudioSourceSSRC())) {
       packet->type = AUDIO_PACKET;
     }
   }
@@ -435,42 +439,42 @@ void WebRtcConnection::read(std::shared_ptr<dataPacket> packet) {
 
   // DELIVER FEEDBACK (RR, FEEDBACK PACKETS)
   if (chead->isFeedback()) {
-    if (fbSink_ != NULL && shouldSendFeedback_) {
-      fbSink_->deliverFeedback(packet);
+    if (fb_sink_ != nullptr && shouldSendFeedback_) {
+      fb_sink_->deliverFeedback(packet);
     }
   } else {
     // RTP or RTCP Sender Report
     if (bundle_) {
       // Check incoming SSRC
       // Deliver data
-      if (recvSSRC == this->getVideoSourceSSRC()) {
+      if (isVideoSourceSSRC(recvSSRC)) {
         parseIncomingPayloadType(buf, len, VIDEO_PACKET);
-        videoSink_->deliverVideoData(packet);
-      } else if (recvSSRC == this->getAudioSourceSSRC()) {
+        video_sink_->deliverVideoData(packet);
+      } else if (isAudioSourceSSRC(recvSSRC)) {
         parseIncomingPayloadType(buf, len, AUDIO_PACKET);
-        audioSink_->deliverAudioData(packet);
+        audio_sink_->deliverAudioData(packet);
       } else {
         ELOG_DEBUG("%s unknownSSRC: %u, localVideoSSRC: %u, localAudioSSRC: %u",
                     toLog(), recvSSRC, this->getVideoSourceSSRC(), this->getAudioSourceSSRC());
       }
     } else {
-      if (packet->type == AUDIO_PACKET && audioSink_ != NULL) {
+      if (packet->type == AUDIO_PACKET && audio_sink_ != NULL) {
         parseIncomingPayloadType(buf, len, AUDIO_PACKET);
         // Firefox does not send SSRC in SDP
-        if (this->getAudioSourceSSRC() == 0) {
+        if (getAudioSourceSSRC() == 0) {
           ELOG_DEBUG("%s discoveredAudioSourceSSRC:%u", toLog(), recvSSRC);
           this->setAudioSourceSSRC(recvSSRC);
         }
-        audioSink_->deliverAudioData(packet);
-      } else if (packet->type == VIDEO_PACKET && videoSink_ != NULL) {
+        audio_sink_->deliverAudioData(packet);
+      } else if (packet->type == VIDEO_PACKET && video_sink_ != NULL) {
         parseIncomingPayloadType(buf, len, VIDEO_PACKET);
         // Firefox does not send SSRC in SDP
-        if (this->getVideoSourceSSRC() == 0) {
+        if (getVideoSourceSSRC() == 0) {
           ELOG_DEBUG("%s discoveredVideoSourceSSRC:%u", toLog(), recvSSRC);
           this->setVideoSourceSSRC(recvSSRC);
         }
         // change ssrc for RTP packets, don't touch here if RTCP
-        videoSink_->deliverVideoData(packet);
+        video_sink_->deliverVideoData(packet);
       }
     }  // if not bundle
   }  // if not Feedback

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -41,9 +41,6 @@ WebRtcConnection::WebRtcConnection(std::shared_ptr<Worker> worker, const std::st
       toLog(), iceConfig.stunServer.c_str(), iceConfig.stunPort, iceConfig.minPort, iceConfig.maxPort);
   setVideoSinkSSRC(55543);
   setAudioSinkSSRC(44444);
-  video_sink_ = nullptr;
-  audio_sink_ = nullptr;
-  fb_sink_ = nullptr;
   source_fb_sink_ = this;
   sink_fb_source_ = this;
   stats_ = std::make_shared<Stats>();
@@ -336,7 +333,7 @@ void WebRtcConnection::onCandidate(const CandidateInfo& cand, Transport *transpo
   std::string sdp = localSdp_.addCandidate(cand);
   ELOG_DEBUG("%s message: Discovered New Candidate, candidate: %s", toLog(), sdp.c_str());
   if (trickleEnabled_) {
-    if (connEventListener_ != NULL) {
+    if (connEventListener_ != nullptr) {
       if (!bundle_) {
         std::string object = this->getJSONCandidate(transport->transport_name, sdp);
         connEventListener_->notifyEvent(CONN_CANDIDATE, object);
@@ -458,7 +455,7 @@ void WebRtcConnection::read(std::shared_ptr<dataPacket> packet) {
                     toLog(), recvSSRC, this->getVideoSourceSSRC(), this->getAudioSourceSSRC());
       }
     } else {
-      if (packet->type == AUDIO_PACKET && audio_sink_ != NULL) {
+      if (packet->type == AUDIO_PACKET && audio_sink_ != nullptr) {
         parseIncomingPayloadType(buf, len, AUDIO_PACKET);
         // Firefox does not send SSRC in SDP
         if (getAudioSourceSSRC() == 0) {
@@ -466,7 +463,7 @@ void WebRtcConnection::read(std::shared_ptr<dataPacket> packet) {
           this->setAudioSourceSSRC(recvSSRC);
         }
         audio_sink_->deliverAudioData(packet);
-      } else if (packet->type == VIDEO_PACKET && video_sink_ != NULL) {
+      } else if (packet->type == VIDEO_PACKET && video_sink_ != nullptr) {
         parseIncomingPayloadType(buf, len, VIDEO_PACKET);
         // Firefox does not send SSRC in SDP
         if (getVideoSourceSSRC() == 0) {
@@ -498,7 +495,7 @@ void WebRtcConnection::updateState(TransportState state, Transport * transport) 
   WebRTCEvent temp = globalState_;
   std::string msg = "";
   ELOG_DEBUG("%s transportName: %s, new_state: %d", toLog(), transport->transport_name.c_str(), state);
-  if (videoTransport_.get() == NULL && audioTransport_.get() == NULL) {
+  if (videoTransport_.get() == nullptr && audioTransport_.get() == nullptr) {
     ELOG_ERROR("%s message: Updating NULL transport, state: %d", toLog(), state);
     return;
   }
@@ -511,9 +508,9 @@ void WebRtcConnection::updateState(TransportState state, Transport * transport) 
       if (bundle_) {
         temp = CONN_STARTED;
       } else {
-        if ((!remoteSdp_.hasAudio || (audioTransport_.get() != NULL
+        if ((!remoteSdp_.hasAudio || (audioTransport_.get() != nullptr
                   && audioTransport_->getTransportState() == TRANSPORT_STARTED)) &&
-            (!remoteSdp_.hasVideo || (videoTransport_.get() != NULL
+            (!remoteSdp_.hasVideo || (videoTransport_.get() != nullptr
                   && videoTransport_->getTransportState() == TRANSPORT_STARTED))) {
             // WebRTCConnection will be ready only when all channels are ready.
             temp = CONN_STARTED;
@@ -536,9 +533,9 @@ void WebRtcConnection::updateState(TransportState state, Transport * transport) 
           msg = this->getLocalSdp();
         }
       } else {
-        if ((!localSdp_.hasAudio || (audioTransport_.get() != NULL
+        if ((!localSdp_.hasAudio || (audioTransport_.get() != nullptr
                   && audioTransport_->getTransportState() == TRANSPORT_GATHERED)) &&
-            (!localSdp_.hasVideo || (videoTransport_.get() != NULL
+            (!localSdp_.hasVideo || (videoTransport_.get() != nullptr
                   && videoTransport_->getTransportState() == TRANSPORT_GATHERED))) {
             // WebRTCConnection will be ready only when all channels are ready.
             if (!trickleEnabled_) {
@@ -553,9 +550,9 @@ void WebRtcConnection::updateState(TransportState state, Transport * transport) 
         temp = CONN_READY;
 
       } else {
-        if ((!remoteSdp_.hasAudio || (audioTransport_.get() != NULL
+        if ((!remoteSdp_.hasAudio || (audioTransport_.get() != nullptr
                   && audioTransport_->getTransportState() == TRANSPORT_READY)) &&
-            (!remoteSdp_.hasVideo || (videoTransport_.get() != NULL
+            (!remoteSdp_.hasVideo || (videoTransport_.get() != nullptr
                   && videoTransport_->getTransportState() == TRANSPORT_READY))) {
             // WebRTCConnection will be ready only when all channels are ready.
             temp = CONN_READY;
@@ -574,7 +571,7 @@ void WebRtcConnection::updateState(TransportState state, Transport * transport) 
       break;
   }
 
-  if (audioTransport_.get() != NULL && videoTransport_.get() != NULL) {
+  if (audioTransport_.get() != nullptr && videoTransport_.get() != nullptr) {
     ELOG_DEBUG("%s message: %s, transportName: %s, videoTransportState: %d"
               ", audioTransportState: %d, calculatedState: %d, globalState: %d",
       toLog(),
@@ -592,7 +589,7 @@ void WebRtcConnection::updateState(TransportState state, Transport * transport) 
 
   globalState_ = temp;
 
-  if (connEventListener_ != NULL) {
+  if (connEventListener_ != nullptr) {
     ELOG_INFO("%s newGlobalState: %d", toLog(), globalState_);
     connEventListener_->notifyEvent(globalState_, msg);
   }

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -408,7 +408,7 @@ void WebRtcConnection::onTransportData(std::shared_ptr<dataPacket> packet, Trans
     uint32_t recvSSRC = head->getSSRC();
     if (isVideoSourceSSRC(recvSSRC)) {
       packet->type = VIDEO_PACKET;
-    } else if (isAudioSourceSSRC(this->getAudioSourceSSRC())) {
+    } else if (isAudioSourceSSRC(recvSSRC)) {
       packet->type = AUDIO_PACKET;
     }
   }

--- a/erizo/src/erizo/media/ExternalInput.cpp
+++ b/erizo/src/erizo/media/ExternalInput.cpp
@@ -163,7 +163,7 @@ int ExternalInput::sendPLI() {
 
 
 void ExternalInput::receiveRtpData(unsigned char* rtpdata, int len) {
-  if (video_sink_ != NULL) {
+  if (video_sink_ != nullptr) {
     std::shared_ptr<dataPacket> packet = std::make_shared<dataPacket>(0, reinterpret_cast<char*>(rtpdata),
         len, VIDEO_PACKET);
     video_sink_->deliverVideoData(packet);

--- a/erizo/src/erizo/media/ExternalInput.cpp
+++ b/erizo/src/erizo/media/ExternalInput.cpp
@@ -13,7 +13,6 @@
 namespace erizo {
 DEFINE_LOGGER(ExternalInput, "media.ExternalInput");
 ExternalInput::ExternalInput(const std::string& inputUrl):url_(inputUrl) {
-  sourcefbSink_ = NULL;
   context_ = NULL;
   running_ = false;
   needTranscoding_ = false;
@@ -164,10 +163,10 @@ int ExternalInput::sendPLI() {
 
 
 void ExternalInput::receiveRtpData(unsigned char* rtpdata, int len) {
-  if (videoSink_ != NULL) {
+  if (video_sink_ != NULL) {
     std::shared_ptr<dataPacket> packet = std::make_shared<dataPacket>(0, reinterpret_cast<char*>(rtpdata),
         len, VIDEO_PACKET);
-    videoSink_->deliverVideoData(packet);
+    video_sink_->deliverVideoData(packet);
   }
 }
 
@@ -215,7 +214,7 @@ void ExternalInput::receiveLoop() {
         if (length > 0) {
           std::shared_ptr<dataPacket> packet = std::make_shared<dataPacket>(0,
               reinterpret_cast<char*>(decodedBuffer_.get()), length, AUDIO_PACKET);
-          audioSink_->deliverAudioData(packet);
+          audio_sink_->deliverAudioData(packet);
         }
       }
     }

--- a/erizo/src/erizo/media/ExternalOutput.cpp
+++ b/erizo/src/erizo/media/ExternalOutput.cpp
@@ -49,8 +49,8 @@ ExternalOutput::ExternalOutput(const std::string& outputUrl)
   }
 
   unpackagedBufferpart_ = unpackagedBuffer_;
-  sinkfbSource_ = this;
-  fbSink_ = NULL;
+  sink_fb_source_ = this;
+  fb_sink_ = nullptr;
   unpackagedSize_ = 0;
   videoSourceSsrc_ = 0;
 }
@@ -473,7 +473,7 @@ void ExternalOutput::queueData(char* buffer, int length, packetType type) {
 }
 
 int ExternalOutput::sendFirPacket() {
-    if (fbSink_ != NULL) {
+    if (fb_sink_ != nullptr) {
       RtcpHeader thePLI;
       thePLI.setPacketType(RTCP_PS_Feedback_PT);
       thePLI.setBlockCount(1);
@@ -483,7 +483,7 @@ int ExternalOutput::sendFirPacket() {
       char *buf = reinterpret_cast<char*>(&thePLI);
       int len = (thePLI.getLength() + 1) * 4;
       std::shared_ptr<dataPacket> pli_packet = std::make_shared<dataPacket>(0, buf, len, VIDEO_PACKET);
-      fbSink_->deliverFeedback(pli_packet);
+      fb_sink_->deliverFeedback(pli_packet);
       return len;
     }
     return -1;

--- a/erizo/src/erizo/media/SyntheticInput.cpp
+++ b/erizo/src/erizo/media/SyntheticInput.cpp
@@ -135,8 +135,8 @@ void SyntheticInput::sendVideoframe(bool is_keyframe, bool is_marker, uint32_t s
     last_video_keyframe_time_ = clock_->now();
     keyframe_requested_ = false;
   }
-  if (videoSink_) {
-    videoSink_->deliverVideoData(std::make_shared<dataPacket>(0, packet_buffer, size, VIDEO_PACKET));
+  if (video_sink_) {
+    video_sink_->deliverVideoData(std::make_shared<dataPacket>(0, packet_buffer, size, VIDEO_PACKET));
   }
   delete header;
 }
@@ -151,8 +151,8 @@ void SyntheticInput::sendAudioFrame(uint32_t size) {
   char packet_buffer[kMaxPacketSize];
   memset(packet_buffer, 0, size);
   memcpy(packet_buffer, reinterpret_cast<char*>(header), header->getHeaderLength());
-  if (audioSink_) {
-    audioSink_->deliverAudioData(std::make_shared<dataPacket>(0, packet_buffer, size, AUDIO_PACKET));
+  if (audio_sink_) {
+    audio_sink_->deliverAudioData(std::make_shared<dataPacket>(0, packet_buffer, size, AUDIO_PACKET));
   }
   delete header;
 }

--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
@@ -205,6 +205,7 @@ void BandwidthEstimationHandler::sendREMBPacket() {
   memcpy(&remb_packet_.report.rembPacket.uniqueid, "REMB", 4);
 
   remb_packet_.setSSRC(connection_->getVideoSinkSSRC());
+  //  todo(pedro) figure out which sourceSSRC to use here
   remb_packet_.setSourceSSRC(connection_->getVideoSourceSSRC());
   remb_packet_.setLength(5);
   remb_packet_.setREMBBitRate(bitrate_);

--- a/erizo/src/erizo/rtp/RRGenerationHandler.cpp
+++ b/erizo/src/erizo/rtp/RRGenerationHandler.cpp
@@ -210,16 +210,17 @@ void RRGenerationHandler::notifyUpdate() {
   if (!connection_) {
     return;
   }
-
-  uint32_t video_ssrc = connection_->getVideoSourceSSRC();
-  if (video_ssrc != 0) {
-    auto video_packets = std::make_shared<RRPackets>();
-    video_packets->ssrc = video_ssrc;
-    video_packets->type = VIDEO_PACKET;
-    rr_info_map_[video_ssrc] = video_packets;
-    ELOG_DEBUG("%s, message: Initialized video, ssrc: %u", connection_->toLog(), video_ssrc);
-    initialized_ = true;
-  }
+  std::vector<uint32_t> video_ssrc_list = connection_->getVideoSourceSSRCList();
+  std::for_each(video_ssrc_list.begin(), video_ssrc_list.end(), [this] (uint32_t video_ssrc){
+      if (video_ssrc != 0) {
+        auto video_packets = std::make_shared<RRPackets>();
+        video_packets->ssrc = video_ssrc;
+        video_packets->type = VIDEO_PACKET;
+        rr_info_map_[video_ssrc] = video_packets;
+        ELOG_DEBUG("%s, message: Initialized video, ssrc: %u", connection_->toLog(), video_ssrc);
+        initialized_ = true;
+      }
+  });
   uint32_t audio_ssrc = connection_->getAudioSourceSSRC();
   if (audio_ssrc != 0) {
     auto audio_packets = std::make_shared<RRPackets>();

--- a/erizo/src/erizo/rtp/RtcpAggregator.cpp
+++ b/erizo/src/erizo/rtp/RtcpAggregator.cpp
@@ -107,7 +107,7 @@ int RtcpAggregator::analyzeFeedback(char *buf, int len) {
           break;
         case RTCP_Receiver_PT:
           theData->rrsReceivedInPeriod++;
-          if (chead->getSourceSSRC() == rtcpSource_->getVideoSourceSSRC()) {
+          if (rtcpSource_->isVideoSourceSSRC(chead->getSourceSSRC())) {
             ELOG_DEBUG("Analyzing Video RR: PacketLost %u, Ratio %u, partNum %d, blocks %d, sourceSSRC %u, ssrc %u",
                         chead->getLostPackets(), chead->getFractionLost(), partNum, chead->getBlockCount(),
                         chead->getSourceSSRC(), chead->getSSRC());
@@ -339,7 +339,7 @@ void RtcpAggregator::checkRtcpFb() {
           length = theLen;
         }
       }
-      if  (sourceSsrc == rtcpSource_->getVideoSourceSSRC()) {
+      if  (rtcpSource_->isVideoSourceSSRC(sourceSsrc)) {
         rtcpSink_->deliverVideoData(std::make_shared<dataPacket>(0, reinterpret_cast<char*>(packet_),
               length, VIDEO_PACKET));
       } else {

--- a/erizo/src/erizo/rtp/RtcpForwarder.cpp
+++ b/erizo/src/erizo/rtp/RtcpForwarder.cpp
@@ -88,7 +88,7 @@ int RtcpForwarder::analyzeFeedback(char *buf, int len) {
           return 0;
           break;
         case RTCP_Receiver_PT:
-          if (chead->getSourceSSRC() == rtcpSource_->getVideoSourceSSRC()) {
+          if (rtcpSource_->isVideoSourceSSRC(chead->getSourceSSRC())) {
             ELOG_DEBUG("Analyzing Video RR: PacketLost %u, Ratio %u, currentBlock %d, blocks %d"
                        ", sourceSSRC %u, ssrc %u changed to %u",
                 chead->getLostPackets(),

--- a/erizo/src/erizo/rtp/RtpSink.cpp
+++ b/erizo/src/erizo/rtp/RtpSink.cpp
@@ -88,8 +88,8 @@ namespace erizo {
   }
 
   void RtpSink::handleReceive(const::boost::system::error_code& error, size_t bytes_recvd) {  // NOLINT
-    if (bytes_recvd > 0 && this->fbSink_) {
-      this->fbSink_->deliverFeedback(std::make_shared<dataPacket>(0, reinterpret_cast<char*>(buffer_),
+    if (bytes_recvd > 0 && fb_sink_) {
+      fb_sink_->deliverFeedback(std::make_shared<dataPacket>(0, reinterpret_cast<char*>(buffer_),
             static_cast<int>(bytes_recvd), OTHER_PACKET));
     }
   }

--- a/erizo/src/erizo/rtp/RtpSource.cpp
+++ b/erizo/src/erizo/rtp/RtpSource.cpp
@@ -39,8 +39,8 @@ int RtpSource::deliverFeedback_(std::shared_ptr<dataPacket> fb_packet) {
 }
 
 void RtpSource::handleReceive(const::boost::system::error_code& error, size_t bytes_recvd) { // NOLINT
-  if (bytes_recvd > 0 && this->videoSink_) {
-    this->videoSink_->deliverVideoData(std::make_shared<dataPacket>(0, reinterpret_cast<char*>(buffer_),
+  if (bytes_recvd > 0 && this->video_sink_) {
+    this->video_sink_->deliverVideoData(std::make_shared<dataPacket>(0, reinterpret_cast<char*>(buffer_),
           static_cast<int>(bytes_recvd), OTHER_PACKET));
   }
 }

--- a/erizo/src/erizo/rtp/StatsHandler.cpp
+++ b/erizo/src/erizo/rtp/StatsHandler.cpp
@@ -37,9 +37,9 @@ void StatsCalculator::processRtpPacket(std::shared_ptr<dataPacket> packet) {
     return;
   }
   if (!getStatsInfo()[ssrc].hasChild("bitrateCalculated")) {
-    if (ssrc == connection_->getVideoSourceSSRC() || ssrc == connection_->getVideoSinkSSRC()) {
+    if (connection_->isVideoSourceSSRC(ssrc) || connection_->isVideoSinkSSRC(ssrc)) {
       getStatsInfo()[ssrc].insertStat("type", StringStat{"video"});
-    } else if (ssrc == connection_->getAudioSourceSSRC() || ssrc == connection_->getAudioSinkSSRC()) {
+    } else if (connection_->isAudioSourceSSRC(ssrc) || connection_->isAudioSinkSSRC(ssrc)) {
       getStatsInfo()[ssrc].insertStat("type", StringStat{"audio"});
     }
     getStatsInfo()[ssrc].insertStat("bitrateCalculated", RateStat{kBitrateStatsPeriod, 8.});

--- a/erizo/src/test/OneToManyProcessorTest.cpp
+++ b/erizo/src/test/OneToManyProcessorTest.cpp
@@ -16,9 +16,9 @@ static const char kArbitraryPeerId[] = "111";
 class MockPublisher: public erizo::MediaSource, public erizo::FeedbackSink {
  public:
   MockPublisher() {
-    videoSourceSSRC_ = 1;
-    audioSourceSSRC_ = 2;
-    sourcefbSink_ = this;
+    video_source_ssrc_list_[0] = 1;
+    audio_source_ssrc_ = 2;
+    source_fb_sink_ = this;
   }
   ~MockPublisher() {}
   void close() override {}
@@ -30,7 +30,7 @@ class MockPublisher: public erizo::MediaSource, public erizo::FeedbackSink {
 class MockSubscriber: public erizo::MediaSink, public erizo::FeedbackSource {
  public:
   MockSubscriber() {
-    sinkfbSource_ = this;
+    sink_fb_source_ = this;
   }
   ~MockSubscriber() {}
   void close() override {}


### PR DESCRIPTION
`MediaSource` now has a video SSRC list instead of a single value.
`getVideoSourceSSRC()` and `setVideoSourceSSRC()` default to the first value of that list to simplify this PR.
You can access the list with `getVideoSourceSSRCList()` and `getVideoSourceSSRCList()`.
Also, now we have the utility methods `isVideoSourceSSRC(uint32_t)` and `isAudioSourceSSRC(uint32_t)` and their `SinkSSRC` counterparts.  I've updated classes that could benefit from that.

Also, I've taken the opportunity to update variable names and initialization of pointers.