### PR TITLE
Revert libnice to version 0.1.4 temporarily

### DIFF
--- a/erizo/src/erizo/lib/LibNiceInterfaceImpl.cpp
+++ b/erizo/src/erizo/lib/LibNiceInterfaceImpl.cpp
@@ -63,13 +63,7 @@ namespace erizo {
   }
   int LibNiceInterfaceImpl::NiceAgentSend(NiceAgent* agent, unsigned int stream_id, unsigned int component_id,
       unsigned int len, const char* buf) {
-    GError *error = NULL;
-    GOutputVector vec[1] = {
-        { buf, len }
-    };
-    NiceOutputMessage message = {vec, G_N_ELEMENTS(vec)};
-
-    return nice_agent_send_messages_nonblocking(agent, stream_id, component_id, &message, 1, NULL, &error);
+    return nice_agent_send(agent, stream_id, component_id, len, buf);
   }
 
 }  // namespace erizo

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -112,10 +112,11 @@ install_openssl(){
 install_libnice(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    if [ ! -f ./libnice-0.1.7.tar.gz ]; then
-      curl -O https://nice.freedesktop.org/releases/libnice-0.1.7.tar.gz
-      tar -zxvf libnice-0.1.7.tar.gz
-      cd libnice-0.1.7
+    if [ ! -f ./libnice-0.1.4.tar.gz ]; then
+      curl -O https://nice.freedesktop.org/releases/libnice-0.1.4.tar.gz
+      tar -zxvf libnice-0.1.4.tar.gz
+      cd libnice-0.1.4
+      patch -R ./agent/conncheck.c < $PATHNAME/libnice-014.patch0
       ./configure --prefix=$PREFIX_DIR
       make -s V=0
       make install

--- a/scripts/libnice-014.patch0
+++ b/scripts/libnice-014.patch0
@@ -1,0 +1,10 @@
+--- conncheck.c	2014-01-20 08:51:48.535625502 +0100
++++ agent/conncheck.c	2013-01-09 22:35:25.000000000 +0100
+@@ -2824,7 +2824,6 @@
+
+   if (agent->compatibility == NICE_COMPATIBILITY_GOOGLE ||
+       agent->compatibility == NICE_COMPATIBILITY_MSN ||
+-      agent->compatibility == NICE_COMPATIBILITY_RFC5245 ||
+       agent->compatibility == NICE_COMPATIBILITY_OC2007) {
+     /* We need to find which local candidate was used */
+     for (i = component->remote_candidates;


### PR DESCRIPTION
**Description**

We've found more ICE failures happening with v0.1.7 so we'll revert version 0.1.4 temporarily while we discuss a better approach for handling ICE (update to latest versions or even switch to another library).

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.
