### PR TITLE
Fix a crash when deleting WebRtcConnection

### DIFF
--- a/erizo/src/erizo/DtlsTransport.cpp
+++ b/erizo/src/erizo/DtlsTransport.cpp
@@ -27,12 +27,10 @@ Resender::Resender(DtlsTransport* transport, dtls::DtlsSocketContext* ctx)
 }
 
 Resender::~Resender() {
-  ELOG_DEBUG("message: ~Resender");
   cancel();
 }
 
 void Resender::cancel() {
-  ELOG_DEBUG("message: cancelled");
   transport_->getWorker()->unschedule(scheduled_task_);
 }
 
@@ -111,11 +109,9 @@ DtlsTransport::DtlsTransport(MediaType med, const std::string &transport_name, c
   }
 
 DtlsTransport::~DtlsTransport() {
-  ELOG_DEBUG("%s message: destroying", toLog());
   if (this->state_ != TRANSPORT_FINISHED) {
     this->close();
   }
-  ELOG_DEBUG("%s message: destroyed", toLog());
 }
 
 void DtlsTransport::start() {
@@ -128,8 +124,21 @@ void DtlsTransport::close() {
   ELOG_DEBUG("%s message: closing", toLog());
   running_ = false;
   nice_->close();
+  if (dtlsRtp) {
+    dtlsRtp->close();
+  }
+  if (dtlsRtcp) {
+    dtlsRtcp->close();
+  }
+  if (rtp_resender_) {
+    rtp_resender_->cancel();
+  }
+  if (rtcp_resender_) {
+    rtcp_resender_->cancel();
+  }
   this->state_ = TRANSPORT_FINISHED;
   ELOG_DEBUG("%s message: closed", toLog());
+
 }
 
 void DtlsTransport::onNiceData(packetPtr packet) {

--- a/erizo/src/erizo/DtlsTransport.cpp
+++ b/erizo/src/erizo/DtlsTransport.cpp
@@ -138,7 +138,6 @@ void DtlsTransport::close() {
   }
   this->state_ = TRANSPORT_FINISHED;
   ELOG_DEBUG("%s message: closed", toLog());
-
 }
 
 void DtlsTransport::onNiceData(packetPtr packet) {

--- a/erizo/src/erizo/NiceConnection.cpp
+++ b/erizo/src/erizo/NiceConnection.cpp
@@ -77,9 +77,7 @@ NiceConnection::NiceConnection(boost::shared_ptr<LibNiceInterface> libnice, Medi
   }
 
 NiceConnection::~NiceConnection() {
-  ELOG_DEBUG("%s message: destroying", toLog());
   this->close();
-  ELOG_DEBUG("%s message: destroyed", toLog());
 }
 
 void NiceConnection::close() {

--- a/erizo/src/erizo/OneToManyProcessor.cpp
+++ b/erizo/src/erizo/OneToManyProcessor.cpp
@@ -114,6 +114,11 @@ namespace erizo {
     if (publisher.get()) {
       publisher->close();
     }
+    std::shared_ptr<WebRtcConnection> temp_publisher = std::dynamic_pointer_cast<WebRtcConnection>(publisher);
+    if (temp_publisher) {
+      temp_publisher->getWorker()->task([temp_publisher] {
+      });
+    }
     publisher.reset();
     boost::unique_lock<boost::mutex> lock(monitor_mutex_);
     std::map<std::string, std::shared_ptr<MediaSink>>::iterator it = subscribers.begin();

--- a/erizo/src/erizo/OneToManyProcessor.h
+++ b/erizo/src/erizo/OneToManyProcessor.h
@@ -55,6 +55,7 @@ class OneToManyProcessor : public MediaSink, public FeedbackSink {
   int deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) override;
   int deliverVideoData_(std::shared_ptr<dataPacket> video_packet) override;
   int deliverFeedback_(std::shared_ptr<dataPacket> fb_packet) override;
+  void deleteAsync(std::shared_ptr<WebRtcConnection> connection);
   void closeAll();
 };
 

--- a/erizo/src/erizo/OneToManyProcessor.h
+++ b/erizo/src/erizo/OneToManyProcessor.h
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <string>
+#include <future>  // NOLINT
 
 #include "./MediaDefinitions.h"
 #include "media/ExternalOutput.h"
@@ -46,7 +47,7 @@ class OneToManyProcessor : public MediaSink, public FeedbackSink {
   */
   void removeSubscriber(const std::string& peerId);
 
-  void close() override {}
+  void close() override;
 
  private:
   typedef std::shared_ptr<MediaSink> sink_ptr;
@@ -55,7 +56,7 @@ class OneToManyProcessor : public MediaSink, public FeedbackSink {
   int deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) override;
   int deliverVideoData_(std::shared_ptr<dataPacket> video_packet) override;
   int deliverFeedback_(std::shared_ptr<dataPacket> fb_packet) override;
-  void deleteAsync(std::shared_ptr<WebRtcConnection> connection);
+  std::future<void> deleteAsync(std::shared_ptr<WebRtcConnection> connection);
   void closeAll();
 };
 

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -80,6 +80,9 @@ WebRtcConnection::~WebRtcConnection() {
 
 void WebRtcConnection::close() {
   ELOG_DEBUG("%s message:Close called", toLog());
+  if (!sending_) {
+    return;
+  }
   sending_ = false;
   if (videoTransport_.get()) {
     videoTransport_->close();

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -72,6 +72,14 @@ WebRtcConnection::WebRtcConnection(std::shared_ptr<Worker> worker, const std::st
 
 WebRtcConnection::~WebRtcConnection() {
   ELOG_DEBUG("%s message:Destructor called", toLog());
+  if (sending_) {
+    close();
+  }
+  ELOG_DEBUG("%s message: Destructor ended", toLog());
+}
+
+void WebRtcConnection::close() {
+  ELOG_DEBUG("%s message:Close called", toLog());
   sending_ = false;
   if (videoTransport_.get()) {
     videoTransport_->close();
@@ -86,10 +94,7 @@ WebRtcConnection::~WebRtcConnection() {
   video_sink_ = nullptr;
   audio_sink_ = nullptr;
   fb_sink_ = nullptr;
-  ELOG_DEBUG("%s message: Destructor ended", toLog());
-}
-
-void WebRtcConnection::close() {
+  ELOG_DEBUG("%s message: Close ended", toLog());
 }
 
 bool WebRtcConnection::init() {

--- a/erizo/src/erizo/dtls/DtlsClient.cpp
+++ b/erizo/src/erizo/dtls/DtlsClient.cpp
@@ -250,11 +250,15 @@ int createCert(const std::string& pAor, int expireDays, int keyLen, X509*& outCe
     }
 
     DtlsSocketContext::~DtlsSocketContext() {
+      mSocket->close();
       delete mSocket;
       mSocket = NULL;
       SSL_CTX_free(mContext);
     }
 
+    void DtlsSocketContext::close() {
+      mSocket->close();
+    }
 
     void DtlsSocketContext::Init() {
       if (DtlsSocketContext::mCert == NULL) {

--- a/erizo/src/erizo/dtls/DtlsSocket.cpp
+++ b/erizo/src/erizo/dtls/DtlsSocket.cpp
@@ -61,8 +61,10 @@ DtlsSocket::DtlsSocket(DtlsSocketContext* socketContext, enum SocketType type):
 }
 
 DtlsSocket::~DtlsSocket() {
-  ELOG_DEBUG("Deleting Socket");
+  close();
+}
 
+void DtlsSocket::close() {
   // Properly shutdown the socket and free it - note: this also free's the BIO's
   if (mSsl != NULL) {
     ELOG_DEBUG("SSL Shutdown");

--- a/erizo/src/erizo/dtls/DtlsSocket.h
+++ b/erizo/src/erizo/dtls/DtlsSocket.h
@@ -75,6 +75,8 @@ class DtlsSocket {
   DtlsSocket(DtlsSocketContext* socketContext, enum SocketType type);
   ~DtlsSocket();
 
+  void close();
+
   // Inspects packet to see if it's a DTLS packet, if so continue processing
   bool handlePacketMaybe(const unsigned char* bytes, unsigned int len);
 
@@ -143,7 +145,7 @@ class DtlsSocketContext {
   DtlsSocketContext();
   virtual ~DtlsSocketContext();
 
-
+  void close();
 
   void start();
   void read(const unsigned char* data, unsigned int len);

--- a/erizoAPI/OneToManyProcessor.cc
+++ b/erizoAPI/OneToManyProcessor.cc
@@ -21,6 +21,7 @@ class AsyncDeleter : public Nan::AsyncWorker {
       }
     ~AsyncDeleter() {}
     void Execute() {
+      otmToDelete_->close();
       delete otmToDelete_;
     }
     void HandleOKCallback() {


### PR DESCRIPTION
**Description**

Fix some crashes when deleting WebRtcConnections. It uses WebRtcConnection's thread to close it.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.
