### PR TITLE
Add selected client candidate host type to logs and stats

### DIFF
--- a/erizo/src/erizo/NiceConnection.cpp
+++ b/erizo/src/erizo/NiceConnection.cpp
@@ -490,6 +490,16 @@ void NiceConnection::updateIceState(IceState state) {
     this->listener_->updateIceState(state, this);
 }
 
+std::string getHostTypeFromCandidate(NiceCandidate *candidate) {
+  switch (candidate->type) {
+    case NICE_CANDIDATE_TYPE_HOST: return "host";
+    case NICE_CANDIDATE_TYPE_SERVER_REFLEXIVE: return "serverReflexive";
+    case NICE_CANDIDATE_TYPE_PEER_REFLEXIVE: return "peerReflexive";
+    case NICE_CANDIDATE_TYPE_RELAYED: return "relayed";
+    default: return "unknown";
+  }
+}
+
 CandidatePair NiceConnection::getSelectedPair() {
   char ipaddr[NICE_ADDRESS_STRING_LEN];
   CandidatePair selectedPair;
@@ -498,13 +508,15 @@ CandidatePair NiceConnection::getSelectedPair() {
   nice_address_to_string(&local->addr, ipaddr);
   selectedPair.erizoCandidateIp = std::string(ipaddr);
   selectedPair.erizoCandidatePort = nice_address_get_port(&local->addr);
-  ELOG_DEBUG("%s message: selected pair, local_addr: %s, local_port: %d",
-              toLog(), ipaddr, nice_address_get_port(&local->addr));
+  selectedPair.erizoHostType = getHostTypeFromCandidate(local);
+  ELOG_DEBUG("%s message: selected pair, local_addr: %s, local_port: %d, local_type: %s",
+              toLog(), ipaddr, nice_address_get_port(&local->addr), selectedPair.erizoHostType.c_str());
   nice_address_to_string(&remote->addr, ipaddr);
   selectedPair.clientCandidateIp = std::string(ipaddr);
   selectedPair.clientCandidatePort = nice_address_get_port(&remote->addr);
-  ELOG_INFO("%s message: selected pair, remote_addr: %s, remote_port: %d",
-             toLog(), ipaddr, nice_address_get_port(&remote->addr));
+  selectedPair.clientHostType = getHostTypeFromCandidate(local);
+  ELOG_INFO("%s message: selected pair, remote_addr: %s, remote_port: %d, remote_type: %s",
+             toLog(), ipaddr, nice_address_get_port(&remote->addr), selectedPair.clientHostType.c_str());
   return selectedPair;
 }
 

--- a/erizo/src/erizo/NiceConnection.h
+++ b/erizo/src/erizo/NiceConnection.h
@@ -41,6 +41,8 @@ struct CandidatePair{
   int erizoCandidatePort;
   std::string clientCandidateIp;
   int clientCandidatePort;
+  std::string erizoHostType;
+  std::string clientHostType;
 };
 
 class IceConfig {

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -31,6 +31,9 @@
 namespace erizo {
 DEFINE_LOGGER(WebRtcConnection, "WebRtcConnection");
 
+constexpr uint32_t kDefaultVideoSinkSSRC = 55543;
+constexpr uint32_t kDefaultAudioSinkSSRC = 44444;
+
 WebRtcConnection::WebRtcConnection(std::shared_ptr<Worker> worker, const std::string& connection_id,
     const IceConfig& iceConfig, const std::vector<RtpMap> rtp_mappings,
     const std::vector<erizo::ExtMap> ext_mappings, WebRtcConnectionEventListener* listener) :
@@ -40,8 +43,8 @@ WebRtcConnection::WebRtcConnection(std::shared_ptr<Worker> worker, const std::st
     pipeline_{Pipeline::create()}, worker_{worker}, audio_muted_{false}, pipeline_initialized_{false} {
   ELOG_INFO("%s message: constructor, stunserver: %s, stunPort: %d, minPort: %d, maxPort: %d",
       toLog(), iceConfig.stunServer.c_str(), iceConfig.stunPort, iceConfig.minPort, iceConfig.maxPort);
-  setVideoSinkSSRC(55543);
-  setAudioSinkSSRC(44444);
+  setVideoSinkSSRC(kDefaultVideoSinkSSRC);
+  setAudioSinkSSRC(kDefaultAudioSinkSSRC);
   source_fb_sink_ = this;
   sink_fb_source_ = this;
   stats_ = std::make_shared<Stats>();
@@ -556,7 +559,7 @@ void WebRtcConnection::updateState(TransportState state, Transport * transport) 
     case TRANSPORT_READY:
       if (bundle_) {
         temp = CONN_READY;
-
+        trackTransportInfo();
       } else {
         if ((!remoteSdp_.hasAudio || (audioTransport_.get() != nullptr
                   && audioTransport_->getTransportState() == TRANSPORT_READY)) &&
@@ -564,6 +567,7 @@ void WebRtcConnection::updateState(TransportState state, Transport * transport) 
                   && videoTransport_->getTransportState() == TRANSPORT_READY))) {
             // WebRTCConnection will be ready only when all channels are ready.
             temp = CONN_READY;
+            trackTransportInfo();
           }
       }
       break;
@@ -600,6 +604,36 @@ void WebRtcConnection::updateState(TransportState state, Transport * transport) 
   if (connEventListener_ != nullptr) {
     ELOG_INFO("%s newGlobalState: %d", toLog(), globalState_);
     connEventListener_->notifyEvent(globalState_, msg);
+  }
+}
+
+void WebRtcConnection::trackTransportInfo() {
+  CandidatePair candidate_pair;
+  if (videoEnabled_ && videoTransport_) {
+    candidate_pair = videoTransport_->getNiceConnection()->getSelectedPair();
+    if (getVideoSinkSSRC() != kDefaultVideoSinkSSRC) {
+      stats_->getNode()[getVideoSinkSSRC()].insertStat("clientHostType",
+                                                       StringStat{candidate_pair.clientHostType});
+    }
+    if (getVideoSourceSSRC() != 0) {
+      stats_->getNode()[getVideoSourceSSRC()].insertStat("clientHostType",
+                                                         StringStat{candidate_pair.clientHostType});
+    }
+  }
+
+  if (audioEnabled_) {
+    if (audioTransport_) {
+      candidate_pair = audioTransport_->getNiceConnection()->getSelectedPair();
+    }
+
+    if (getAudioSinkSSRC() != kDefaultAudioSinkSSRC) {
+      stats_->getNode()[getAudioSinkSSRC()].insertStat("clientHostType",
+                                                       StringStat{candidate_pair.clientHostType});
+    }
+    if (getAudioSourceSSRC() != 0) {
+      stats_->getNode()[getAudioSourceSSRC()].insertStat("clientHostType",
+                                                         StringStat{candidate_pair.clientHostType});
+    }
   }
 }
 

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -181,6 +181,7 @@ class WebRtcConnection: public MediaSink, public MediaSource, public FeedbackSin
   void changeDeliverPayloadType(dataPacket *dp, packetType type);
   // parses incoming payload type, replaces occurence in buf
   void parseIncomingPayloadType(char *buf, int len, packetType type);
+  void trackTransportInfo();
 
  private:
   std::string connection_id_;


### PR DESCRIPTION
**Description**

It adds more information to the stats and logs, to know the client and erizo candidate Host Type (server reflexive, host, peer reflexive or relay).

- [ ] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

There's no change in the public APIs.

- [ ] It includes documentation for these changes in `/doc`.
