### PR TITLE
Added more options to customize logs in ErizoClient

### DIFF
--- a/doc/client_api.md
+++ b/doc/client_api.md
@@ -874,6 +874,15 @@ In this example we will make a basic videoconference application. Every client t
   </body>
 </html>
 ```
+# Customize Logging
+
+You can configure and customize the way ErizoClient:
+
+| Function                               | Description                                                                                         |
+|----------------------------------------|-----------------------------------------------------------------------------------------------------|
+| `L.Logger.setLogLevel(LogLevel)`         | Sets the log level from 0 (DEBUG) to 5(NONE) with decreasing level of detail               |
+| `L.Logger.setLogPrefix(logPrefix)`       | You can pass a string as a prefix for every log ErizoClient log message              |
+| `L.Logger.setOutputFunction(outputFunction)`      | You can pass a function that takes an array forming the log message to further customize the output|
 
 # Node.js Client
 

--- a/erizo_controller/erizoClient/src/utils/L.Logger.js
+++ b/erizo_controller/erizoClient/src/utils/L.Logger.js
@@ -14,6 +14,10 @@ L.Logger = (function (L) {
         NONE = 5,
         enableLogPanel,
         setLogLevel,
+        setOutputFunction,
+        setLogPrefix,
+        outputFunction,
+        logPrefix = '',
         log,
         debug,
         trace,
@@ -43,10 +47,22 @@ L.Logger = (function (L) {
         L.Logger.logLevel = level;
     };
 
+    outputFunction = function (args) {
+      console.log.apply(console, args);
+    };
+
+    setOutputFunction = function (outputFunction) {
+      L.Logger.outputFunction = outputFunction;
+    };
+
+    setLogPrefix = function (newLogPrefix) {
+      L.Logger.logPrefix = logPrefix;
+    };
+
     // Generic function to print logs for a given level:
     //  L.Logger.[DEBUG, TRACE, INFO, WARNING, ERROR]
     log = function (level) {
-        var out = '';
+        var out = logPrefix;
         if (level < L.Logger.logLevel) {
             return;
         }
@@ -75,7 +91,7 @@ L.Logger = (function (L) {
             }
             L.Logger.panel.value = L.Logger.panel.value + '\n' + tmp;
         } else {
-            console.log.apply(console, args);
+            L.Logger.outputFunction.apply(L.Logger, [args]);
         }
     };
 
@@ -133,6 +149,10 @@ L.Logger = (function (L) {
         NONE: NONE,
         enableLogPanel: enableLogPanel,
         setLogLevel: setLogLevel,
+        setOutputFunction: setOutputFunction,
+        setLogPrefix: setLogPrefix,
+        outputFunction: outputFunction,
+        logPrefix, logPrefix,
         log: log,
         debug: debug,
         trace: trace,


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

Adds a couple of ways to customize logs in ErizoClient. You can add a prefix or completely change the output function of the logs.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

There are two new methos for L.Logger `setLogPrefix`  and `setOutputFunction` they are detailed in the docs

- [x] It includes documentation for these changes in `/doc`.