### PR TITLE
Avoid using java in nuveClient installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ addons:
       - libboost-thread-dev
       - libboost-system-dev
       - liblog4cxx10-dev
-      - openjdk-6-jre
       - curl
       - libboost-test-dev
       - yasm

--- a/erizo/src/erizo/rtp/RtpSlideShowHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpSlideShowHandler.cpp
@@ -169,7 +169,9 @@ bool RtpSlideShowHandler::isVP9Keyframe(std::shared_ptr<dataPacket> packet) {
 void RtpSlideShowHandler::storeKeyframePacket(std::shared_ptr<dataPacket> packet) {
   RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
   uint16_t index = rtp_header->getSeqNumber() - first_keyframe_seq_num_;
-  keyframe_buffer_[index] = packet;
+  if (index < keyframe_buffer_.size()) {
+    keyframe_buffer_[index] = packet;
+  }
 }
 
 void RtpSlideShowHandler::setSlideShowMode(bool active) {

--- a/nuve/installNuve.sh
+++ b/nuve/installNuve.sh
@@ -27,7 +27,8 @@ then
 fi
 
 nvm use
-npm install --loglevel error amqp express mongojs$MONGO_VERSION aws-sdk log4js node-getopt body-parser google-closure-compiler-js
+npm install --loglevel error amqp express mongojs$MONGO_VERSION aws-sdk log4js node-getopt body-parser
+npm install --loglevel error -g google-closure-compiler-js
 echo [nuve] Done, node_modules installed
 
 cd ../nuveClient/tools

--- a/nuve/installNuve.sh
+++ b/nuve/installNuve.sh
@@ -27,7 +27,7 @@ then
 fi
 
 nvm use
-npm install --loglevel error amqp express mongojs$MONGO_VERSION aws-sdk log4js node-getopt body-parser
+npm install --loglevel error amqp express mongojs$MONGO_VERSION aws-sdk log4js node-getopt body-parser google-closure-compiler-js
 echo [nuve] Done, node_modules installed
 
 cd ../nuveClient/tools

--- a/nuve/nuveClient/tools/compile.sh
+++ b/nuve/nuveClient/tools/compile.sh
@@ -5,6 +5,6 @@ set -e
 mkdir ../dist || true
 mkdir ../build || true
 
-java -jar compiler.jar --js ../src/hmac-sha1.js --js ../src/N.js --js ../src/N.Base64.js --js ../src/N.API.js --js_output_file ../build/nuve.js
+google-closure-compiler-js ../src/hmac-sha1.js ../src/N.js ../src/N.Base64.js ../src/N.API.js > ../build/nuve.js
 
 ./compileDist.sh

--- a/nuve/nuveClient/tools/compileDist.sh
+++ b/nuve/nuveClient/tools/compileDist.sh
@@ -5,7 +5,7 @@ set -e
 mkdir ../dist || true
 mkdir ../build || true
 
-java -jar compiler.jar --js ../lib/xmlhttprequest.js --js_output_file ../dist/xmlhttprequest.js
+google-closure-compiler-js ../lib/xmlhttprequest.js > ../dist/xmlhttprequest.js
 
 TARGET=../dist/nuve.js
 


### PR DESCRIPTION
**Description**

Fixes an issue when installing NuveClient because we still used Java, which is a removed dependency.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.
