### PR TITLE
fixed MovingAverageStat when value < old_value

### DIFF
--- a/erizo/src/erizo/stats/StatNode.cpp
+++ b/erizo/src/erizo/stats/StatNode.cpp
@@ -1,5 +1,6 @@
 #include "stats/StatNode.h"
 
+#include <cmath>
 #include <sstream>
 #include <string>
 #include <memory>
@@ -249,8 +250,7 @@ StatNode& MovingAverageStat::operator+=(uint64_t value) {
 }
 
 uint64_t MovingAverageStat::value() {
-  // without +0.1 4.999999 will be cast to 4
-  return static_cast<uint64_t>(current_average_ + 0.1);
+  return static_cast<uint64_t>(std::round(current_average_));
 }
 
 uint64_t MovingAverageStat::value(uint32_t sample_number) {

--- a/erizo/src/erizo/stats/StatNode.cpp
+++ b/erizo/src/erizo/stats/StatNode.cpp
@@ -249,7 +249,8 @@ StatNode& MovingAverageStat::operator+=(uint64_t value) {
 }
 
 uint64_t MovingAverageStat::value() {
-  return static_cast<uint64_t>(current_average_);
+  // without +0.1 4.999999 will be cast to 4
+  return static_cast<uint64_t>(current_average_ + 0.1);
 }
 
 uint64_t MovingAverageStat::value(uint32_t sample_number) {
@@ -266,7 +267,11 @@ void MovingAverageStat::add(uint64_t value) {
       / (next_sample_position_ + 1);
   } else {
     uint64_t old_value = (*sample_vector_.get())[next_sample_position_ % window_size_];
-    current_average_ = current_average_ + static_cast<double>(value - old_value) / window_size_;
+    if (value > old_value) {
+      current_average_ = current_average_ + static_cast<double>(value - old_value) / window_size_;
+    } else {
+      current_average_ = current_average_ - static_cast<double>(old_value - value) / window_size_;
+    }
   }
 
   (*sample_vector_.get())[next_sample_position_ % window_size_] = value;

--- a/erizo/src/test/stats/MovingAverageStatTest.cpp
+++ b/erizo/src/test/stats/MovingAverageStatTest.cpp
@@ -42,6 +42,14 @@ TEST_F(MovingAverageStatTest, shouldCalculateAverageForLessSamplesThanWindowSize
   EXPECT_EQ(moving_average_stat.value(), calculated_average);
 }
 
+TEST_F(MovingAverageStatTest, shouldCalculateAverageForLessSamplesThanWindowSize2) {
+  moving_average_stat+=kArbitraryNumberToAdd;
+  moving_average_stat+=kArbitraryNumberToAdd - 1;
+  moving_average_stat+=kArbitraryNumberToAdd - 2;
+  uint32_t calculated_average = (3*kArbitraryNumberToAdd - 3)/3;
+  EXPECT_EQ(moving_average_stat.value(), calculated_average);
+}
+
 TEST_F(MovingAverageStatTest, shouldCalculateAverageForValuesInWindow) {
   for (uint i = 0; i < kArbitraryWindowSize; i++) {
     moving_average_stat+=kArbitraryNumberToAdd;
@@ -52,10 +60,28 @@ TEST_F(MovingAverageStatTest, shouldCalculateAverageForValuesInWindow) {
   EXPECT_EQ(moving_average_stat.value(), kArbitraryNumberToAdd + 1);
 }
 
+TEST_F(MovingAverageStatTest, shouldCalculateAverageForValuesInWindow2) {
+  for (uint i = 0; i < kArbitraryWindowSize; i++) {
+    moving_average_stat+=kArbitraryNumberToAdd;
+  }
+  for (uint i = 0; i < kArbitraryWindowSize; i++) {
+    moving_average_stat+=kArbitraryNumberToAdd - 1;
+  }
+  EXPECT_EQ(moving_average_stat.value(), kArbitraryNumberToAdd - 1);
+}
+
 TEST_F(MovingAverageStatTest, shouldCalculateAverageForGivenNumberOfSamples) {
   for (uint i = 0; i < kArbitraryWindowSize; i++) {
     moving_average_stat+=i;
   }
-  EXPECT_EQ(moving_average_stat.value(1), 4u);
-  EXPECT_EQ(moving_average_stat.value(2), uint((4 + 3) / 2));
+  EXPECT_EQ(moving_average_stat.value(1), kArbitraryWindowSize - 1);
+  EXPECT_EQ(moving_average_stat.value(2), uint((kArbitraryWindowSize * 2 - 3) / 2));
+}
+
+TEST_F(MovingAverageStatTest, shouldCalculateAverageForGivenNumberOfSamples2) {
+  for (uint i = kArbitraryWindowSize; i > 0; i--) {
+    moving_average_stat+=i;
+  }
+  EXPECT_EQ(moving_average_stat.value(1), 1u);
+  EXPECT_EQ(moving_average_stat.value(2), uint((1 + 2) / 2));
 }


### PR DESCRIPTION
- fixed MovingAverageStat when value < old_value
- +0.1 when casting _current_average to uint64, to avoid 3.999... -> 3
- added some test cases for MovingAverageStat
