### PR TITLE
Revert to libnice 0.1.4 also in Mac and Travis

### DIFF
--- a/scripts/installMacDeps.sh
+++ b/scripts/installMacDeps.sh
@@ -135,10 +135,11 @@ install_openssl(){
 install_libnice(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O https://nice.freedesktop.org/releases/libnice-0.1.7.tar.gz
-    tar -zxvf libnice-0.1.7.tar.gz
-    cd libnice-0.1.7
+    curl -O https://nice.freedesktop.org/releases/libnice-0.1.4.tar.gz
+    tar -zxvf libnice-0.1.4.tar.gz
+    cd libnice-0.1.4
     check_result $?
+    patch -R ./agent/conncheck.c < $PATHNAME/libnice-014.patch0
     ./configure --prefix=$PREFIX_DIR && make -s V=0 && make install
     check_result $?
     cd $CURRENT_DIR

--- a/scripts/travisInstallDeps.sh
+++ b/scripts/travisInstallDeps.sh
@@ -92,10 +92,11 @@ install_openssl(){
 install_libnice(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    if [ ! -f ./libnice-0.1.7.tar.gz ]; then
-      curl -O https://nice.freedesktop.org/releases/libnice-0.1.7.tar.gz
-      tar -zxvf libnice-0.1.7.tar.gz
-      cd libnice-0.1.7
+    if [ ! -f ./libnice-0.1.4.tar.gz ]; then
+      curl -O https://nice.freedesktop.org/releases/libnice-0.1.4.tar.gz
+      tar -zxvf libnice-0.1.4.tar.gz
+      cd libnice-0.1.4
+      patch -R ./agent/conncheck.c < $PATHNAME/libnice-014.patch0
       ./configure --prefix=$PREFIX_DIR
       make -s V=0
       make install


### PR DESCRIPTION
**Description**

Also revert to libnice 0.1.4 in Mac and Travis.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.
