### PR TITLE
Copying nuve and erizoClient dist files in initBasicExample script

### DIFF
--- a/scripts/initBasicExample.sh
+++ b/scripts/initBasicExample.sh
@@ -9,6 +9,9 @@ CURRENT_DIR=`pwd`
 NVM_CHECK="$PATHNAME"/checkNvm.sh
 EXTRAS=$ROOT/extras
 
+cp $ROOT/erizo_controller/erizoClient/dist/erizo.js $EXTRAS/basic_example/public/
+cp $ROOT/nuve/nuveClient/dist/nuve.js $EXTRAS/basic_example/
+
 . $NVM_CHECK
 
 nvm use

--- a/scripts/initLicode.sh
+++ b/scripts/initLicode.sh
@@ -27,7 +27,4 @@ cd $ROOT/erizo_controller
 ./initErizo_controller.sh
 ./initErizo_agent.sh
 
-cp $ROOT/erizo_controller/erizoClient/dist/erizo.js $EXTRAS/basic_example/public/
-cp $ROOT/nuve/nuveClient/dist/nuve.js $EXTRAS/basic_example/
-
-echo [licode] Done, run basic_example/basicServer.js
+echo [licode] Done, run ./scripts/initBasicExample.sh


### PR DESCRIPTION
**Description**

Now nuve and erizoClient dist scripts are copied to basic example when running its initialization script

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

none

[] It includes documentation for these changes in `/doc`.
