### PR TITLE
Fix wrong reset in SeqNum Translator

### DIFF
--- a/erizo/src/erizo/rtp/QualityFilterHandler.cpp
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.cpp
@@ -205,5 +205,6 @@ void QualityFilterHandler::notifyUpdate() {
 
   video_sink_ssrc_ = connection_->getVideoSinkSSRC();
   video_source_ssrc_ = connection_->getVideoSourceSSRC();
+  initialized_ = true;
 }
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.cpp
@@ -14,7 +14,6 @@ DEFINE_LOGGER(RtpPaddingGeneratorHandler, "rtp.RtpPaddingGeneratorHandler");
 constexpr duration kStatsPeriod = std::chrono::milliseconds(100);
 constexpr uint8_t kMaxPaddingSize = 255;
 constexpr uint64_t kMinMarkerRate = 3;
-constexpr uint8_t kMaxFractionLostAllowed = .05 * 255;  // 5% of packet losts
 constexpr uint64_t kInitialBitrate = 300000;
 
 RtpPaddingGeneratorHandler::RtpPaddingGeneratorHandler(std::shared_ptr<erizo::Clock> the_clock) :

--- a/erizo/src/erizo/rtp/SequenceNumberTranslator.h
+++ b/erizo/src/erizo/rtp/SequenceNumberTranslator.h
@@ -43,13 +43,14 @@ class SequenceNumberTranslator: public Service, public std::enable_shared_from_t
   uint16_t fill(const uint16_t &first, const uint16_t &last);
   SequenceNumber& internalGet(uint16_t input_sequence_number);
   SequenceNumber& internalReverse(uint16_t output_sequence_number);
+  void updateLastOutputSequenceNumber(bool skip, uint16_t output_sequence_number);
 
  private:
   std::vector<SequenceNumber> in_out_buffer_;
   std::vector<SequenceNumber> out_in_buffer_;
   uint16_t first_input_sequence_number_;
   uint16_t last_input_sequence_number_;
-  uint16_t initial_output_sequence_number_;
+  uint16_t last_output_sequence_number_;
   uint16_t offset_;
   bool initialized_;
   bool reset_;


### PR DESCRIPTION
**Description**

This PR fixes cases where we are resetting the sequence number translator without having received no more than skipped packets.

It adds more tests to SequenceNumberTranslatorTest.cpp
- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.
