### PR TITLE
Fix - put packets in pipeline only when ready

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -412,7 +412,8 @@ int WebRtcConnection::deliverFeedback_(std::shared_ptr<dataPacket> fb_packet) {
 }
 
 void WebRtcConnection::onTransportData(std::shared_ptr<dataPacket> packet, Transport *transport) {
-  if (audio_sink_ == nullptr && video_sink_ == nullptr && fb_sink_ == nullptr) {
+  if ((audio_sink_ == nullptr && video_sink_ == nullptr && fb_sink_ == nullptr) ||
+      getCurrentState() != CONN_READY) {
     return;
   }
   if (transport->mediaType == AUDIO_TYPE) {
@@ -659,7 +660,7 @@ void WebRtcConnection::trackTransportInfo() {
 
 // changes the outgoing payload type for in the given data packet
 void WebRtcConnection::sendPacketAsync(std::shared_ptr<dataPacket> packet) {
-  if (!sending_) {
+  if (!sending_ || getCurrentState() != CONN_READY) {
     return;
   }
   auto conn_ptr = shared_from_this();


### PR DESCRIPTION
**Description**

Check if the WebRTCConnection is ready before sending packets to the pipeline

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

[] It includes documentation for these changes in `/doc`.
