### PR TITLE
Fix bad quality filter behaviour with VP9 SVC

### DIFF
--- a/erizo/src/erizo/rtp/QualityFilterHandler.cpp
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.cpp
@@ -130,7 +130,7 @@ void QualityFilterHandler::write(Context *ctx, std::shared_ptr<dataPacket> packe
     uint32_t ssrc = rtp_header->getSSRC();
     uint16_t sequence_number = rtp_header->getSeqNumber();
 
-    if (ssrc != last_ssrc_received_) {
+    if (last_ssrc_received_ != 0 && ssrc != last_ssrc_received_) {
       receiving_multiple_ssrc_ = true;
     }
 


### PR DESCRIPTION
**Description**

Fix Quality Filter Handler to take into account packets from other spatial layers during SeqNum translation.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.
