### PR TITLE
Fix ExternalOutput with Simulcast

### DIFF
--- a/erizo/src/erizo/media/ExternalOutput.cpp
+++ b/erizo/src/erizo/media/ExternalOutput.cpp
@@ -334,6 +334,10 @@ int ExternalOutput::deliverAudioData_(std::shared_ptr<dataPacket> audio_packet) 
 
 int ExternalOutput::deliverVideoData_(std::shared_ptr<dataPacket> video_packet) {
   std::shared_ptr<dataPacket> copied_packet = std::make_shared<dataPacket>(*video_packet);
+  // TODO(javierc): We should support higher layers, but it requires having an entire pipeline at this point
+  if (!video_packet->belongsToSpatialLayer(0)) {
+    return 0;
+  }
   if (videoSourceSsrc_ == 0) {
     RtpHeader* h = reinterpret_cast<RtpHeader*>(copied_packet->data);
     videoSourceSsrc_ = h->getSSRC();


### PR DESCRIPTION
**Description**

Fix ExternalOutput with Simulcast. It now gets the lower quality layer, which is sub-optimal. But having a better solution would involve:

- Implement a pipeline in ExternalOutput to detect quality layers and filter packets.
- Connect two ErizoJS (one acting as a pure MCU and another recording the stream).

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.
