### PR TITLE
Avoid reinitializing pipeline and other things on a setMaxBW

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -148,7 +148,7 @@ bool WebRtcConnection::setRemoteSdp(const std::string &sdp) {
   }
 
   if (pipeline_initialized_)
-    return;
+    return true;
 
 
   bundle_ = remoteSdp_.isBundle;

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -139,7 +139,17 @@ bool WebRtcConnection::createOffer(bool videoEnabled, bool audioEnabled, bool bu
 
 bool WebRtcConnection::setRemoteSdp(const std::string &sdp) {
   ELOG_DEBUG("%s message: setting remote SDP", toLog());
+
   remoteSdp_.initWithSdp(sdp, "");
+
+  if (remoteSdp_.videoBandwidth != 0) {
+    ELOG_DEBUG("%s message: Setting remote BW, maxVideoBW: %u", toLog(), remoteSdp_.videoBandwidth);
+    this->rtcp_processor_->setMaxVideoBW(remoteSdp_.videoBandwidth*1000);
+  }
+
+  if (pipeline_initialized_)
+    return;
+
 
   bundle_ = remoteSdp_.isBundle;
   localSdp_.setOfferSdp(remoteSdp_);
@@ -220,10 +230,6 @@ bool WebRtcConnection::setRemoteSdp(const std::string &sdp) {
   }
 
 
-  if (remoteSdp_.videoBandwidth != 0) {
-    ELOG_DEBUG("%s message: Setting remote BW, maxVideoBW: %u", toLog(), remoteSdp_.videoBandwidth);
-    this->rtcp_processor_->setMaxVideoBW(remoteSdp_.videoBandwidth*1000);
-  }
 
   initializePipeline();
 


### PR DESCRIPTION
Currently `updateConfiguration({maxVideoBW: value})` will trigger a new `setRemoteSdp` in `WebRtcConnection` which may cause trouble with the way the pipeline is initialized now.
I've limited the things that can be done in any renegotiation for now until we decide how much we want to be able to renegotiate.
