### PR TITLE
Fix several loops in SequenceNumberTranslator

### DIFF
--- a/erizo/src/erizo/rtp/SequenceNumberTranslator.cpp
+++ b/erizo/src/erizo/rtp/SequenceNumberTranslator.cpp
@@ -84,7 +84,7 @@ SequenceNumber SequenceNumberTranslator::get(uint16_t input_sequence_number, boo
 
     add(SequenceNumber{input_sequence_number, output_sequence_number, type});
     last_input_sequence_number_ = input_sequence_number;
-    if (last_input_sequence_number_ - kMaxDistance > first_input_sequence_number_) {
+    if (RtpUtils::sequenceNumberLessThan(first_input_sequence_number_, last_input_sequence_number_ - kMaxDistance)) {
       first_input_sequence_number_ = last_input_sequence_number_ - kMaxDistance;
     }
     SequenceNumber info = get(input_sequence_number);


### PR DESCRIPTION
**Description**

This PR fixes an issue in SequenceNumberTranslator when there are several loops of sequence numbers in total. I added a Unit Test to cover this case too.

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

No needed.

[] It includes documentation for these changes in `/doc`.
