### PR TITLE
Terminate RTCP Feedback in Scalable Video

### DIFF
--- a/erizo/src/erizo/rtp/QualityFilterHandler.cpp
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.cpp
@@ -10,7 +10,8 @@ DEFINE_LOGGER(QualityFilterHandler, "rtp.QualityFilterHandler");
 
 QualityFilterHandler::QualityFilterHandler()
   : connection_{nullptr}, enabled_{true}, initialized_{false},
-  receiving_multiple_ssrc_{false}, changing_spatial_layer_{false}, target_spatial_layer_{0},
+  receiving_multiple_ssrc_{false}, changing_spatial_layer_{false}, is_scalable_{false},
+  target_spatial_layer_{0},
   future_spatial_layer_{-1}, target_temporal_layer_{0},
   video_sink_ssrc_{0}, video_source_ssrc_{0}, last_ssrc_received_{0},
   max_video_bw_{0}, last_timestamp_sent_{0}, timestamp_offset_{0} {}
@@ -25,30 +26,20 @@ void QualityFilterHandler::disable() {
 
 void QualityFilterHandler::handleFeedbackPackets(std::shared_ptr<dataPacket> packet) {
   RtpUtils::forEachRRBlock(packet, [this](RtcpHeader *chead) {
-    // TODO(javier): Find a better way to terminate RTCP
-    if (chead->packettype == RTCP_Receiver_PT) {
-      chead->setFractionLost(0);
-      chead->setLostPackets(0);
-      chead->setJitter(0);
+    if (chead->packettype == RTCP_PS_Feedback_PT &&
+          (chead->getBlockCount() == RTCP_PLI_FMT ||
+           chead->getBlockCount() == RTCP_SLI_FMT ||
+           chead->getBlockCount() == RTCP_PLI_FMT)) {
+      sendPLI();
     }
-
-    RtpUtils::updateREMB(chead, max_video_bw_);
-
-    RtpUtils::forEachNack(chead, [this, chead](uint16_t seq_num, uint16_t plb) {
-      SequenceNumber result = translator_.reverse(seq_num);
-      if (result.type == SequenceNumberType::Valid) {
-        chead->setSourceSSRC(last_ssrc_received_);
-        chead->setNackPid(result.input);
-      }
-    });
   });
 }
 
 void QualityFilterHandler::read(Context *ctx, std::shared_ptr<dataPacket> packet) {
-  if (enabled_) {
-    handleFeedbackPackets(packet);  // TODO(javier) remove this line when RTCP termination is enabled
-
-    // TODO(javier): Handle RRs and NACKs and translate Sequence Numbers?
+  RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
+  if (chead->isFeedback() && enabled_ && is_scalable_) {
+    handleFeedbackPackets(packet);
+    return;
   }
 
   ctx->fireRead(packet);
@@ -93,9 +84,21 @@ void QualityFilterHandler::changeSpatialLayerOnKeyframeReceived(std::shared_ptr<
   }
 }
 
+void QualityFilterHandler::detectVideoScalability(std::shared_ptr<dataPacket> packet) {
+  if (is_scalable_ || packet->type != VIDEO_PACKET) {
+    return;
+  }
+  if (packet->belongsToTemporalLayer(1) || packet->belongsToSpatialLayer(1)) {
+    is_scalable_ = true;
+  }
+}
+
 void QualityFilterHandler::write(Context *ctx, std::shared_ptr<dataPacket> packet) {
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
-  if (!chead->isRtcp() && enabled_ && packet->type == VIDEO_PACKET) {
+
+  detectVideoScalability(packet);
+
+  if (is_scalable_ && !chead->isRtcp() && enabled_ && packet->type == VIDEO_PACKET) {
     RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
 
     checkLayers();

--- a/erizo/src/erizo/rtp/QualityFilterHandler.h
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.h
@@ -39,6 +39,7 @@ class QualityFilterHandler: public Handler, public std::enable_shared_from_this<
   void handleFeedbackPackets(std::shared_ptr<dataPacket> packet);
   bool checkSSRCChange(uint32_t ssrc);
   void changeSpatialLayerOnKeyframeReceived(std::shared_ptr<dataPacket> packet);
+  void detectVideoScalability(std::shared_ptr<dataPacket> packet);
 
  private:
   std::shared_ptr<QualityManager> quality_manager_;
@@ -48,6 +49,7 @@ class QualityFilterHandler: public Handler, public std::enable_shared_from_this<
   bool initialized_;
   bool receiving_multiple_ssrc_;
   bool changing_spatial_layer_;
+  bool is_scalable_;
   int target_spatial_layer_;
   int future_spatial_layer_;
   int target_temporal_layer_;


### PR DESCRIPTION
**Description**

We now drop feedback packets when Simulcast/SVC is enabled. But we still send PLIs when we receive them in Erizo.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

No change.

[] It includes documentation for these changes in `/doc`.
