### PR TITLE
fix stream status after successfuly adding external input

### DIFF
--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -538,6 +538,7 @@ var listen = function () {
                                             video: options.video,
                                             data: options.data,
                                             attributes: options.attributes});
+                        st.status = PUBLISHER_READY;
                         socket.streams.push(id);
                         socket.room.streams[id] = st;
                         callback(id);


### PR DESCRIPTION
Stream status was not set to PUBLISHER_READY causing erizo controller not include the stream on the stream list after a room connection, causing clients not being able to subscribe if they weren't already on the room.

[] It needs and includes Unit Tests

It needs but doesn't include, couldn't find erizo controller tests checking PUBLISHER_READY status in other scenarios, I guess it's the way the RPC calls are tested that makes it complex to test?. Also would be helpful a mini-guide about how to run the full test suite, or just some components. I am running them as I figured out but I am sure there is better way to do it.

No public API changes.

[] It includes documentation for these changes in `/doc`.
