### PR TITLE
Add a mechanism to drop padding bytes and packets

### DIFF
--- a/erizo/src/erizo/rtp/QualityFilterHandler.cpp
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.cpp
@@ -93,6 +93,21 @@ void QualityFilterHandler::detectVideoScalability(std::shared_ptr<dataPacket> pa
   }
 }
 
+void QualityFilterHandler::removePaddingBytes(std::shared_ptr<dataPacket> packet) {
+  RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
+  int header_length = rtp_header->getHeaderLength();
+  uint16_t sequence_number = rtp_header->getSeqNumber();
+
+  int padding_length = RtpUtils::getPaddingLength(packet);
+  if (padding_length + header_length == packet->length) {
+    translator_.get(sequence_number, true);
+    return;
+  }
+
+  packet->length -= padding_length;
+  rtp_header->padding = 0;
+}
+
 void QualityFilterHandler::write(Context *ctx, std::shared_ptr<dataPacket> packet) {
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
 
@@ -132,6 +147,8 @@ void QualityFilterHandler::write(Context *ctx, std::shared_ptr<dataPacket> packe
       translator_.get(sequence_number, true);
       return;
     }
+
+    removePaddingBytes(packet);
 
     SequenceNumber sequence_number_info = translator_.get(sequence_number, false);
     if (sequence_number_info.type != SequenceNumberType::Valid) {

--- a/erizo/src/erizo/rtp/QualityFilterHandler.h
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.h
@@ -40,6 +40,7 @@ class QualityFilterHandler: public Handler, public std::enable_shared_from_this<
   bool checkSSRCChange(uint32_t ssrc);
   void changeSpatialLayerOnKeyframeReceived(std::shared_ptr<dataPacket> packet);
   void detectVideoScalability(std::shared_ptr<dataPacket> packet);
+  void removePaddingBytes(std::shared_ptr<dataPacket> packet);
 
  private:
   std::shared_ptr<QualityManager> quality_manager_;

--- a/erizo/src/erizo/rtp/RtpUtils.cpp
+++ b/erizo/src/erizo/rtp/RtpUtils.cpp
@@ -47,6 +47,14 @@ std::shared_ptr<dataPacket> RtpUtils::createPLI(uint32_t source_ssrc, uint32_t s
   return std::make_shared<dataPacket>(0, buf, len, VIDEO_PACKET);
 }
 
+int RtpUtils::getPaddingLength(std::shared_ptr<dataPacket> packet) {
+  RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
+  if (rtp_header->hasPadding()) {
+    return packet->data[packet->length - 1] & 0xFF;
+  }
+  return 0;
+}
+
 void RtpUtils::forEachRRBlock(std::shared_ptr<dataPacket> packet, std::function<void(RtcpHeader*)> f) {
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
   int len = packet->length;

--- a/erizo/src/erizo/rtp/RtpUtils.h
+++ b/erizo/src/erizo/rtp/RtpUtils.h
@@ -22,6 +22,8 @@ class RtpUtils {
   static void forEachNack(RtcpHeader *chead, std::function<void(uint16_t, uint16_t)> f);
 
   static std::shared_ptr<dataPacket> createPLI(uint32_t source_ssrc, uint32_t sink_ssrc);
+
+  static int getPaddingLength(std::shared_ptr<dataPacket> packet);
 };
 
 }  // namespace erizo


### PR DESCRIPTION
**Description**

We now remove padding bytes (or entire packets if there is no payload data) to save bandwidth in the subscribers.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.
