### PR TITLE
Assign controller to room

### DIFF
--- a/nuve/nuveAPI/mdb/roomRegistry.js
+++ b/nuve/nuveAPI/mdb/roomRegistry.js
@@ -49,13 +49,14 @@ exports.addRoom = function (room, callback) {
 };
 
 exports.assignErizoControllerToRoom = function(room, erizoControllerId, callback) {
-  // TODO: Add error handling
   db.rooms.findOne({_id: db.ObjectId(room._id)}, function(err, findRoom){
+    if (err) log.warn('message: assignErizoControllerToRoom error, ' + logger.objectToLog(err));
     if (!findRoom) {
        callback(undefined);
     }
     if (findRoom.erizoControllerId) {
       db.erizoControllers.findOne({_id: findRoom.erizoControllerId}, function(err, assignedErizoController){
+        if (err) log.warn('message: assignErizoControllerToRoom error, ' + logger.objectToLog(err));
         if (assignedErizoController) {
           callback(assignedErizoController);
         }
@@ -64,10 +65,13 @@ exports.assignErizoControllerToRoom = function(room, erizoControllerId, callback
 
   });
   db.erizoControllers.findOne({_id: db.ObjectId(erizoControllerId)}, function(err, notAssignedErizoController){
+    if (err) log.warn('message: assignErizoControllerToRoom error, ' + logger.objectToLog(err));
     if (notAssignedErizoController) {
       room.erizoControllerId = db.ObjectId(erizoControllerId);
 
-      db.rooms.save( room, function(){});
+      db.rooms.save( room, function(err, savedRoom){
+        if (err) log.warn('message: assignErizoControllerToRoom error, ' + logger.objectToLog(err));
+      });
       callback(notAssignedErizoController);
     }
   });

--- a/nuve/nuveAPI/mdb/roomRegistry.js
+++ b/nuve/nuveAPI/mdb/roomRegistry.js
@@ -49,32 +49,26 @@ exports.addRoom = function (room, callback) {
 };
 
 exports.assignErizoControllerToRoom = function(room, erizoControllerId, callback) {
-  return db.eval(function(id, erizoControllerId) {
-    var erizoController = undefined;
-    var room = db.rooms.findOne({_id: ObjectId(id)});
-    if (!room) {
-      return erizoController;
+  // TODO: Add error handling
+  db.rooms.findOne({_id: db.ObjectId(room._id)}, function(err, findRoom){
+    if (!findRoom) {
+       callback(undefined);
+    }
+    if (findRoom.erizoControllerId) {
+      db.erizoControllers.findOne({_id: findRoom.erizoControllerId}, function(err, assignedErizoController){
+        if (assignedErizoController) {
+          callback(assignedErizoController);
+        }
+      });
     }
 
-    if (room.erizoControllerId) {
-      erizoController = db.erizoControllers.findOne({_id: room.erizoControllerId});
-      if (erizoController) {
-        return erizoController;
-      }
-    }
+  });
+  db.erizoControllers.findOne({_id: db.ObjectId(erizoControllerId)}, function(err, notAssignedErizoController){
+    if (notAssignedErizoController) {
+      room.erizoControllerId = db.ObjectId(erizoControllerId);
 
-    erizoController = db.erizoControllers.findOne({_id: ObjectId(erizoControllerId)});
-
-    if (erizoController) {
-      room.erizoControllerId = ObjectId(erizoControllerId);
-
-      db.rooms.save( room );
-    }
-    return erizoController;
-  }, room._id + '', erizoControllerId + '', function(error, erizoController) {
-    if (error) log.warn('message: assignErizoControllerToRoom error, ' + logger.objectToLog(error));
-    if (callback) {
-      callback(erizoController);
+      db.rooms.save( room, function(){});
+      callback(notAssignedErizoController);
     }
   });
 };


### PR DESCRIPTION
**Description**

*The assignment of erizoController to a room don't work on sharded mongodb deployments, it only works in monolitic mongodb deployments*

**Changes in Client or Server public APIs**

*I re-write complete assignErizoControllerToRoom function removing the use of db.eval(), this function don't work on sharded mongodb deployments. For more info: https://docs.mongodb.com/manual/reference/method/db.eval/#sharded-data*
