### PR TITLE
Add a new Sequence Number translator for Simulcast/SVC

### DIFF
--- a/erizo/src/erizo/rtp/RtpUtils.cpp
+++ b/erizo/src/erizo/rtp/RtpUtils.cpp
@@ -1,0 +1,11 @@
+#include "rtp/RtpUtils.h"
+
+
+namespace erizo {
+
+bool RtpUtils::sequenceNumberLessThan(uint16_t first, uint16_t last) {
+  uint16_t result = first - last;
+  return result > 0xF000;
+}
+
+}

--- a/erizo/src/erizo/rtp/RtpUtils.h
+++ b/erizo/src/erizo/rtp/RtpUtils.h
@@ -1,0 +1,15 @@
+#ifndef ERIZO_SRC_ERIZO_RTP_RTPUTILS_H_
+#define ERIZO_SRC_ERIZO_RTP_RTPUTILS_H_
+
+#include <stdint.h>
+
+namespace erizo {
+
+class RtpUtils {
+ public:
+  static bool sequenceNumberLessThan(uint16_t first, uint16_t second);
+};
+
+}  // namespace erizo
+
+#endif  // ERIZO_SRC_ERIZO_RTP_RTPUTILS_H_

--- a/erizo/src/erizo/rtp/SequenceNumberTranslator.cpp
+++ b/erizo/src/erizo/rtp/SequenceNumberTranslator.cpp
@@ -1,0 +1,114 @@
+#include "rtp/SequenceNumberTranslator.h"
+
+#include <vector>
+
+namespace erizo {
+
+constexpr uint16_t kMaxSequenceNumberInBuffer = 511;  // = 65536 / 128 and more than 10s of audio @50fps
+constexpr uint16_t kMaxDistance = 200;
+
+DEFINE_LOGGER(SequenceNumberTranslator, "rtp.SequenceNumberTranslator");
+
+SequenceNumberTranslator::SequenceNumberTranslator()
+    : in_out_buffer_{kMaxSequenceNumberInBuffer},
+      out_in_buffer_{kMaxSequenceNumberInBuffer},
+      first_input_sequence_number_{0},
+      last_input_sequence_number_{0},
+      initial_output_sequence_number_{0},
+      initialized_{false}, reset_{false} {
+}
+
+bool SequenceNumberTranslator::lessThan(uint16_t first, uint16_t last) const {
+  uint16_t result = first - last;
+  return result > 0xF000;
+}
+
+void SequenceNumberTranslator::add(SequenceNumber sequence_number) {
+  in_out_buffer_[sequence_number.input % kMaxSequenceNumberInBuffer] = sequence_number;
+  out_in_buffer_[sequence_number.output % kMaxSequenceNumberInBuffer] = sequence_number;
+}
+
+uint16_t SequenceNumberTranslator::fill(const uint16_t &first,
+                                        const uint16_t &last) {
+  const SequenceNumber& first_sequence_number = get(first);
+  uint16_t output_sequence_number = first_sequence_number.output;
+
+  if (first_sequence_number.type != SequenceNumberType::Skip) {
+    output_sequence_number++;
+  }
+
+  for (uint16_t sequence_number = first_sequence_number.input + 1;
+       lessThan(sequence_number, last);
+       sequence_number++) {
+    add({sequence_number, output_sequence_number++, SequenceNumberType::Valid});
+  }
+
+  return output_sequence_number;
+}
+
+SequenceNumber& SequenceNumberTranslator::internalGet(uint16_t input_sequence_number) {
+  return in_out_buffer_[input_sequence_number % kMaxSequenceNumberInBuffer];
+}
+
+SequenceNumber SequenceNumberTranslator::get(uint16_t input_sequence_number) const {
+  return in_out_buffer_[input_sequence_number % kMaxSequenceNumberInBuffer];
+}
+
+SequenceNumber SequenceNumberTranslator::get(uint16_t input_sequence_number, bool skip) {
+  if (!initialized_) {
+    SequenceNumberType type = skip ? SequenceNumberType::Skip : SequenceNumberType::Valid;
+    uint16_t output_sequence_number = reset_ ? initial_output_sequence_number_ : input_sequence_number;
+    add({input_sequence_number, output_sequence_number, type});
+    last_input_sequence_number_ = input_sequence_number;
+    first_input_sequence_number_ = input_sequence_number;
+    initialized_ = true;
+    reset_ = false;
+    return internalGet(input_sequence_number);
+  }
+
+  if (lessThan(input_sequence_number, first_input_sequence_number_)) {
+    return {input_sequence_number, 0, SequenceNumberType::Skip};
+  }
+
+  if (lessThan(last_input_sequence_number_, input_sequence_number)) {
+    uint8_t output_sequence_number = fill(last_input_sequence_number_, input_sequence_number);
+
+    SequenceNumberType type = skip ? SequenceNumberType::Skip : SequenceNumberType::Valid;
+
+    add({input_sequence_number, output_sequence_number, type});
+    last_input_sequence_number_ = input_sequence_number;
+    if (last_input_sequence_number_ - first_input_sequence_number_ > kMaxDistance) {
+      first_input_sequence_number_ = last_input_sequence_number_ - kMaxDistance;
+    }
+    return get(input_sequence_number);
+  } else {
+    SequenceNumber& result = internalGet(input_sequence_number);
+    if (result.type == SequenceNumberType::Valid) {
+      SequenceNumberType type = skip ? SequenceNumberType::Discard : SequenceNumberType::Valid;
+      result.type = type;
+    }
+    return result;
+  }
+}
+
+SequenceNumber SequenceNumberTranslator::reverse(uint16_t output_sequence_number) const {
+  SequenceNumber result = out_in_buffer_[output_sequence_number % kMaxSequenceNumberInBuffer];
+  if (lessThan(result.input, first_input_sequence_number_) ||
+      lessThan(last_input_sequence_number_, result.input)) {
+    return {0, output_sequence_number, SequenceNumberType::Discard};
+  }
+  return result;
+}
+
+void SequenceNumberTranslator::reset() {
+  initialized_ = false;
+  SequenceNumber &last = internalGet(last_input_sequence_number_);
+  initial_output_sequence_number_ = last.output;
+  first_input_sequence_number_ = 0;
+  last_input_sequence_number_ = 0;
+  reset_ = true;
+  in_out_buffer_ = std::vector<SequenceNumber>(kMaxSequenceNumberInBuffer);
+  out_in_buffer_ = std::vector<SequenceNumber>(kMaxSequenceNumberInBuffer);
+}
+
+}  // namespace erizo

