### PR TITLE
Fixes unit tests and bad sequence number translations

### DIFF
--- a/erizo/src/erizo/rtp/SequenceNumberTranslator.cpp
+++ b/erizo/src/erizo/rtp/SequenceNumberTranslator.cpp
@@ -71,7 +71,9 @@ SequenceNumber SequenceNumberTranslator::generate() {
 }
 
 void SequenceNumberTranslator::updateLastOutputSequenceNumber(bool skip, uint16_t output_sequence_number) {
-  if (!skip && RtpUtils::sequenceNumberLessThan(last_output_sequence_number_, output_sequence_number)) {
+  bool first_packet = !initialized_ && !(reset_ || offset_ > 0);
+  if (!skip &&
+      (RtpUtils::sequenceNumberLessThan(last_output_sequence_number_, output_sequence_number) || first_packet)) {
     last_output_sequence_number_ = output_sequence_number;
   }
 }
@@ -138,6 +140,7 @@ void SequenceNumberTranslator::reset() {
     return;
   }
   initialized_ = false;
+  reset_ = true;
   first_input_sequence_number_ = 0;
   last_input_sequence_number_ = 0;
   in_out_buffer_ = std::vector<SequenceNumber>(kMaxSequenceNumberInBuffer);


### PR DESCRIPTION
**Description**

The previous PR did not solve the issue completely and it introduce some wrong behavior in the padding generator. I fixed unit tests and the bug itself here.

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed

[] It includes documentation for these changes in `/doc`.
