### PR TITLE
fixed crash in nackGeneration because of an out of bounds index

### DIFF
--- a/erizo/src/erizo/rtp/RtcpNackGenerator.cpp
+++ b/erizo/src/erizo/rtp/RtcpNackGenerator.cpp
@@ -81,6 +81,7 @@ bool RtcpNackGenerator::addNackPacketToRr(std::shared_ptr<dataPacket> rr_packet)
       ELOG_DEBUG("message: Removing Nack in list too many retransmits, ssrc: %u, seq_num: %u",
           ssrc_, base_nack_info.seq_num);
         nack_info_list_.erase(nack_info_list_.begin() + index);
+        index--;  // Items are moved in the list so the next element has the current index
         continue;
     }
     ELOG_DEBUG("message: PID, seq_num %u", base_nack_info.seq_num);


### PR DESCRIPTION
**Description**
Fixes a crash in `RtcpNackGenerator`. I did not update the index properly after erasing an element in the nack vector,  causing out of bounds problems.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Noooop

[] It includes documentation for these changes in `/doc`.
