### PR TITLE
Add more stats 

### DIFF
--- a/erizo/src/erizo/rtp/QualityFilterHandler.cpp
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.cpp
@@ -130,7 +130,7 @@ void QualityFilterHandler::write(Context *ctx, std::shared_ptr<dataPacket> packe
     uint32_t ssrc = rtp_header->getSSRC();
     uint16_t sequence_number = rtp_header->getSeqNumber();
 
-    if (ssrc != last_ssrc_received_) {
+    if (last_ssrc_received_ != 0 && ssrc != last_ssrc_received_) {
       receiving_multiple_ssrc_ = true;
     }
 

--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -109,6 +109,11 @@ void QualityManager::calculateMaxActiveLayer() {
       break;
     }
   }
+  stats_->getNode()["qualityLayers"].insertStat("maxActiveSpatialLayer",
+      CumulativeStat{static_cast<uint64_t>(max_active_spatial_layer_)});
+  stats_->getNode()["qualityLayers"].insertStat("maxActiveTemporalLayer",
+      CumulativeStat{static_cast<uint64_t>(max_active_temporal_layer_)});
+
   max_active_spatial_layer_ = max_active_spatial_layer;
   max_active_temporal_layer_ = max_active_temporal_layer;
 }
@@ -142,11 +147,15 @@ void QualityManager::setSpatialLayer(int spatial_layer) {
   if (!forced_layers_) {
     spatial_layer_ = spatial_layer;
   }
+  stats_->getNode()["qualityLayers"].insertStat("selectedSpatialLayer",
+      CumulativeStat{static_cast<uint64_t>(spatial_layer_)});
 }
 void QualityManager::setTemporalLayer(int temporal_layer) {
   if (!forced_layers_) {
     temporal_layer_ = temporal_layer;
   }
+  stats_->getNode()["qualityLayers"].insertStat("selectedTemporalLayer",
+      CumulativeStat{static_cast<uint64_t>(temporal_layer_)});
 }
 
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -139,6 +139,7 @@ bool QualityManager::isInMaxLayer() {
 
 void QualityManager::forceLayers(int spatial_layer, int temporal_layer) {
   forced_layers_ = true;
+  padding_enabled_ = false;
   spatial_layer_ = spatial_layer;
   temporal_layer_ = temporal_layer;
 }

--- a/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.h
+++ b/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.h
@@ -61,7 +61,6 @@ class RtpPaddingGeneratorHandler: public Handler {
   bool enabled_;
   bool first_packet_received_;
   MovingIntervalRateStat marker_rate_;
-  MovingIntervalRateStat padding_bitrate_;
   uint32_t rtp_header_length_;
 };
 

--- a/erizo/src/erizo/rtp/RtpRetransmissionHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpRetransmissionHandler.cpp
@@ -21,6 +21,7 @@ void RtpRetransmissionHandler::notifyUpdate() {
   auto pipeline = getContext()->getPipelineShared();
   if (pipeline && !connection_) {
     connection_ = pipeline->getService<WebRtcConnection>().get();
+    stats_ = pipeline->getService<Stats>();
   }
 }
 
@@ -62,7 +63,14 @@ void RtpRetransmissionHandler::read(Context *ctx, std::shared_ptr<dataPacket> pa
 
             if (recovered.get()) {
               RtpHeader *recovered_head = reinterpret_cast<RtpHeader*> (recovered->data);
+              uint32_t ssrc = recovered_head->getSSRC();
               if (recovered_head->getSeqNumber() == seq_num) {
+                if (!stats_->getNode()[ssrc].hasChild("rtxBitrate")) {
+                  stats_->getNode()[ssrc].insertStat("rtxBitrate",
+                      MovingIntervalRateStat{ std::chrono::milliseconds(100),
+                      30, 8.});
+                }
+                stats_->getNode()[ssrc]["rtxBitrate"] += recovered->length;
                 getContext()->fireWrite(recovered);
                 continue;
               }

--- a/erizo/src/erizo/rtp/RtpRetransmissionHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpRetransmissionHandler.cpp
@@ -63,14 +63,13 @@ void RtpRetransmissionHandler::read(Context *ctx, std::shared_ptr<dataPacket> pa
 
             if (recovered.get()) {
               RtpHeader *recovered_head = reinterpret_cast<RtpHeader*> (recovered->data);
-              uint32_t ssrc = recovered_head->getSSRC();
               if (recovered_head->getSeqNumber() == seq_num) {
-                if (!stats_->getNode()[ssrc].hasChild("rtxBitrate")) {
-                  stats_->getNode()[ssrc].insertStat("rtxBitrate",
-                      MovingIntervalRateStat{ std::chrono::milliseconds(100),
+                if (!stats_->getNode()["total"].hasChild("rtxBitrate")) {
+                  stats_->getNode()["total"].insertStat("rtxBitrate",
+                      MovingIntervalRateStat{std::chrono::milliseconds(100),
                       30, 8.});
                 }
-                stats_->getNode()[ssrc]["rtxBitrate"] += recovered->length;
+                stats_->getNode()["total"]["rtxBitrate"] += recovered->length;
                 getContext()->fireWrite(recovered);
                 continue;
               }

--- a/erizo/src/erizo/rtp/RtpRetransmissionHandler.h
+++ b/erizo/src/erizo/rtp/RtpRetransmissionHandler.h
@@ -35,6 +35,7 @@ class RtpRetransmissionHandler : public Handler {
   WebRtcConnection *connection_;
   std::vector<std::shared_ptr<dataPacket>> audio_;
   std::vector<std::shared_ptr<dataPacket>> video_;
+  std::shared_ptr<Stats> stats_;
 };
 }  // namespace erizo
 

--- a/erizo/src/test/rtp/QualityManagerTest.cpp
+++ b/erizo/src/test/rtp/QualityManagerTest.cpp
@@ -158,6 +158,7 @@ TEST_F(QualityManagerTest, shouldNotGoToHigherLayerInEarlierThanInterval) {
   const int kArbitrarySpatialLayer = 1;
   const int kArbitraryTemporalLayer = 1;
 
+  quality_manager->notifyQualityUpdate();
   quality_manager->setSpatialLayer(kBaseSpatialLayer);
   quality_manager->setTemporalLayer(kBaseTemporalLayer);
 
@@ -173,6 +174,7 @@ TEST_F(QualityManagerTest, shouldSwitchLayerImmediatelyWhenLayerIsGone) {
   const int kArbitrarySpatialLayer = 1;
   const int kArbitraryTemporalLayer = 1;
 
+  quality_manager->notifyQualityUpdate();
   quality_manager->setSpatialLayer(kArbitrarySpatialLayer);
   quality_manager->setTemporalLayer(kArbitraryTemporalLayer);
 
@@ -188,6 +190,7 @@ TEST_F(QualityManagerTest, shouldStickToForcedLayer) {
   const int kArbitrarySpatialLayer = 1;
   const int kArbitraryTemporalLayer = 1;
 
+  quality_manager->notifyQualityUpdate();
   quality_manager->forceLayers(kBaseSpatialLayer, kBaseTemporalLayer);
   quality_manager->setSpatialLayer(kArbitrarySpatialLayer);
   quality_manager->setSpatialLayer(kArbitraryTemporalLayer);


### PR DESCRIPTION
**Description**

Added more stats:
- rtxBitrate: Bitrate generated by erizo retransmissions to subscribers
- paddingBitrate: The bitrate generated by padding in simucast
- selected[Temporal | Spatial]Layer
- maxActive[Temporal | Spatial]Layer

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**


[] It includes documentation for these changes in `/doc`.
