### PR TITLE
QualityManager will be disabled unless is_scalable

### DIFF
--- a/erizo/src/erizo/rtp/QualityFilterHandler.cpp
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.cpp
@@ -99,6 +99,7 @@ void QualityFilterHandler::detectVideoScalability(std::shared_ptr<dataPacket> pa
   }
   if (packet->belongsToTemporalLayer(1) || packet->belongsToSpatialLayer(1)) {
     is_scalable_ = true;
+    quality_manager_->enable();
   }
 }
 

--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -10,13 +10,27 @@ constexpr duration QualityManager::kActiveLayerInterval;
 constexpr float QualityManager::kIncreaseLayerBitrateThreshold;
 
 QualityManager::QualityManager(std::shared_ptr<Clock> the_clock)
-  : initialized_{false}, padding_enabled_{true}, forced_layers_{false},
+  : initialized_{false}, enabled_{false}, padding_enabled_{false}, forced_layers_{false},
   spatial_layer_{0}, temporal_layer_{0}, max_active_spatial_layer_{0}, max_active_temporal_layer_{0},
   current_estimated_bitrate_{0}, last_quality_check_{the_clock->now()},
   last_activity_check_{the_clock->now()}, clock_{the_clock} {}
 
+void QualityManager::enable() {
+  ELOG_DEBUG("message: Enabling QualityManager");
+  enabled_ = true;
+  setPadding(true);
+}
+
+void QualityManager::disable() {
+  enabled_ = false;
+  setPadding(false);
+}
 
 void QualityManager::notifyQualityUpdate() {
+  if (!enabled_) {
+    return;
+  }
+
   if (!initialized_) {
     auto pipeline = getContext()->getPipelineShared();
     if (!pipeline) {
@@ -31,6 +45,7 @@ void QualityManager::notifyQualityUpdate() {
     }
     initialized_ = true;
   }
+
   if (forced_layers_) {
     return;
   }
@@ -41,9 +56,6 @@ void QualityManager::notifyQualityUpdate() {
 
   if (now - last_activity_check_ > kActiveLayerInterval) {
     calculateMaxActiveLayer();
-    if (max_active_spatial_layer_ == 0 && max_active_temporal_layer_ == 0 && padding_enabled_) {
-      setPadding(false);
-    }
     last_activity_check_ = now;
   }
 

--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -22,6 +22,7 @@ void QualityManager::enable() {
 }
 
 void QualityManager::disable() {
+  ELOG_DEBUG("message: Disabling QualityManager");
   enabled_ = false;
   setPadding(false);
 }

--- a/erizo/src/erizo/rtp/QualityManager.h
+++ b/erizo/src/erizo/rtp/QualityManager.h
@@ -18,6 +18,8 @@ class QualityManager: public Service, public std::enable_shared_from_this<Qualit
 
  public:
   explicit QualityManager(std::shared_ptr<Clock> the_clock = std::make_shared<SteadyClock>());
+  void enable();
+  void disable();
 
   virtual  int getSpatialLayer() const { return spatial_layer_; }
   virtual  int getTemporalLayer() const { return temporal_layer_; }
@@ -41,6 +43,7 @@ class QualityManager: public Service, public std::enable_shared_from_this<Qualit
 
  private:
   bool initialized_;
+  bool enabled_;
   bool padding_enabled_;
   bool forced_layers_;
   int spatial_layer_;

--- a/erizo/src/test/rtp/QualityManagerTest.cpp
+++ b/erizo/src/test/rtp/QualityManagerTest.cpp
@@ -48,9 +48,12 @@ class QualityManagerTest : public erizo::HandlerTest{
  protected:
   void setHandler() {
     quality_manager = std::make_shared<QualityManager>(simulated_clock);
-    quality_manager->enable();
     pipeline->addService(quality_manager);
     generateLayersWithGrowingBitrate(kArbitraryNumberOfSpatialLayers, kArbitraryNumberOfTemporalLayers);
+  }
+
+  void afterPipelineSetup() {
+    quality_manager->enable();
   }
 
   void generateLayersWithGrowingBitrate(int spatial_layers, int temporal_layers) {

--- a/erizo/src/test/rtp/QualityManagerTest.cpp
+++ b/erizo/src/test/rtp/QualityManagerTest.cpp
@@ -48,6 +48,7 @@ class QualityManagerTest : public erizo::HandlerTest{
  protected:
   void setHandler() {
     quality_manager = std::make_shared<QualityManager>(simulated_clock);
+    quality_manager->enable();
     pipeline->addService(quality_manager);
     generateLayersWithGrowingBitrate(kArbitraryNumberOfSpatialLayers, kArbitraryNumberOfTemporalLayers);
   }

--- a/erizo/src/test/utils/Tools.h
+++ b/erizo/src/test/utils/Tools.h
@@ -164,6 +164,7 @@ class BaseHandlerTest  {
   BaseHandlerTest() {}
 
   virtual void setHandler() = 0;
+  virtual void afterPipelineSetup() {}
 
   virtual void internalSetUp() {
     simulated_clock = std::make_shared<erizo::SimulatedClock>();
@@ -198,6 +199,7 @@ class BaseHandlerTest  {
     setHandler();
     pipeline->addBack(reader);
     pipeline->finalize();
+    afterPipelineSetup();
   }
 
   virtual void executeTasksInNextMs(int time) {


### PR DESCRIPTION
**Description**

The `QualityManager` will now be disabled by default (and padding also), until `QualityFilterHandler` detects the first packet of an scalable layer. 

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

[] It includes documentation for these changes in `/doc`.
