### PR TITLE
Fix PLI sending rates

### DIFF
--- a/erizo/src/erizo/rtp/PliPacerHandler.h
+++ b/erizo/src/erizo/rtp/PliPacerHandler.h
@@ -16,7 +16,7 @@ class PliPacerHandler: public Handler, public std::enable_shared_from_this<PliPa
 
  public:
   static constexpr duration kMinPLIPeriod = std::chrono::milliseconds(200);
-  static constexpr duration kKeyframeTimeout = std::chrono::seconds(4);
+  static constexpr duration kKeyframeTimeout = std::chrono::seconds(10);
 
  public:
   explicit PliPacerHandler(std::shared_ptr<erizo::Clock> the_clock = std::make_shared<SteadyClock>());

--- a/erizo/src/erizo/rtp/QualityFilterHandler.cpp
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.cpp
@@ -51,8 +51,6 @@ void QualityFilterHandler::checkLayers() {
   int new_spatial_layer = quality_manager_->getSpatialLayer();
   if (new_spatial_layer != target_spatial_layer_) {
     sendPLI();
-    sendPLI();
-    sendPLI();
     future_spatial_layer_ = new_spatial_layer;
     changing_spatial_layer_ = true;
     time_change_started_ = clock::now();

--- a/erizo/src/test/rtp/PliPacerHandlerTest.cpp
+++ b/erizo/src/test/rtp/PliPacerHandlerTest.cpp
@@ -1,12 +1,11 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <queue>
-
 #include <rtp/PliPacerHandler.h>
 #include <rtp/RtpHeaders.h>
 #include <MediaDefinitions.h>
 #include <WebRtcConnection.h>
 
+#include <queue>
 #include <string>
 #include <vector>
 
@@ -135,7 +134,7 @@ TEST_F(PliPacerHandlerTest, shouldNotSendMultiplePLIsWhenDisabled) {
 TEST_F(PliPacerHandlerTest, shouldSendFIRWhenKeyframesAreNotReceivedInALongPeriod) {
     auto pli1 = erizo::PacketTools::createPLI();
 
-    EXPECT_CALL(*writer.get(), write(_, _)).With(Args<1>(erizo::IsPLI())).Times(20);
+    EXPECT_CALL(*writer.get(), write(_, _)).With(Args<1>(erizo::IsPLI())).Times(50);
     EXPECT_CALL(*writer.get(), write(_, _)).With(Args<1>(erizo::IsFIR())).Times(3);
     pipeline->write(pli1);
 


### PR DESCRIPTION
**Description**

Increases the timeout for sending PLIs and it avoids sending multiple PLIs in the Quality Filter because we now rely on the PLI pacer.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

None.

[] It includes documentation for these changes in `/doc`.
