### PR TITLE
Fix/padding removal handler

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -277,8 +277,8 @@ void WebRtcConnection::initializePipeline() {
   pipeline_->addFront(RtpPaddingGeneratorHandler());
   pipeline_->addFront(PliPacerHandler());
   pipeline_->addFront(BandwidthEstimationHandler());
-  pipeline_->addFront(RtcpFeedbackGenerationHandler());
   pipeline_->addFront(RtpPaddingRemovalHandler());
+  pipeline_->addFront(RtcpFeedbackGenerationHandler());
   pipeline_->addFront(RtpRetransmissionHandler());
   pipeline_->addFront(SRPacketHandler());
   pipeline_->addFront(SenderBandwidthEstimationHandler());

--- a/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.cpp
@@ -18,14 +18,24 @@ void RtpPaddingRemovalHandler::disable() {
 
 void RtpPaddingRemovalHandler::read(Context *ctx, std::shared_ptr<dataPacket> packet) {
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
+  RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
 
   if (!chead->isRtcp() && enabled_ && packet->type == VIDEO_PACKET) {
-    if (!removePaddingBytes(packet)) {
+    uint32_t ssrc = rtp_header->getSSRC();
+    auto translator_it = translator_map_.find(ssrc);
+    std::shared_ptr<SequenceNumberTranslator> translator;
+    if (translator_it != translator_map_.end()) {
+      translator = translator_it->second;
+    } else {
+      ELOG_DEBUG("message: no Translator found creating a new one, ssrc: %u", ssrc);
+      translator = std::make_shared<SequenceNumberTranslator>();
+      translator_map_[ssrc] = translator;
+    }
+    if (!removePaddingBytes(packet, translator)) {
       return;
     }
-    RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
     uint16_t sequence_number = rtp_header->getSeqNumber();
-    SequenceNumber sequence_number_info = translator_.get(sequence_number, false);
+    SequenceNumber sequence_number_info = translator->get(sequence_number, false);
 
     if (sequence_number_info.type != SequenceNumberType::Valid) {
       return;
@@ -39,14 +49,15 @@ void RtpPaddingRemovalHandler::write(Context *ctx, std::shared_ptr<dataPacket> p
   ctx->fireWrite(packet);
 }
 
-bool RtpPaddingRemovalHandler::removePaddingBytes(std::shared_ptr<dataPacket> packet) {
+bool RtpPaddingRemovalHandler::removePaddingBytes(std::shared_ptr<dataPacket> packet,
+    std::shared_ptr<SequenceNumberTranslator> translator) {
   RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
   int header_length = rtp_header->getHeaderLength();
 
   int padding_length = RtpUtils::getPaddingLength(packet);
   if (padding_length + header_length == packet->length) {
     uint16_t sequence_number = rtp_header->getSeqNumber();
-    translator_.get(sequence_number, true);
+    translator->get(sequence_number, true);
     return false;
   }
   packet->length -= padding_length;

--- a/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.cpp
@@ -21,6 +21,14 @@ void RtpPaddingRemovalHandler::read(Context *ctx, std::shared_ptr<dataPacket> pa
 
   if (!chead->isRtcp() && enabled_ && packet->type == VIDEO_PACKET) {
     removePaddingBytes(packet);
+    RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
+    uint16_t sequence_number = rtp_header->getSeqNumber();
+    SequenceNumber sequence_number_info = translator_.get(sequence_number, false);
+
+    if (sequence_number_info.type != SequenceNumberType::Valid) {
+      return;
+    }
+    rtp_header->setSeqNumber(sequence_number_info.output);
   }
   ctx->fireRead(packet);
 }
@@ -32,19 +40,14 @@ void RtpPaddingRemovalHandler::write(Context *ctx, std::shared_ptr<dataPacket> p
 void RtpPaddingRemovalHandler::removePaddingBytes(std::shared_ptr<dataPacket> packet) {
   RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
   int header_length = rtp_header->getHeaderLength();
-  uint16_t sequence_number = rtp_header->getSeqNumber();
 
   int padding_length = RtpUtils::getPaddingLength(packet);
   if (padding_length + header_length == packet->length) {
+    uint16_t sequence_number = rtp_header->getSeqNumber();
     translator_.get(sequence_number, true);
     return;
   }
-  SequenceNumber sequence_number_info = translator_.get(sequence_number, false);
-  if (sequence_number_info.type != SequenceNumberType::Valid) {
-    return;
-  }
   packet->length -= padding_length;
-  rtp_header->setSeqNumber(sequence_number_info.output);
   rtp_header->padding = 0;
 }
 

--- a/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.cpp
@@ -66,7 +66,7 @@ void RtpPaddingRemovalHandler::write(Context *ctx, std::shared_ptr<dataPacket> p
         if (seq_nums.size() > 0) {
           uint16_t pid = seq_nums[0];
           uint16_t blp = 0;
-          for (int index = 1; index < seq_nums.size() ; index++) {
+          for (uint16_t index = 1; index < seq_nums.size() ; index++) {
             uint16_t distance = seq_nums[index] - pid - 1;
             blp |= (1 << distance);
           }

--- a/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.cpp
@@ -22,15 +22,7 @@ void RtpPaddingRemovalHandler::read(Context *ctx, std::shared_ptr<dataPacket> pa
 
   if (!chead->isRtcp() && enabled_ && packet->type == VIDEO_PACKET) {
     uint32_t ssrc = rtp_header->getSSRC();
-    auto translator_it = translator_map_.find(ssrc);
-    std::shared_ptr<SequenceNumberTranslator> translator;
-    if (translator_it != translator_map_.end()) {
-      translator = translator_it->second;
-    } else {
-      ELOG_DEBUG("message: no Translator found creating a new one, ssrc: %u", ssrc);
-      translator = std::make_shared<SequenceNumberTranslator>();
-      translator_map_[ssrc] = translator;
-    }
+    std::shared_ptr<SequenceNumberTranslator> translator = getTranslatorForSsrc(ssrc, true);
     if (!removePaddingBytes(packet, translator)) {
       return;
     }
@@ -46,6 +38,45 @@ void RtpPaddingRemovalHandler::read(Context *ctx, std::shared_ptr<dataPacket> pa
 }
 
 void RtpPaddingRemovalHandler::write(Context *ctx, std::shared_ptr<dataPacket> packet) {
+  RtcpHeader* rtcp_head = reinterpret_cast<RtcpHeader*>(packet->data);
+  if (!rtcp_head->isFeedback()) {
+    ctx->fireWrite(packet);
+    return;
+  }
+  uint32_t ssrc = rtcp_head->getSSRC();
+  std::shared_ptr<SequenceNumberTranslator> translator = getTranslatorForSsrc(ssrc, false);
+
+
+  RtpUtils::forEachRRBlock(packet, [this, translator](RtcpHeader *chead) {
+    if (chead->packettype == RTCP_RTP_Feedback_PT) {
+      RtpUtils::forEachNack(chead, [this, chead, translator](uint16_t new_seq_num, uint16_t new_plb,
+      RtcpHeader* nack_header) {
+        uint16_t initial_seq_num = new_seq_num;
+        std::vector<uint16_t> seq_nums;
+        for (int i = -1; i <= 15; i++) {
+          uint16_t seq_num = initial_seq_num + i + 1;
+          SequenceNumber input_seq_num = translator->reverse(seq_num);
+          if (input_seq_num.type == SequenceNumberType::Valid) {
+            seq_nums.push_back(input_seq_num.input);
+          } else {
+            ELOG_DEBUG("Input is not valid for %d", seq_num);
+          }
+          ELOG_DEBUG("Lost packet %d, input %d", seq_num, input_seq_num.input);
+        }
+        if (seq_nums.size() > 0) {
+          uint16_t pid = seq_nums[0];
+          uint16_t blp = 0;
+          for (int index = 1; index < seq_nums.size() ; index++) {
+            uint16_t distance = seq_nums[index] - pid - 1;
+            blp |= (1 << distance);
+          }
+          nack_header->setNackPid(pid);
+          nack_header->setNackBlp(blp);
+          ELOG_DEBUG("Translated pid %u, translated blp %u", pid, blp);
+        }
+      });
+    }
+  });
   ctx->fireWrite(packet);
 }
 
@@ -64,6 +95,22 @@ bool RtpPaddingRemovalHandler::removePaddingBytes(std::shared_ptr<dataPacket> pa
   rtp_header->padding = 0;
   return true;
 }
+
+std::shared_ptr<SequenceNumberTranslator> RtpPaddingRemovalHandler::getTranslatorForSsrc(uint32_t ssrc,
+  bool should_create) {
+    auto translator_it = translator_map_.find(ssrc);
+    std::shared_ptr<SequenceNumberTranslator> translator;
+    if (translator_it != translator_map_.end()) {
+      translator = translator_it->second;
+    } else {
+      if (should_create) {
+        ELOG_DEBUG("message: no Translator found creating a new one, ssrc: %u", ssrc);
+        translator = std::make_shared<SequenceNumberTranslator>();
+        translator_map_[ssrc] = translator;
+      }
+    }
+    return translator;
+  }
 
 void RtpPaddingRemovalHandler::notifyUpdate() {
   auto pipeline = getContext()->getPipelineShared();

--- a/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.cpp
@@ -110,13 +110,11 @@ std::shared_ptr<SequenceNumberTranslator> RtpPaddingRemovalHandler::getTranslato
     if (translator_it != translator_map_.end()) {
       ELOG_DEBUG("Found Translator for %u, %s", ssrc, connection_->toLog());
       translator = translator_it->second;
-    } else {
-      if (should_create) {
-        ELOG_DEBUG("message: no Translator found creating a new one, ssrc: %u, %s", ssrc,
+    } else if (should_create) {
+      ELOG_DEBUG("message: no Translator found creating a new one, ssrc: %u, %s", ssrc,
       connection_->toLog());
-        translator = std::make_shared<SequenceNumberTranslator>();
-        translator_map_[ssrc] = translator;
-      }
+      translator = std::make_shared<SequenceNumberTranslator>();
+      translator_map_[ssrc] = translator;
     }
     return translator;
   }
@@ -126,10 +124,10 @@ void RtpPaddingRemovalHandler::notifyUpdate() {
   if (!pipeline) {
     return;
   }
-  connection_ = pipeline->getService<WebRtcConnection>().get();
   if (initialized_) {
     return;
   }
+  connection_ = pipeline->getService<WebRtcConnection>().get();
   initialized_ = true;
 }
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.h
+++ b/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.h
@@ -1,6 +1,8 @@
 #ifndef ERIZO_SRC_ERIZO_RTP_RTPPADDINGREMOVALHANDLER_H_
 #define ERIZO_SRC_ERIZO_RTP_RTPPADDINGREMOVALHANDLER_H_
 
+#include <map>
+
 #include "./logger.h"
 #include "pipeline/Handler.h"
 #include "rtp/SequenceNumberTranslator.h"
@@ -28,12 +30,13 @@ class RtpPaddingRemovalHandler: public Handler, public std::enable_shared_from_t
   void notifyUpdate() override;
 
  private:
-  bool removePaddingBytes(std::shared_ptr<dataPacket> packet);
+  bool removePaddingBytes(std::shared_ptr<dataPacket> packet,
+      std::shared_ptr<SequenceNumberTranslator> translator);
 
  private:
   bool enabled_;
   bool initialized_;
-  SequenceNumberTranslator translator_;
+  std::map<uint32_t, std::shared_ptr<SequenceNumberTranslator>> translator_map_;
 };
 }  // namespace erizo
 

--- a/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.h
+++ b/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.h
@@ -28,7 +28,7 @@ class RtpPaddingRemovalHandler: public Handler, public std::enable_shared_from_t
   void notifyUpdate() override;
 
  private:
-  void removePaddingBytes(std::shared_ptr<dataPacket> packet);
+  bool removePaddingBytes(std::shared_ptr<dataPacket> packet);
 
  private:
   bool enabled_;

--- a/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.h
+++ b/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.h
@@ -7,6 +7,7 @@
 #include "./logger.h"
 #include "pipeline/Handler.h"
 #include "rtp/SequenceNumberTranslator.h"
+#include "WebRtcConnection.h"
 
 namespace erizo {
 
@@ -40,6 +41,7 @@ class RtpPaddingRemovalHandler: public Handler, public std::enable_shared_from_t
   bool enabled_;
   bool initialized_;
   std::map<uint32_t, std::shared_ptr<SequenceNumberTranslator>> translator_map_;
+  WebRtcConnection* connection_;
 };
 }  // namespace erizo
 

--- a/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.h
+++ b/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.h
@@ -1,3 +1,4 @@
+
 #ifndef ERIZO_SRC_ERIZO_RTP_RTPPADDINGREMOVALHANDLER_H_
 #define ERIZO_SRC_ERIZO_RTP_RTPPADDINGREMOVALHANDLER_H_
 
@@ -32,6 +33,8 @@ class RtpPaddingRemovalHandler: public Handler, public std::enable_shared_from_t
  private:
   bool removePaddingBytes(std::shared_ptr<dataPacket> packet,
       std::shared_ptr<SequenceNumberTranslator> translator);
+  std::shared_ptr<SequenceNumberTranslator> getTranslatorForSsrc(uint32_t ssrc,
+    bool should_create);
 
  private:
   bool enabled_;

--- a/erizo/src/erizo/rtp/RtpRetransmissionHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpRetransmissionHandler.cpp
@@ -74,7 +74,8 @@ void RtpRetransmissionHandler::read(Context *ctx, std::shared_ptr<dataPacket> pa
     if (chead->packettype == RTCP_RTP_Feedback_PT) {
       contains_nack = true;
 
-      RtpUtils::forEachNack(chead, [this, chead, &is_fully_recovered](uint16_t new_seq_num, uint16_t new_plb) {
+      RtpUtils::forEachNack(chead, [this, chead, &is_fully_recovered](uint16_t new_seq_num,
+         uint16_t new_plb, RtcpHeader* nack_head) {
         uint16_t initial_seq_num = new_seq_num;
         uint16_t plb = new_plb;
 

--- a/erizo/src/erizo/rtp/RtpUtils.cpp
+++ b/erizo/src/erizo/rtp/RtpUtils.cpp
@@ -21,7 +21,7 @@ void RtpUtils::updateREMB(RtcpHeader *chead, uint bitrate) {
   }
 }
 
-void RtpUtils::forEachNack(RtcpHeader *chead, std::function<void(uint16_t, uint16_t)> f) {
+void RtpUtils::forEachNack(RtcpHeader *chead, std::function<void(uint16_t, uint16_t, RtcpHeader*)> f) {
   if (chead->packettype == RTCP_RTP_Feedback_PT) {
     int length = (chead->getLength() + 1)*4;
     int current_position = kNackCommonHeaderLengthBytes;
@@ -31,7 +31,7 @@ void RtpUtils::forEachNack(RtcpHeader *chead, std::function<void(uint16_t, uint1
       aux_chead = reinterpret_cast<RtcpHeader*>(aux_pointer);
       uint16_t initial_seq_num = aux_chead->getNackPid();
       uint16_t plb = aux_chead->getNackBlp();
-      f(initial_seq_num, plb);
+      f(initial_seq_num, plb, aux_chead);
       current_position += 4;
       aux_pointer += 4;
     }

--- a/erizo/src/erizo/rtp/RtpUtils.h
+++ b/erizo/src/erizo/rtp/RtpUtils.h
@@ -23,7 +23,7 @@ class RtpUtils {
 
   static bool isFIR(std::shared_ptr<dataPacket> packet);
 
-  static void forEachNack(RtcpHeader *chead, std::function<void(uint16_t, uint16_t)> f);
+  static void forEachNack(RtcpHeader *chead, std::function<void(uint16_t, uint16_t, RtcpHeader*)> f);
 
   static std::shared_ptr<dataPacket> createPLI(uint32_t source_ssrc, uint32_t sink_ssrc);
 

--- a/erizo/src/test/log4cxx.properties
+++ b/erizo/src/test/log4cxx.properties
@@ -53,6 +53,7 @@ log4j.logger.rtp.RtpAudioMuteHandler=ERROR
 log4j.logger.rtp.RtpSink=ERROR
 log4j.logger.rtp.RtpSource=ERROR
 log4j.logger.rtp.RtcpFeedbackGenerationHandler=ERROR
+log4j.logger.rtp.RtpPaddingRemovalHandler=ERROR
 log4j.logger.rtp.RtcpRrGenerator=ERROR
 log4j.logger.rtp.RtcpNackGenerator=ERROR
 log4j.logger.rtp.SRPacketHandler=ERROR

--- a/erizo/src/test/rtp/RtcpNackGeneratorTest.cpp
+++ b/erizo/src/test/rtp/RtcpNackGeneratorTest.cpp
@@ -58,7 +58,8 @@ class RtcpNackGeneratorTest :public ::testing::Test {
       total_length += rtcp_length;
 
       if (chead->packettype == RTCP_RTP_Feedback_PT) {
-        erizo::RtpUtils::forEachNack(chead, [chead, lost_seq_num, &found_nack](uint16_t seq_num, uint16_t plb) {
+        erizo::RtpUtils::forEachNack(chead, [chead, lost_seq_num, &found_nack](uint16_t seq_num,
+           uint16_t plb, RtcpHeader* nack_head) {
           uint16_t initial_seq_num = seq_num;
           if (initial_seq_num == lost_seq_num) {
              found_nack = true;
@@ -201,4 +202,3 @@ TEST_F(RtcpNackGeneratorTest, shouldNotRetransmitNacksMoreThanTwice) {
   receiver_report = generateRrWithNack();
   EXPECT_FALSE(RtcpPacketContainsNackSeqNum(receiver_report, erizo::kArbitrarySeqNumber + 1));
 }
-

--- a/erizo_controller/erizoAgent/log4cxx.properties
+++ b/erizo_controller/erizoAgent/log4cxx.properties
@@ -54,6 +54,7 @@ log4j.logger.rtp.RtpAudioMuteHandler=WARN
 log4j.logger.rtp.RtpSink=WARN
 log4j.logger.rtp.RtpSource=WARN
 log4j.logger.rtp.RtcpFeedbackGenerationHandler=WARN
+log4j.logger.rtp.RtpPaddingRemovalHandler=WARN
 log4j.logger.rtp.RtcpRrGenerator=WARN
 log4j.logger.rtp.RtcpNackGenerator=WARN
 log4j.logger.rtp.SRPacketHandler=WARN


### PR DESCRIPTION
**Description**

This PR fixes `PaddingRemovalHandler`. It adds sequence number translation for NACKs to avoid problems when there is Padding in non-simulcast connections. Also, the handler is moved in the pipeline to avoid conflicts with `FeedbackGenerationHandler`

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**


[] It includes documentation for these changes in `/doc`.