--- a/erizo/src/erizo/rtp/SequenceNumberTranslator.cpp
+++ b/erizo/src/erizo/rtp/SequenceNumberTranslator.cpp
@@ -40,7 +40,7 @@ uint16_t SequenceNumberTranslator::fill(const uint16_t &first,
   for (uint16_t sequence_number = first_sequence_number.input + 1;
        lessThan(sequence_number, last);
        sequence_number++) {
-    add({sequence_number, output_sequence_number++, SequenceNumberType::Valid});
+    add(SequenceNumber{sequence_number, output_sequence_number++, SequenceNumberType::Valid});
   }
 
   return output_sequence_number;
@@ -58,24 +58,24 @@ SequenceNumber SequenceNumberTranslator::get(uint16_t input_sequence_number, boo
   if (!initialized_) {
     SequenceNumberType type = skip ? SequenceNumberType::Skip : SequenceNumberType::Valid;
     uint16_t output_sequence_number = reset_ ? initial_output_sequence_number_ : input_sequence_number;
-    add({input_sequence_number, output_sequence_number, type});
+    add(SequenceNumber{input_sequence_number, output_sequence_number, type});
     last_input_sequence_number_ = input_sequence_number;
     first_input_sequence_number_ = input_sequence_number;
     initialized_ = true;
     reset_ = false;
-    return internalGet(input_sequence_number);
+    return get(input_sequence_number);
   }
 
   if (lessThan(input_sequence_number, first_input_sequence_number_)) {
-    return {input_sequence_number, 0, SequenceNumberType::Skip};
+    return SequenceNumber{input_sequence_number, 0, SequenceNumberType::Skip};
   }
 
   if (lessThan(last_input_sequence_number_, input_sequence_number)) {
-    uint8_t output_sequence_number = fill(last_input_sequence_number_, input_sequence_number);
+    uint16_t output_sequence_number = fill(last_input_sequence_number_, input_sequence_number);
 
     SequenceNumberType type = skip ? SequenceNumberType::Skip : SequenceNumberType::Valid;
 
-    add({input_sequence_number, output_sequence_number, type});
+    add(SequenceNumber{input_sequence_number, output_sequence_number, type});
     last_input_sequence_number_ = input_sequence_number;
     if (last_input_sequence_number_ - first_input_sequence_number_ > kMaxDistance) {
       first_input_sequence_number_ = last_input_sequence_number_ - kMaxDistance;
@@ -95,7 +95,7 @@ SequenceNumber SequenceNumberTranslator::reverse(uint16_t output_sequence_number
   SequenceNumber result = out_in_buffer_[output_sequence_number % kMaxSequenceNumberInBuffer];
   if (lessThan(result.input, first_input_sequence_number_) ||
       lessThan(last_input_sequence_number_, result.input)) {
-    return {0, output_sequence_number, SequenceNumberType::Discard};
+    return SequenceNumber{0, output_sequence_number, SequenceNumberType::Discard};
   }
   return result;
 }

--- a/erizo/src/erizo/rtp/SequenceNumberTranslator.h
+++ b/erizo/src/erizo/rtp/SequenceNumberTranslator.h
@@ -1,0 +1,56 @@
+#ifndef ERIZO_SRC_ERIZO_RTP_SEQUENCENUMBERTRANSLATOR_H_
+#define ERIZO_SRC_ERIZO_RTP_SEQUENCENUMBERTRANSLATOR_H_
+
+#include <utility>
+#include <vector>
+
+#include "./logger.h"
+#include "pipeline/Service.h"
+
+namespace erizo {
+
+enum class SequenceNumberType : uint8_t {
+  Valid = 0,
+  Skip = 1,
+  Discard = 2
+};
+
+struct SequenceNumber {
+  SequenceNumber() : input{0}, output{0}, type{SequenceNumberType::Valid} {}
+  SequenceNumber(uint16_t input_, uint16_t output_, SequenceNumberType type_) :
+      input{input_}, output{output_}, type{type_} {}
+
+  uint16_t input;
+  uint16_t output;
+  SequenceNumberType type;
+};
+
+class SequenceNumberTranslator: public Service, public std::enable_shared_from_this<SequenceNumberTranslator> {
+  DECLARE_LOGGER();
+
+ public:
+  SequenceNumberTranslator();
+
+  SequenceNumber get(uint16_t input_sequence_number) const;
+  SequenceNumber get(uint16_t input_sequence_number, bool skip);
+  SequenceNumber reverse(uint16_t output_sequence_number) const;
+  void reset();
+
+ private:
+  bool lessThan(uint16_t first, uint16_t second) const;
+  void add(SequenceNumber sequence_number);
+  uint16_t fill(const uint16_t &first, const uint16_t &last);
+  SequenceNumber& internalGet(uint16_t input_sequence_number);
+
+ private:
+  std::vector<SequenceNumber> in_out_buffer_;
+  std::vector<SequenceNumber> out_in_buffer_;
+  uint16_t first_input_sequence_number_;
+  uint16_t last_input_sequence_number_;
+  uint16_t initial_output_sequence_number_;
+  bool initialized_;
+  bool reset_;
+};
+}  // namespace erizo
+
+#endif  // ERIZO_SRC_ERIZO_RTP_SEQUENCENUMBERTRANSLATOR_H_

--- a/erizo/src/erizo/rtp/SequenceNumberTranslator.h
+++ b/erizo/src/erizo/rtp/SequenceNumberTranslator.h
@@ -37,7 +37,6 @@ class SequenceNumberTranslator: public Service, public std::enable_shared_from_t
   void reset();
 
  private:
-  bool lessThan(uint16_t first, uint16_t second) const;
   void add(SequenceNumber sequence_number);
   uint16_t fill(const uint16_t &first, const uint16_t &last);
   SequenceNumber& internalGet(uint16_t input_sequence_number);

--- a/erizo/src/test/rtp/SequenceNumberTranslatorTest.cpp
+++ b/erizo/src/test/rtp/SequenceNumberTranslatorTest.cpp
@@ -1,0 +1,143 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <rtp/SequenceNumberTranslator.h>
+#include <rtp/RtpHeaders.h>
+#include <MediaDefinitions.h>
+#include <WebRtcConnection.h>
+
+#include <queue>
+#include <string>
+#include <vector>
+
+#include "../utils/Mocks.h"
+#include "../utils/Tools.h"
+#include "../utils/Matchers.h"
+
+using ::testing::_;
+using ::testing::IsNull;
+using ::testing::Eq;
+using ::testing::Args;
+using ::testing::Return;
+using erizo::SequenceNumberTranslator;
+using erizo::SequenceNumber;
+using erizo::SequenceNumberType;
+
+enum class PacketState {
+  Forward = 0,
+  Skip = 1
+};
+
+struct Packet {
+  int sequence_number;
+  PacketState state;
+  int expected_output;
+  SequenceNumberType expected_type;
+};
+
+class SequenceNumberTranslatorTest : public ::testing::TestWithParam<std::vector<Packet>> {
+ public:
+  SequenceNumberTranslatorTest() {
+    queue = GetParam();
+  }
+ protected:
+  void SetUp() {
+  }
+
+  void TearDown() {
+  }
+
+  SequenceNumberTranslator translator;
+  std::vector<Packet> queue;
+};
+
+TEST_P(SequenceNumberTranslatorTest, shouldReturnRightOutputSequenceNumbers) {
+  for (Packet packet : queue) {
+    bool skip = packet.state == PacketState::Skip;
+    SequenceNumber output = translator.get(packet.sequence_number, skip);
+    EXPECT_THAT(output.output, Eq(packet.expected_output));
+    EXPECT_THAT(output.type, Eq(packet.expected_type));
+  }
+}
+
+TEST_P(SequenceNumberTranslatorTest, shouldReturnRightInputSequenceNumbers) {
+  for (Packet packet : queue) {
+    bool skip = packet.state == PacketState::Skip;
+    translator.get(packet.sequence_number, skip);
+  }
+
+  // Reverse look-up
+  for (Packet packet : queue) {
+    if (packet.expected_type != SequenceNumberType::Valid) {
+      continue;
+    }
+    SequenceNumber output = translator.reverse(packet.expected_output);
+    EXPECT_THAT(output.input, Eq(packet.sequence_number));
+    EXPECT_THAT(output.type, Eq(packet.expected_type));
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(
+  SequenceNumberScenarios, SequenceNumberTranslatorTest, testing::Values(
+    //                     input                        expected_output
+    std::vector<Packet>({{     5, PacketState::Forward,               5, SequenceNumberType::Valid},
+                         {     6, PacketState::Forward,               6, SequenceNumberType::Valid},
+                         {     7, PacketState::Forward,               7, SequenceNumberType::Valid},
+                         {     8, PacketState::Forward,               8, SequenceNumberType::Valid}}),
+
+    // Packet reordering
+    std::vector<Packet>({{     5, PacketState::Forward,               5, SequenceNumberType::Valid},
+                         {     6, PacketState::Forward,               6, SequenceNumberType::Valid},
+                         {     8, PacketState::Forward,               8, SequenceNumberType::Valid},
+                         {     7, PacketState::Forward,               7, SequenceNumberType::Valid}}),
+
+    // Skip packets
+    std::vector<Packet>({{     5, PacketState::Forward,               5, SequenceNumberType::Valid},
+                         {     6, PacketState::Forward,               6, SequenceNumberType::Valid},
+                         {     7, PacketState::Skip,                  7, SequenceNumberType::Skip},
+                         {     8, PacketState::Forward,               7, SequenceNumberType::Valid},
+                         {     9, PacketState::Forward,               8, SequenceNumberType::Valid}}),
+
+    // Discard packets
+    std::vector<Packet>({{     5, PacketState::Forward,               5, SequenceNumberType::Valid},
+                         {     6, PacketState::Forward,               6, SequenceNumberType::Valid},
+                         {     8, PacketState::Forward,               8, SequenceNumberType::Valid},
+                         {     7, PacketState::Skip,                  7, SequenceNumberType::Discard},
+                         {     9, PacketState::Forward,               9, SequenceNumberType::Valid}}),
+
+
+    // Retransmissions
+    std::vector<Packet>({{     5, PacketState::Forward,               5, SequenceNumberType::Valid},
+                         {     6, PacketState::Forward,               6, SequenceNumberType::Valid},
+                         {     7, PacketState::Forward,               7, SequenceNumberType::Valid},
+                         {     8, PacketState::Forward,               8, SequenceNumberType::Valid},
+                         {     7, PacketState::Forward,               7, SequenceNumberType::Valid}}),
+
+    // Retransmissions of skipped packets
+    std::vector<Packet>({{     5, PacketState::Forward,               5, SequenceNumberType::Valid},
+                         {     6, PacketState::Forward,               6, SequenceNumberType::Valid},
+                         {     7, PacketState::Skip,                  7, SequenceNumberType::Skip},
+                         {     8, PacketState::Forward,               7, SequenceNumberType::Valid},
+                         {     7, PacketState::Skip,                  7, SequenceNumberType::Skip}}),
+
+    // Rollover
+    std::vector<Packet>({{ 65535, PacketState::Forward,           65535, SequenceNumberType::Valid},
+                         {     0, PacketState::Forward,               0, SequenceNumberType::Valid}}),
+
+    // Rollover with packets reordering
+    std::vector<Packet>({{ 65535, PacketState::Forward,           65535, SequenceNumberType::Valid},
+                         {     1, PacketState::Forward,               1, SequenceNumberType::Valid},
+                         {     0, PacketState::Forward,               0, SequenceNumberType::Valid}}),
+
+    // Rollover with packets skipped
+    std::vector<Packet>({{ 65535, PacketState::Forward,           65535, SequenceNumberType::Valid},
+                         {     0, PacketState::Skip,                  0, SequenceNumberType::Skip},
+                         {     1, PacketState::Forward,               0, SequenceNumberType::Valid},
+                         {     2, PacketState::Forward,               1, SequenceNumberType::Valid}}),
+
+    // Rollover with packets skipped
+    std::vector<Packet>({{ 65535, PacketState::Forward,           65535, SequenceNumberType::Valid},
+                         {     1, PacketState::Forward,               1, SequenceNumberType::Valid},
+                         {     0, PacketState::Skip,                  0, SequenceNumberType::Discard},
+                         {     2, PacketState::Forward,               2, SequenceNumberType::Valid}})
+  ));

--- a/erizo/src/test/rtp/SequenceNumberTranslatorTest.cpp
+++ b/erizo/src/test/rtp/SequenceNumberTranslatorTest.cpp
@@ -139,5 +139,4 @@ INSTANTIATE_TEST_CASE_P(
     std::vector<Packet>({{ 65535, PacketState::Forward,           65535, SequenceNumberType::Valid},
                          {     1, PacketState::Forward,               1, SequenceNumberType::Valid},
                          {     0, PacketState::Skip,                  0, SequenceNumberType::Discard},
-                         {     2, PacketState::Forward,               2, SequenceNumberType::Valid}})
-  ));
+                         {     2, PacketState::Forward,               2, SequenceNumberType::Valid}})));


### PR DESCRIPTION
With this new translator we should be able to seamlessly send packets that belong to different temporal and spatial layers in SVC and temporal layers in Simulcast. 