### PR TITLE
Added the possibility of dynamically creating p2p rooms in basic example

### DIFF
--- a/extras/basic_example/basicServer.js
+++ b/extras/basic_example/basicServer.js
@@ -72,7 +72,7 @@ var getOrCreateRoom = function (name, type = 'erizo', callback) {
             }
         }
 
-        let extra = {data: {basicExampleRoom:true}};
+        let extra = {data: {basicExampleRoom: true}};
         if (type === 'p2p') extra.p2p = true;
 
         N.API.createRoom(name, function (roomID) {

--- a/extras/basic_example/basicServer.js
+++ b/extras/basic_example/basicServer.js
@@ -49,11 +49,11 @@ app.use(function(req, res, next) {
 N.API.init(config.nuve.superserviceID, config.nuve.superserviceKey, 'http://localhost:3000/');
 
 var defaultRoom;
-var defaultRoomName = 'basicExampleRoom';
+const defaultRoomName = 'basicExampleRoom';
 
-var getOrCreateRoom = function (roomName, callback) {
+var getOrCreateRoom = function (name, type = 'erizo', callback) {
 
-    if (roomName === defaultRoomName && defaultRoom) {
+    if (name === defaultRoomName && defaultRoom) {
         callback(defaultRoom);
         return;
     }
@@ -61,20 +61,24 @@ var getOrCreateRoom = function (roomName, callback) {
     N.API.getRooms(function (roomlist){
         var theRoom = '';
         var rooms = JSON.parse(roomlist);
-        for (var room in rooms) {
-            if (rooms[room].name === roomName &&
-                rooms[room].data &&
-                rooms[room].data.basicExampleRoom){
+        for (var room of rooms) {
+            if (room.name === name &&
+                room.data &&
+                room.data.basicExampleRoom){
 
-                theRoom = rooms[room]._id;
+                theRoom = room._id;
                 callback(theRoom);
                 return;
             }
         }
-        N.API.createRoom(roomName, function (roomID) {
+
+        let extra = {data: {basicExampleRoom:true}};
+        if (type === 'p2p') extra.p2p = true;
+
+        N.API.createRoom(name, function (roomID) {
             theRoom = roomID._id;
             callback(theRoom);
-        }, function(){}, {data: {basicExampleRoom:true}});
+        }, function(){}, extra);
     });
 };
 
@@ -109,15 +113,16 @@ var deleteRoomsIfEmpty = function (theRooms, callback) {
 };
 
 var cleanExampleRooms = function (callback) {
+    console.log('Cleaning basic example rooms');
     N.API.getRooms(function (roomlist) {
         var rooms = JSON.parse(roomlist);
         var roomsToCheck = [];
-        for (var room in rooms){
-            if (rooms[room].data &&
-                rooms[room].data.basicExampleRoom &&
-                rooms[room].name !== defaultRoomName){
+        for (var room of rooms){
+            if (room.data &&
+                room.data.basicExampleRoom &&
+                room.name !== defaultRoomName){
 
-                roomsToCheck.push(rooms[room]);
+                roomsToCheck.push(room);
             }
         }
         deleteRoomsIfEmpty (roomsToCheck, function () {
@@ -142,21 +147,22 @@ app.get('/getUsers/:room', function(req, res) {
 
 
 app.post('/createToken/', function(req, res) {
-    console.log(req.body);
-    var room = defaultRoomName;
-    if (req.body.room && !isNaN(req.body.room)) {
-        room = req.body.room;
-    }
+    console.log('Creating token. Request body: ',req.body);
+    
+    let username = req.body.username;
+    let role = req.body.role;
+    
+    let room = defaultRoomName, type;
 
-    var username = req.body.username,
-    role = req.body.role;
+    if (req.body.room && !isNaN(req.body.room)) room = req.body.room;
+    if (req.body.type) type = req.body.type;
 
-    getOrCreateRoom(room, function (roomId) {
+    getOrCreateRoom(room, type, function (roomId) {
         N.API.createToken(roomId, username, role, function(token) {
-            console.log(token);
+            console.log('Token created', token);
             res.send(token);
         }, function(error) {
-            console.log(error);
+            console.log('Error creating token', error);
             res.status(401).send('No Erizo Controller found');
         });
     });
@@ -175,7 +181,7 @@ app.use(function(req, res, next) {
 });
 
 cleanExampleRooms(function() {
-    getOrCreateRoom(defaultRoomName, function (roomId) {
+    getOrCreateRoom(defaultRoomName, undefined, function (roomId) {
         defaultRoom = roomId;
         app.listen(3001);
         var server = https.createServer(options, app);

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -65,7 +65,7 @@ window.onload = function () {
     config.extensionId = 'okeephmleflklcdebijnponpabbmmgeo';
   }
   localStream = Erizo.Stream(config);
-  var createToken = function(room_data, callback) {
+  var createToken = function(roomData, callback) {
 
     var req = new XMLHttpRequest();
     var url = serverUrl + 'createToken/';
@@ -78,12 +78,12 @@ window.onload = function () {
 
     req.open('POST', url, true);
     req.setRequestHeader('Content-Type', 'application/json');
-    req.send(JSON.stringify(room_data));
+    req.send(JSON.stringify(roomData));
   };
 
-  var room_data = {username: 'user', role: 'presenter', room: roomName, type: roomType};
+  var roomData  = {username: 'user', role: 'presenter', room: roomName, type: roomType};
 
-  createToken(room_data, function (response) {
+  createToken(roomData, function (response) {
     var token = response;
     console.log(token);
     room = Erizo.Room({token: token});

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -50,7 +50,8 @@ window.onload = function () {
   recording = false;
   var screen = getParameterByName('screen');
   var roomName = getParameterByName('room') || 'basicExampleRoom';
-  console.log('Selected Room', room);
+  var roomType = getParameterByName('type') || 'erizo';
+  console.log('Selected Room', roomName, 'of type', roomType);
   var config = {audio: true,
                 video: true,
                 data: true,
@@ -64,11 +65,10 @@ window.onload = function () {
     config.extensionId = 'okeephmleflklcdebijnponpabbmmgeo';
   }
   localStream = Erizo.Stream(config);
-  var createToken = function(userName, role, roomName, callback) {
+  var createToken = function(room_data, callback) {
 
     var req = new XMLHttpRequest();
     var url = serverUrl + 'createToken/';
-    var body = {username: userName, role: role, room:roomName};
 
     req.onreadystatechange = function () {
       if (req.readyState === 4) {
@@ -78,10 +78,12 @@ window.onload = function () {
 
     req.open('POST', url, true);
     req.setRequestHeader('Content-Type', 'application/json');
-    req.send(JSON.stringify(body));
+    req.send(JSON.stringify(room_data));
   };
 
-  createToken('user', 'presenter', roomName, function (response) {
+  var room_data = {username: 'user', role: 'presenter', room: roomName, type: roomType};
+
+  createToken(room_data, function (response) {
     var token = response;
     console.log(token);
     room = Erizo.Room({token: token});


### PR DESCRIPTION
**Description**

Now you can specify the room type when dynamically creating rooms in basic example. Connecting to `https://basic_server:3004/?room=1234&type=p2p` creates a p2p room called '1234'.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

No changes

[] It includes documentation for these changes in `/doc`.
