### PR TITLE
candidates won’t be added when Firefox in audio publish only.

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -293,7 +293,7 @@ bool WebRtcConnection::addRemoteCandidate(const std::string &mid, int mLineIndex
   // TODO(pedro) Check type of transport.
   ELOG_DEBUG("%s message: Adding remote Candidate, candidate: %s, mid: %s, sdpMLine: %d",
               toLog(), sdp.c_str(), mid.c_str(), mLineIndex);
-  if (videoTransport_ == nullptr) {
+  if (videoTransport_ == nullptr && audioTransport_ == nullptr) {
     ELOG_WARN("%s message: addRemoteCandidate on NULL transport", toLog());
     return false;
   }


### PR DESCRIPTION
**Description**

testing the current branch, I noticed that firefox won't publish in audio only mode. digging into the code i found this "return" statement if the video transport wasn't specified. 
Resolved adding another check but don't know if it's ok.
Tell me what do you think.

[] It needs and includes Unit Tests

Probably needs but doesn't include

[] It includes documentation for these changes in `/doc`.
