### PR TITLE
Add nullptr check when delivering audio

### DIFF
--- a/erizo/src/erizo/OneToManyProcessor.cpp
+++ b/erizo/src/erizo/OneToManyProcessor.cpp
@@ -31,7 +31,9 @@ namespace erizo {
 
     std::map<std::string, std::shared_ptr<MediaSink>>::iterator it;
     for (it = subscribers.begin(); it != subscribers.end(); ++it) {
-      (*it).second->deliverAudioData(audio_packet);
+      if ((*it).second != nullptr) {
+        (*it).second->deliverAudioData(audio_packet);
+      }
     }
 
     return 0;


### PR DESCRIPTION
**Description**

Adds a nullptr check to avoid having crashes in Erizo. Fixes #793 

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed

[] It includes documentation for these changes in `/doc`.
