### PR TITLE
Add a padding generator handler

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -31,6 +31,7 @@
 #include "rtp/QualityFilterHandler.h"
 #include "rtp/QualityManager.h"
 #include "rtp/PliPacerHandler.h"
+#include "rtp/RtpPaddingGeneratorHandler.h"
 
 namespace erizo {
 DEFINE_LOGGER(WebRtcConnection, "WebRtcConnection");
@@ -259,6 +260,7 @@ void WebRtcConnection::initializePipeline() {
   pipeline_->addFront(QualityFilterHandler());
   pipeline_->addFront(RtpAudioMuteHandler());
   pipeline_->addFront(RtpSlideShowHandler());
+  pipeline_->addFront(RtpPaddingGeneratorHandler());
   pipeline_->addFront(PliPacerHandler());
   pipeline_->addFront(BandwidthEstimationHandler());
   pipeline_->addFront(RtcpFeedbackGenerationHandler());

--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -5,6 +5,6 @@ namespace erizo {
 DEFINE_LOGGER(QualityManager, "rtp.QualityManager");
 
 QualityManager::QualityManager()
-  : spatial_layer_{0}, temporal_layer_{0} {}
+  : spatial_layer_{0}, temporal_layer_{0}, padding_enabled_{false} {}
 
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/QualityManager.h
+++ b/erizo/src/erizo/rtp/QualityManager.h
@@ -12,15 +12,18 @@ class QualityManager: public Service, public std::enable_shared_from_this<Qualit
  public:
   QualityManager();
 
-  int getSpatialLayer() const { return spatial_layer_; }
-  int getTemporalLayer() const { return temporal_layer_; }
+  virtual int getSpatialLayer() const { return spatial_layer_; }
+  virtual int getTemporalLayer() const { return temporal_layer_; }
 
   void setSpatialLayer(int spatial_layer) { spatial_layer_ = spatial_layer; }
   void setTemporalLayer(int temporal_layer) { temporal_layer_ = temporal_layer; }
 
+  virtual bool isPaddingEnabled() const { return padding_enabled_; }
+
  private:
   int spatial_layer_;
   int temporal_layer_;
+  bool padding_enabled_;
 };
 }  // namespace erizo
 

--- a/erizo/src/erizo/rtp/RtcpAggregator.cpp
+++ b/erizo/src/erizo/rtp/RtcpAggregator.cpp
@@ -23,8 +23,8 @@ namespace erizo {
 
 DEFINE_LOGGER(RtcpAggregator, "rtp.RtcpAggregator");
 
-RtcpAggregator::RtcpAggregator(MediaSink* msink, MediaSource* msource, uint32_t maxVideoBw)
-    : RtcpProcessor(msink, msource, maxVideoBw), defaultVideoBw_(maxVideoBw / 2) {
+RtcpAggregator::RtcpAggregator(MediaSink* msink, MediaSource* msource, uint32_t max_video_bw)
+    : RtcpProcessor(msink, msource, max_video_bw), defaultVideoBw_(max_video_bw / 2) {
   ELOG_DEBUG("Starting RtcpAggregator");
 }
 
@@ -43,7 +43,7 @@ void RtcpAggregator::addSourceSsrc(uint32_t ssrc) {
 }
 
 void RtcpAggregator::setPublisherBW(uint32_t bandwidth) {
-  defaultVideoBw_ = (bandwidth*1.2) > maxVideoBw_? maxVideoBw_:(bandwidth*1.2);
+  defaultVideoBw_ = (bandwidth*1.2) > max_video_bw_? max_video_bw_:(bandwidth*1.2);
 }
 
 void RtcpAggregator::analyzeSr(RtcpHeader* chead) {

--- a/erizo/src/erizo/rtp/RtcpAggregator.h
+++ b/erizo/src/erizo/rtp/RtcpAggregator.h
@@ -20,7 +20,7 @@ class RtcpAggregator: public RtcpProcessor{
   DECLARE_LOGGER();
 
  public:
-  RtcpAggregator(MediaSink* msink, MediaSource* msource, uint32_t maxVideoBw = 300000);
+  RtcpAggregator(MediaSink* msink, MediaSource* msource, uint32_t max_video_bw = 300000);
   virtual ~RtcpAggregator() {}
   void addSourceSsrc(uint32_t ssrc);
   void setPublisherBW(uint32_t bandwidth);

--- a/erizo/src/erizo/rtp/RtcpForwarder.cpp
+++ b/erizo/src/erizo/rtp/RtcpForwarder.cpp
@@ -14,8 +14,8 @@ using std::memcpy;
 namespace erizo {
 DEFINE_LOGGER(RtcpForwarder, "rtp.RtcpForwarder");
 
-RtcpForwarder::RtcpForwarder(MediaSink* msink, MediaSource* msource, uint32_t maxVideoBw)
-  : RtcpProcessor(msink, msource, maxVideoBw) {
+RtcpForwarder::RtcpForwarder(MediaSink* msink, MediaSource* msource, uint32_t max_video_bw)
+  : RtcpProcessor(msink, msource, max_video_bw) {
     ELOG_DEBUG("Starting RtcpForwarder");
   }
 
@@ -132,11 +132,11 @@ int RtcpForwarder::analyzeFeedback(char *buf, int len) {
                 if (!strncmp(uniqueId, "REMB", 4)) {
                   uint64_t bitrate = chead->getBrMantis() << chead->getBrExp();
                   uint64_t cappedBitrate = 0;
-                  cappedBitrate = bitrate < maxVideoBw_? bitrate: maxVideoBw_;
-                  if (bitrate < maxVideoBw_) {
+                  cappedBitrate = bitrate < max_video_bw_? bitrate: max_video_bw_;
+                  if (bitrate < max_video_bw_) {
                     cappedBitrate = bitrate;
                   } else {
-                    cappedBitrate = maxVideoBw_;
+                    cappedBitrate = max_video_bw_;
                   }
                   ELOG_DEBUG("Received REMB %llu, partnum %u, cappedBitrate %llu",
                               bitrate, currentBlock, cappedBitrate);

--- a/erizo/src/erizo/rtp/RtcpForwarder.h
+++ b/erizo/src/erizo/rtp/RtcpForwarder.h
@@ -19,7 +19,7 @@ class RtcpForwarder: public RtcpProcessor{
   DECLARE_LOGGER();
 
  public:
-  RtcpForwarder(MediaSink* msink, MediaSource* msource, uint32_t maxVideoBw = 300000);
+  RtcpForwarder(MediaSink* msink, MediaSource* msource, uint32_t max_video_bw = 300000);
   virtual ~RtcpForwarder() {}
   void addSourceSsrc(uint32_t ssrc);
   void setPublisherBW(uint32_t bandwidth);

--- a/erizo/src/erizo/rtp/RtcpProcessor.h
+++ b/erizo/src/erizo/rtp/RtcpProcessor.h
@@ -109,8 +109,8 @@ class RtcpData {
 
 class RtcpProcessor : public Service {
  public:
-  RtcpProcessor(MediaSink* msink, MediaSource* msource, uint32_t maxVideoBw = 300000):
-    rtcpSink_(msink), rtcpSource_(msource) {}
+  RtcpProcessor(MediaSink* msink, MediaSource* msource, uint32_t max_video_bw = 300000):
+    rtcpSink_(msink), rtcpSource_(msource), max_video_bw_{max_video_bw} {}
   virtual ~RtcpProcessor() {}
   virtual void addSourceSsrc(uint32_t ssrc) = 0;
   virtual void setPublisherBW(uint32_t bandwidth) = 0;
@@ -118,13 +118,13 @@ class RtcpProcessor : public Service {
   virtual int analyzeFeedback(char* buf, int len) = 0;
   virtual void checkRtcpFb() = 0;
 
-  virtual void setMaxVideoBW(uint32_t bandwidth) { maxVideoBw_ = bandwidth; }
-  virtual uint32_t getMaxVideoBW() { return maxVideoBw_; }
+  virtual void setMaxVideoBW(uint32_t bandwidth) { max_video_bw_ = bandwidth; }
+  virtual uint32_t getMaxVideoBW() { return max_video_bw_; }
 
  protected:
   MediaSink* rtcpSink_;  // The sink to send RRs
   MediaSource* rtcpSource_;  // The source of SRs
-  uint32_t maxVideoBw_;
+  uint32_t max_video_bw_;
 };
 
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/RtpHeaders.h
+++ b/erizo/src/erizo/rtp/RtpHeaders.h
@@ -107,6 +107,10 @@ class RtpHeader {
     return padding;
   }
 
+  inline void setPadding(uint8_t has_padding) {
+    padding = has_padding;
+  }
+
   inline uint8_t getVersion() const {
     return version;
   }

--- a/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.cpp
@@ -67,7 +67,7 @@ void RtpPaddingGeneratorHandler::read(Context *ctx, std::shared_ptr<dataPacket> 
       }
     } else if (fast_start_ && chead->packettype == RTCP_Receiver_PT && chead->getSourceSSRC() == audio_source_ssrc_) {
       if (chead->getFractionLost() > kMaxFractionLostAllowed) {
-        ELOG_WARN("Fast start disabled");
+        ELOG_DEBUG("Fast start disabled");
         fast_start_ = false;
       }
     }
@@ -86,7 +86,7 @@ void RtpPaddingGeneratorHandler::write(Context *ctx, std::shared_ptr<dataPacket>
     }
     first_packet_received_ = true;
     if (fast_start_ && clock_->now() - started_at_ > kFastStartMaxDuration) {
-      ELOG_WARN("Fast start disabled");
+      ELOG_DEBUG("Fast start disabled");
       fast_start_ = false;
     }
   }

--- a/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.cpp
@@ -1,0 +1,217 @@
+#include "rtp/RtpPaddingGeneratorHandler.h"
+
+#include <algorithm>
+#include <string>
+
+#include "./MediaDefinitions.h"
+#include "./WebRtcConnection.h"
+#include "./RtpUtils.h"
+
+namespace erizo {
+
+DEFINE_LOGGER(RtpPaddingGeneratorHandler, "rtp.RtpPaddingGeneratorHandler");
+
+constexpr duration kStatsPeriod = std::chrono::milliseconds(100);
+constexpr duration kFastStartMaxDuration = std::chrono::seconds(30);
+constexpr uint8_t kMaxPaddingSize = 255;
+constexpr uint64_t kMinMarkerRate = 3;
+constexpr uint8_t kMaxFractionLostAllowed = .05 * 255;  // 5% of packet losts
+constexpr uint64_t kInitialRembValue = 300000;
+
+RtpPaddingGeneratorHandler::RtpPaddingGeneratorHandler(std::shared_ptr<erizo::Clock> the_clock) :
+  clock_{the_clock}, connection_{nullptr}, max_video_bw_{0}, higher_sequence_number_{0},
+  video_sink_ssrc_{0}, audio_source_ssrc_{0},
+  number_of_full_padding_packets_{0}, last_padding_packet_size_{0},
+  last_rate_calculation_time_{clock_->now()}, started_at_{clock_->now()},
+  enabled_{false}, first_packet_received_{false},
+  marker_rate_{std::chrono::milliseconds(100), 20, 1., clock_},
+  padding_bitrate_{std::chrono::milliseconds(100), 10, 8., clock_},
+  rtp_header_length_{12}, remb_value_{kInitialRembValue}, fast_start_{true} {}
+
+
+void RtpPaddingGeneratorHandler::enable() {
+}
+
+void RtpPaddingGeneratorHandler::disable() {
+}
+
+void RtpPaddingGeneratorHandler::notifyUpdate() {
+  auto pipeline = getContext()->getPipelineShared();
+  if (pipeline && !connection_) {
+    connection_ = pipeline->getService<WebRtcConnection>().get();
+    video_sink_ssrc_ = connection_->getVideoSinkSSRC();
+    audio_source_ssrc_ = connection_->getAudioSinkSSRC();
+    stats_ = pipeline->getService<Stats>();
+  }
+
+  auto quality_manager = pipeline->getService<QualityManager>();
+
+  if (quality_manager->isPaddingEnabled() && !enabled_) {
+    enablePadding();
+  } else if (!quality_manager->isPaddingEnabled() && enabled_) {
+    disablePadding();
+  }
+
+  auto processor = pipeline->getService<RtcpProcessor>();
+  if (processor) {
+    max_video_bw_ = processor->getMaxVideoBW();
+  }
+}
+
+void RtpPaddingGeneratorHandler::read(Context *ctx, std::shared_ptr<dataPacket> packet) {
+  RtpUtils::forEachRRBlock(packet, [this](RtcpHeader *chead) {
+    if (chead->packettype == RTCP_PS_Feedback_PT && chead->getBlockCount() == RTCP_AFB) {
+      char *uniqueId = reinterpret_cast<char*>(&chead->report.rembPacket.uniqueid);
+      if (!strncmp(uniqueId, "REMB", 4)) {
+        remb_value_ = chead->getREMBBitRate();
+      }
+    } else if (fast_start_ && chead->packettype == RTCP_Receiver_PT && chead->getSourceSSRC() == audio_source_ssrc_) {
+      if (chead->getFractionLost() > kMaxFractionLostAllowed) {
+        ELOG_WARN("Fast start disabled");
+        fast_start_ = false;
+      }
+    }
+  });
+
+  ctx->fireRead(packet);
+}
+
+void RtpPaddingGeneratorHandler::write(Context *ctx, std::shared_ptr<dataPacket> packet) {
+  RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
+  bool is_higher_sequence_number = false;
+  if (packet->type == VIDEO_PACKET && !chead->isRtcp()) {
+    is_higher_sequence_number = isHigherSequenceNumber(packet);
+    if (!first_packet_received_) {
+      started_at_ = clock_->now();
+    }
+    first_packet_received_ = true;
+    if (fast_start_ && clock_->now() - started_at_ > kFastStartMaxDuration) {
+      ELOG_WARN("Fast start disabled");
+      fast_start_ = false;
+    }
+  }
+
+  ctx->fireWrite(packet);
+
+  if (is_higher_sequence_number) {
+    onVideoPacket(packet);
+  }
+}
+
+void RtpPaddingGeneratorHandler::sendPaddingPacket(std::shared_ptr<dataPacket> packet, uint8_t padding_size) {
+  if (padding_size == 0) {
+    return;
+  }
+
+  SequenceNumber sequence_number = translator_.generate();
+
+  auto padding_packet = RtpUtils::makePaddingPacket(packet, padding_size);
+
+  RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(padding_packet->data);
+
+  rtp_header->setSeqNumber(sequence_number.output);
+  padding_bitrate_ += padding_packet->length;
+
+  getContext()->fireWrite(padding_packet);
+}
+
+void RtpPaddingGeneratorHandler::onPacketWithMarkerSet(std::shared_ptr<dataPacket> packet) {
+  marker_rate_++;
+
+  for (int i = 0; i < number_of_full_padding_packets_; i++) {
+    sendPaddingPacket(packet, kMaxPaddingSize);
+  }
+  sendPaddingPacket(packet, last_padding_packet_size_);
+}
+
+bool RtpPaddingGeneratorHandler::isHigherSequenceNumber(std::shared_ptr<dataPacket> packet) {
+  RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
+  rtp_header_length_ = rtp_header->getHeaderLength();
+  uint16_t new_sequence_number = rtp_header->getSeqNumber();
+  SequenceNumber sequence_number = translator_.get(new_sequence_number, false);
+  rtp_header->setSeqNumber(sequence_number.output);
+  if (first_packet_received_ && RtpUtils::sequenceNumberLessThan(new_sequence_number, higher_sequence_number_)) {
+    return false;
+  }
+  higher_sequence_number_ = new_sequence_number;
+  return true;
+}
+
+void RtpPaddingGeneratorHandler::onVideoPacket(std::shared_ptr<dataPacket> packet) {
+  if (!enabled_) {
+    return;
+  }
+
+  recalculatePaddingRate();
+
+  RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
+  if (rtp_header->getMarker()) {
+    onPacketWithMarkerSet(packet);
+  }
+}
+
+uint64_t RtpPaddingGeneratorHandler::getStat(std::string stat_name) {
+  if (stats_->getNode()["total"].hasChild(stat_name)) {
+    StatNode & stat = stats_->getNode()["total"][stat_name];
+    return static_cast<MovingIntervalRateStat&>(stat).value();
+  }
+  return 0;
+}
+
+bool RtpPaddingGeneratorHandler::isTimeToCalculateBitrate() {
+  return (clock_->now() - last_rate_calculation_time_) >= kStatsPeriod;
+}
+
+void RtpPaddingGeneratorHandler::recalculatePaddingRate() {
+  if (!isTimeToCalculateBitrate()) {
+    return;
+  }
+
+  last_rate_calculation_time_ = clock_->now();
+
+  int64_t total_bitrate = getStat("bitrateCalculated");
+  int64_t padding_bitrate = padding_bitrate_.value();
+  int64_t media_bitrate = std::max(total_bitrate - padding_bitrate, int64_t(0));
+
+  uint64_t target_bitrate = getTargetBitrate();
+
+  int64_t target_padding_bitrate = target_bitrate - media_bitrate;
+
+  if (target_padding_bitrate <= 0) {
+    number_of_full_padding_packets_ = 0;
+    last_padding_packet_size_ = 0;
+    return;
+  }
+
+  uint64_t marker_rate = marker_rate_.value(std::chrono::seconds(2));
+  marker_rate = std::max(marker_rate, kMinMarkerRate);
+  uint64_t bytes_per_marker = target_padding_bitrate / (marker_rate * 8);
+  number_of_full_padding_packets_ = bytes_per_marker / (kMaxPaddingSize + rtp_header_length_);
+  last_padding_packet_size_ = bytes_per_marker % (kMaxPaddingSize + rtp_header_length_) - rtp_header_length_;
+}
+
+uint64_t RtpPaddingGeneratorHandler::getTargetBitrate() {
+  uint64_t target_bitrate = remb_value_;
+
+  if (!fast_start_) {
+    target_bitrate = getStat("senderBitrateEstimation");
+  }
+
+  if (max_video_bw_ > 0) {
+    target_bitrate = std::min(target_bitrate, max_video_bw_);
+  }
+  return target_bitrate;
+}
+
+void RtpPaddingGeneratorHandler::enablePadding() {
+  enabled_ = true;
+  number_of_full_padding_packets_ = 0;
+  last_padding_packet_size_ = 0;
+  last_rate_calculation_time_ = clock_->now();
+}
+
+void RtpPaddingGeneratorHandler::disablePadding() {
+  enabled_ = false;
+}
+
+}  // namespace erizo

--- a/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.h
+++ b/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.h
@@ -1,0 +1,72 @@
+#ifndef ERIZO_SRC_ERIZO_RTP_RTPPADDINGGENERATORHANDLER_H_
+#define ERIZO_SRC_ERIZO_RTP_RTPPADDINGGENERATORHANDLER_H_
+
+#include <string>
+
+#include "./logger.h"
+#include "pipeline/Handler.h"
+#include "lib/Clock.h"
+#include "rtp/SequenceNumberTranslator.h"
+#include "./Stats.h"
+
+namespace erizo {
+
+class WebRtcConnection;
+
+class RtpPaddingGeneratorHandler: public Handler {
+  DECLARE_LOGGER();
+
+ public:
+  explicit RtpPaddingGeneratorHandler(std::shared_ptr<erizo::Clock> the_clock = std::make_shared<erizo::SteadyClock>());
+
+  void enable() override;
+  void disable() override;
+
+  std::string getName() override {
+    return "padding-generator";
+  }
+
+  void read(Context *ctx, std::shared_ptr<dataPacket> packet) override;
+  void write(Context *ctx, std::shared_ptr<dataPacket> packet) override;
+  void notifyUpdate() override;
+
+ private:
+  void sendPaddingPacket(std::shared_ptr<dataPacket> packet, uint8_t padding_size);
+  void onPacketWithMarkerSet(std::shared_ptr<dataPacket> packet);
+  bool isHigherSequenceNumber(std::shared_ptr<dataPacket> packet);
+  void onVideoPacket(std::shared_ptr<dataPacket> packet);
+
+  uint64_t getStat(std::string stat_name);
+  uint64_t getTargetBitrate();
+
+  bool isTimeToCalculateBitrate();
+  void recalculatePaddingRate();
+
+  void enablePadding();
+  void disablePadding();
+
+ private:
+  std::shared_ptr<erizo::Clock> clock_;
+  SequenceNumberTranslator translator_;
+  WebRtcConnection* connection_;
+  std::shared_ptr<Stats> stats_;
+  uint64_t max_video_bw_;
+  uint16_t higher_sequence_number_;
+  uint32_t video_sink_ssrc_;
+  uint32_t audio_source_ssrc_;
+  uint64_t number_of_full_padding_packets_;
+  uint8_t last_padding_packet_size_;
+  time_point last_rate_calculation_time_;
+  time_point started_at_;
+  bool enabled_;
+  bool first_packet_received_;
+  MovingIntervalRateStat marker_rate_;
+  MovingIntervalRateStat padding_bitrate_;
+  uint32_t rtp_header_length_;
+  uint64_t remb_value_;
+  bool fast_start_;
+};
+
+}  // namespace erizo
+
+#endif  // ERIZO_SRC_ERIZO_RTP_RTPPADDINGGENERATORHANDLER_H_

--- a/erizo/src/erizo/rtp/RtpUtils.h
+++ b/erizo/src/erizo/rtp/RtpUtils.h
@@ -30,6 +30,8 @@ class RtpUtils {
   static std::shared_ptr<dataPacket> createFIR(uint32_t source_ssrc, uint32_t sink_ssrc, uint8_t seq_number);
 
   static int getPaddingLength(std::shared_ptr<dataPacket> packet);
+
+  static std::shared_ptr<dataPacket> makePaddingPacket(std::shared_ptr<dataPacket> packet, uint8_t padding_size);
 };
 
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/SequenceNumberTranslator.h
+++ b/erizo/src/erizo/rtp/SequenceNumberTranslator.h
@@ -12,7 +12,8 @@ namespace erizo {
 enum class SequenceNumberType : uint8_t {
   Valid = 0,
   Skip = 1,
-  Discard = 2
+  Discard = 2,
+  Generated = 3
 };
 
 struct SequenceNumber {
@@ -35,6 +36,7 @@ class SequenceNumberTranslator: public Service, public std::enable_shared_from_t
   SequenceNumber get(uint16_t input_sequence_number, bool skip);
   SequenceNumber reverse(uint16_t output_sequence_number) const;
   void reset();
+  SequenceNumber generate();
 
  private:
   void add(SequenceNumber sequence_number);
@@ -48,6 +50,7 @@ class SequenceNumberTranslator: public Service, public std::enable_shared_from_t
   uint16_t first_input_sequence_number_;
   uint16_t last_input_sequence_number_;
   uint16_t initial_output_sequence_number_;
+  uint16_t offset_;
   bool initialized_;
   bool reset_;
 };

--- a/erizo/src/test/log4cxx.properties
+++ b/erizo/src/test/log4cxx.properties
@@ -56,3 +56,4 @@ log4j.logger.rtp.RtcpNackGenerator=ERROR
 log4j.logger.rtp.SRPacketHandler=ERROR
 log4j.logger.rtp.SenderBandwidthEstimationHandler=ERROR
 log4j.logger.rtp.StatsCalculator=ERROR
+log4j.logger.rtp.RtpPaddingGeneratorHandler=ERROR

--- a/erizo/src/test/rtp/RtpPaddingGeneratorHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpPaddingGeneratorHandlerTest.cpp
@@ -1,0 +1,127 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <rtp/RtpPaddingGeneratorHandler.h>
+#include <rtp/RtpHeaders.h>
+#include <MediaDefinitions.h>
+#include <WebRtcConnection.h>
+#include <stats/StatNode.h>
+
+#include <queue>
+#include <string>
+#include <vector>
+
+#include "../utils/Mocks.h"
+#include "../utils/Tools.h"
+#include "../utils/Matchers.h"
+
+using ::testing::_;
+using ::testing::IsNull;
+using ::testing::Args;
+using ::testing::Return;
+using ::testing::AtLeast;
+using erizo::dataPacket;
+using erizo::packetType;
+using erizo::AUDIO_PACKET;
+using erizo::VIDEO_PACKET;
+using erizo::MovingIntervalRateStat;
+using erizo::IceConfig;
+using erizo::RtpMap;
+using erizo::RtpPaddingGeneratorHandler;
+using erizo::WebRtcConnection;
+using erizo::Pipeline;
+using erizo::InboundHandler;
+using erizo::OutboundHandler;
+using erizo::Worker;
+using std::queue;
+
+
+class RtpPaddingGeneratorHandlerTest : public erizo::HandlerTest {
+ public:
+  RtpPaddingGeneratorHandlerTest() {}
+
+ protected:
+  void setHandler() {
+    EXPECT_CALL(*processor.get(), getMaxVideoBW()).Times(AtLeast(0));
+    EXPECT_CALL(*quality_manager.get(), isPaddingEnabled()).Times(AtLeast(0));
+    clock = std::make_shared<erizo::SimulatedClock>();
+    padding_generator_handler = std::make_shared<RtpPaddingGeneratorHandler>(clock);
+    pipeline->addBack(padding_generator_handler);
+
+    stats->getNode()["total"].insertStat("bitrateCalculated",
+            MovingIntervalRateStat{std::chrono::milliseconds(100), 10, 1., clock});
+    stats->getNode()["total"].insertStat("senderBitrateEstimation",
+            MovingIntervalRateStat{std::chrono::milliseconds(100), 10, 1., clock});
+
+    EXPECT_CALL(*quality_manager.get(), isPaddingEnabled()).WillRepeatedly(Return(true));
+
+    EXPECT_CALL(*processor.get(), getMaxVideoBW()).WillRepeatedly(Return(100000));
+    stats->getNode()["total"]["bitrateCalculated"]       += 40000 * 2 / 10;
+    stats->getNode()["total"]["senderBitrateEstimation"] += 60000 * 2 / 10;
+  }
+
+  std::shared_ptr<RtpPaddingGeneratorHandler> padding_generator_handler;
+  std::shared_ptr<erizo::SimulatedClock> clock;
+};
+
+TEST_F(RtpPaddingGeneratorHandlerTest, basicBehaviourShouldReadPackets) {
+  auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+  EXPECT_CALL(*reader.get(), read(_, _)).
+    With(Args<1>(erizo::RtpHasSequenceNumber(erizo::kArbitrarySeqNumber))).Times(1);
+  pipeline->read(packet);
+}
+
+TEST_F(RtpPaddingGeneratorHandlerTest, basicBehaviourShouldWritePackets) {
+  auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+  EXPECT_CALL(*writer.get(), write(_, _)).
+    With(Args<1>(erizo::RtpHasSequenceNumber(erizo::kArbitrarySeqNumber))).Times(1);
+  pipeline->write(packet);
+}
+
+TEST_F(RtpPaddingGeneratorHandlerTest, shouldSendPaddingWhenEnabled) {
+  EXPECT_CALL(*writer.get(), write(_, _)).Times(AtLeast(3));
+
+  pipeline->write(erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber, true, true));
+
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber + 1, true, true));
+}
+
+TEST_F(RtpPaddingGeneratorHandlerTest, shouldNotSendPaddingWhenDisabled) {
+  EXPECT_CALL(*writer.get(), write(_, _)).Times(2);
+  EXPECT_CALL(*quality_manager.get(), isPaddingEnabled()).WillRepeatedly(Return(false));
+  pipeline->notifyUpdate();
+
+  pipeline->write(erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber, true, true));
+
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber + 1, true, true));
+}
+
+TEST_F(RtpPaddingGeneratorHandlerTest, shouldNotSendPaddingAfterNotMarkers) {
+  EXPECT_CALL(*writer.get(), write(_, _)).Times(2);
+
+  pipeline->write(erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber, true, true));
+
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber + 1, true, false));
+}
+
+TEST_F(RtpPaddingGeneratorHandlerTest, shouldNotSendPaddingIfBitrateIsHigherThanBitrateEstimation) {
+  const uint32_t kFractionLost = .1 * 255;
+  EXPECT_CALL(*writer.get(), write(_, _)).Times(2);
+
+  stats->getNode()["total"]["bitrateCalculated"]       += 70000;
+  stats->getNode()["total"]["senderBitrateEstimation"] += 60000;
+
+  pipeline->read(erizo::PacketTools::createReceiverReport(erizo::kAudioSsrc, erizo::kAudioSsrc,
+                                                          erizo::kArbitrarySeqNumber, VIDEO_PACKET, 0, kFractionLost));
+
+  pipeline->write(erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber, true, true));
+
+  clock->advanceTime(std::chrono::milliseconds(1000));
+
+  pipeline->write(erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber + 1, true, true));
+}

--- a/erizo/src/test/utils/Mocks.h
+++ b/erizo/src/test/utils/Mocks.h
@@ -4,6 +4,7 @@
 #include <WebRtcConnection.h>
 #include <pipeline/Handler.h>
 #include <rtp/RtcpProcessor.h>
+#include <rtp/QualityManager.h>
 #include <rtp/FecReceiverHandler.h>
 #include <rtp/BandwidthEstimationHandler.h>
 #include <rtp/SenderBandwidthEstimationHandler.h>
@@ -19,10 +20,19 @@ class MockRtcpProcessor : public RtcpProcessor {
   MockRtcpProcessor() : RtcpProcessor(nullptr, nullptr) {}
   MOCK_METHOD1(addSourceSsrc, void(uint32_t));
   MOCK_METHOD1(setMaxVideoBW, void(uint32_t));
+  MOCK_METHOD0(getMaxVideoBW, uint32_t());
   MOCK_METHOD1(setPublisherBW, void(uint32_t));
   MOCK_METHOD1(analyzeSr, void(RtcpHeader*));
   MOCK_METHOD2(analyzeFeedback, int(char*, int));
   MOCK_METHOD0(checkRtcpFb, void());
+};
+
+class MockQualityManager : public QualityManager {
+ public:
+  MockQualityManager() : QualityManager() {}
+  MOCK_CONST_METHOD0(getSpatialLayer, int());
+  MOCK_CONST_METHOD0(getTemporalLayer, int());
+  MOCK_CONST_METHOD0(isPaddingEnabled, bool());
 };
 
 class MockMediaSink : public MediaSink {

--- a/erizo_controller/erizoAgent/log4cxx.properties
+++ b/erizo_controller/erizoAgent/log4cxx.properties
@@ -59,3 +59,4 @@ log4j.logger.rtp.SenderBandwidthEstimationHandler=WARN
 log4j.logger.rtp.StatsCalculator=WARN
 log4j.logger.rtp.LayerDetectorHandler=WARN
 log4j.logger.rtp.PliPacerHandler=WARN
+log4j.logger.rtp.RtpPaddingGeneratorHandler=WARN


### PR DESCRIPTION
**Description**

As part of Simulcast/SVC it adds a new handler to generate padding. It will be useful when we need to increase bitrates and sender bandwidth estimations. 

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.
