### PR TITLE
Add the option to update the max video bw in the subscriber

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -754,6 +754,11 @@ Erizo.Room = function (spec) {
                                                 metadata: options.metadata});
                     if(callback) callback(true);
                 } else {
+
+                    options.maxVideoBW = options.maxVideoBW || spec.defaultVideoBW;
+                    if (options.maxVideoBW > spec.maxVideoBW) {
+                        options.maxVideoBW = spec.maxVideoBW;
+                    }
                     L.Logger.info('Checking subscribe options for', stream.getID());
                     stream.checkOptions(options);
                     sendSDPSocket('subscribe', {streamId: stream.getID(),
@@ -784,6 +789,10 @@ Erizo.Room = function (spec) {
                               nop2p: true,
                               audio: options.audio,
                               video: options.video,
+                              maxAudioBW: spec.maxAudioBW,
+                              maxVideoBW: spec.maxVideoBW,
+                              limitMaxAudioBW:spec.maxAudioBW,
+                              limitMaxVideoBW: spec.maxVideoBW,
                               iceServers: that.iceServers});
 
                             stream.pc.onaddstream = function (evt) {


### PR DESCRIPTION
**Description**

It adds the possibility to set a Maximum Video Bandwidth from the subscribers.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

I didn't update the docs because it was already there and we made no distinction between publisher and subscriber.

[] It includes documentation for these changes in `/doc`.
