### PR TITLE
Disable padding when max layer is 0/0

### DIFF
--- a/erizo/src/erizo/rtp/QualityManager.h
+++ b/erizo/src/erizo/rtp/QualityManager.h
@@ -36,6 +36,7 @@ class QualityManager: public Service, public std::enable_shared_from_this<Qualit
   uint64_t getInstantLayerBitrate(int spatial_layer, int temporal_layer);
   bool isInBaseLayer();
   bool isInMaxLayer();
+  void setPadding(bool enabled);
 
 
  private:


### PR DESCRIPTION
**Description**

Disable padding when max layer is 0/0 to avoid introducing padding when there is no simulcast/svc.
Also added a utility method to enable/disable padding
[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

[] It includes documentation for these changes in `/doc`.
