### PR TITLE
Add/pass chrome desktop

### DIFF
--- a/doc/client_api.md
+++ b/doc/client_api.md
@@ -874,6 +874,15 @@ In this example we will make a basic videoconference application. Every client t
   </body>
 </html>
 ```
+# Customize Logging
+
+You can configure and customize the way ErizoClient:
+
+| Function                               | Description                                                                                         |
+|----------------------------------------|-----------------------------------------------------------------------------------------------------|
+| `L.Logger.setLogLevel(LogLevel)`         | Sets the log level from 0 (DEBUG) to 5(NONE) with decreasing level of detail               |
+| `L.Logger.setLogPrefix(logPrefix)`       | You can pass a string as a prefix for every log ErizoClient log message              |
+| `L.Logger.setOutputFunction(outputFunction)`      | You can pass a function that takes an array forming the log message to further customize the output|
 
 # Node.js Client
 

--- a/doc/client_api.md
+++ b/doc/client_api.md
@@ -38,6 +38,12 @@ var stream = Erizo.Stream({screen: true, data: true, attributes: {name:'myStream
 
 Note that, if you use a Stream this way, the client that will share its sreen must access to your web app using a secure connection (with https protocol) and use a screensharing plugin as explained <a href="http://lynckia.com/licode/plugin.html" target="_blank">here</a>.
 
+Additionally, in Chrome, you can use your own extension outside of Licode and directly pass the `chromeMediaSourceId` as a parameter:
+
+```
+var stream = Erizo.Stream({screen: true, data: true, attributes: {name:'myStream'}, desktopStreamId:'ID_PROVIDED_BY_YOUR_EXTENSION'});
+```
+
 You can also specify some constraints about the video size when creating a stream. In order to do this you need to include a `videoSize` parameter that is an array with the following format: `[minWidth, minHeight, maxWidth, maxHeight]`
 
 ```

--- a/erizo_controller/erizoClient/src/Connection.js
+++ b/erizo_controller/erizoClient/src/Connection.js
@@ -94,9 +94,6 @@ Erizo.GetUserMedia = function (config, callback, error) {
 
             case 'chrome-stable':
             L.Logger.debug('Screen sharing in Chrome');
-                // Default extensionId - this extension is only usable in our server,
-                // please make your own extension based on the code in
-                // erizo_controller/erizoClient/extras/chrome-extension
                 if (config.desktopStreamId){
                     var theConfig = {};
                     theConfig.video = config.video || {};
@@ -104,6 +101,9 @@ Erizo.GetUserMedia = function (config, callback, error) {
                     theConfig.video.mandatory.chromeMediaSourceId = config.desktopStreamId;
                     navigator.getMedia(theConfig, callback, error);
                 } else {
+                  // Default extensionId - this extension is only usable in our server,
+                  // please make your own extension based on the code in
+                  // erizo_controller/erizoClient/extras/chrome-extension
                   var extensionId = 'okeephmleflklcdebijnponpabbmmgeo';
                   if (config.extensionId){
                       L.Logger.debug('extensionId supplied, using ' + config.extensionId);

--- a/erizo_controller/erizoClient/src/Connection.js
+++ b/erizo_controller/erizoClient/src/Connection.js
@@ -93,42 +93,50 @@ Erizo.GetUserMedia = function (config, callback, error) {
                 break;
 
             case 'chrome-stable':
-                L.Logger.debug('Screen sharing in Chrome');
+            L.Logger.debug('Screen sharing in Chrome');
                 // Default extensionId - this extension is only usable in our server,
                 // please make your own extension based on the code in
                 // erizo_controller/erizoClient/extras/chrome-extension
-                var extensionId = 'okeephmleflklcdebijnponpabbmmgeo';
-                if (config.extensionId){
-                    L.Logger.debug('extensionId supplied, using ' + config.extensionId);
-                    extensionId = config.extensionId;
-                }
-                L.Logger.debug('Screen access on chrome stable, looking for extension');
-                try {
-                    chrome.runtime.sendMessage(extensionId, {getStream: true}, function (response){
-                        var theConfig = {};
-                        if (response === undefined){
-                            L.Logger.error('Access to screen denied');
-                            var theError = {code:'Access to screen denied'};
-                            error(theError);
-                            return;
-                        }
-                        var theId = response.streamId;
-                        if(config.video.mandatory !== undefined){
-                            theConfig.video = config.video;
-                            theConfig.video.mandatory.chromeMediaSource = 'desktop';
-                            theConfig.video.mandatory.chromeMediaSourceId = theId;
+                if (config.desktopStreamId){
+                    var theConfig = {};
+                    theConfig.video = config.video || {};
+                    theConfig.video.mandatory.chromeMediaSource = 'desktop';
+                    theConfig.video.mandatory.chromeMediaSourceId = config.desktopStreamId;
+                    navigator.getMedia(theConfig, callback, error);
+                } else {
+                  var extensionId = 'okeephmleflklcdebijnponpabbmmgeo';
+                  if (config.extensionId){
+                      L.Logger.debug('extensionId supplied, using ' + config.extensionId);
+                      extensionId = config.extensionId;
+                  }
+                  L.Logger.debug('Screen access on chrome stable, looking for extension');
+                  try {
+                      chrome.runtime.sendMessage(extensionId, {getStream: true}, function (response){
+                          var theConfig = {};
+                          if (response === undefined){
+                              L.Logger.error('Access to screen denied');
+                              var theError = {code:'Access to screen denied'};
+                              error(theError);
+                              return;
+                          }
+                          var theId = response.streamId;
+                          if(config.video.mandatory !== undefined){
+                              theConfig.video = config.video;
+                              theConfig.video.mandatory.chromeMediaSource = 'desktop';
+                              theConfig.video.mandatory.chromeMediaSourceId = theId;
 
-                        }else{
-                            theConfig = {video: {mandatory: {chromeMediaSource: 'desktop',
-                                                             chromeMediaSourceId: theId }}};
-                        }
-                        navigator.getMedia(theConfig, callback, error);
-                    });
-                } catch(e) {
-                    L.Logger.debug('Screensharing plugin is not accessible ');
-                    var theError = {code:'no_plugin_present'};
-                    error(theError);
-                    return;
+                          }else{
+                              theConfig = {video: {mandatory: {chromeMediaSource: 'desktop',
+                                                               chromeMediaSourceId: theId }}};
+                          }
+                          navigator.getMedia(theConfig, callback, error);
+                      });
+                  } catch(e) {
+                      L.Logger.debug('Screensharing plugin is not accessible ');
+                      var theError = {code:'no_plugin_present'};
+                      error(theError);
+                      return;
+                  }
                 }
                 break;
 

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -21,6 +21,7 @@ Erizo.Stream = function (spec) {
     that.videoSize = spec.videoSize;
     that.videoFrameRate = spec.videoFrameRate;
     that.extensionId = spec.extensionId;
+    that.desktopStreamId = spec.desktopStreamId;
 
     if (that.videoSize !== undefined &&
         (!(that.videoSize instanceof Array) ||
@@ -93,9 +94,9 @@ Erizo.Stream = function (spec) {
           L.Logger.info('Requested access to local media');
           var videoOpt = spec.video;
           if (videoOpt === true || spec.screen === true) {
-              videoOpt = {};
+              videoOpt = videoOpt === true ? {}: videoOpt;
               if (that.videoSize !== undefined) {
-                  videoOpt.mandatory = {};
+                  videoOpt.mandatory = videoOpt.mandatory || {};
                   videoOpt.mandatory.minWidth = that.videoSize[0];
                   videoOpt.mandatory.minHeight = that.videoSize[1];
                   videoOpt.mandatory.maxWidth = that.videoSize[2];
@@ -103,7 +104,7 @@ Erizo.Stream = function (spec) {
               }
 
               if (that.videoFrameRate !== undefined) {
-                  videoOpt.optional = [];
+                  videoOpt.optional = videoOpt.optional || [];
                   videoOpt.optional.push({minFrameRate: that.videoFrameRate[0]});
                   videoOpt.optional.push({maxFrameRate: that.videoFrameRate[1]});
               }
@@ -115,8 +116,8 @@ Erizo.Stream = function (spec) {
                      audio: spec.audio,
                      fake: spec.fake,
                      screen: spec.screen,
-                     extensionId:that.extensionId};
-          L.Logger.debug(opt);
+                     extensionId: that.extensionId,
+                     desktopStreamId: that.desktopStreamId};
           Erizo.GetUserMedia(opt, function (stream) {
             //navigator.webkitGetUserMedia("audio, video", function (stream) {
 
@@ -333,9 +334,9 @@ Erizo.Stream = function (spec) {
         handlers = (handlers instanceof Array) ? handlers : [];
 
         if (handlers.length > 0) {
-            that.room.sendControlMessage(that, 'control', {name: 'controlhandlers', 
-                                        enable: enable, 
-                                        publisherSide: publisherSide, 
+            that.room.sendControlMessage(that, 'control', {name: 'controlhandlers',
+                                        enable: enable,
+                                        publisherSide: publisherSide,
                                         handlers: handlers});
         }
     };

--- a/erizo_controller/erizoClient/src/utils/L.Logger.js
+++ b/erizo_controller/erizoClient/src/utils/L.Logger.js
@@ -51,12 +51,12 @@ L.Logger = (function (L) {
       console.log.apply(console, args);
     };
 
-    setOutputFunction = function (outputFunction) {
-      L.Logger.outputFunction = outputFunction;
+    setOutputFunction = function (newOutputFunction) {
+      outputFunction = newOutputFunction;
     };
 
     setLogPrefix = function (newLogPrefix) {
-      L.Logger.logPrefix = logPrefix;
+      logPrefix = newLogPrefix;
     };
 
     // Generic function to print logs for a given level:
@@ -91,7 +91,7 @@ L.Logger = (function (L) {
             }
             L.Logger.panel.value = L.Logger.panel.value + '\n' + tmp;
         } else {
-            L.Logger.outputFunction.apply(L.Logger, [args]);
+            outputFunction.apply(L.Logger, [args]);
         }
     };
 
@@ -151,8 +151,6 @@ L.Logger = (function (L) {
         setLogLevel: setLogLevel,
         setOutputFunction: setOutputFunction,
         setLogPrefix: setLogPrefix,
-        outputFunction: outputFunction,
-        logPrefix, logPrefix,
         log: log,
         debug: debug,
         trace: trace,

--- a/erizo_controller/erizoClient/src/utils/L.Logger.js
+++ b/erizo_controller/erizoClient/src/utils/L.Logger.js
@@ -14,6 +14,10 @@ L.Logger = (function (L) {
         NONE = 5,
         enableLogPanel,
         setLogLevel,
+        setOutputFunction,
+        setLogPrefix,
+        outputFunction,
+        logPrefix = '',
         log,
         debug,
         trace,
@@ -43,10 +47,22 @@ L.Logger = (function (L) {
         L.Logger.logLevel = level;
     };
 
+    outputFunction = function (args) {
+      console.log.apply(console, args);
+    };
+
+    setOutputFunction = function (outputFunction) {
+      L.Logger.outputFunction = outputFunction;
+    };
+
+    setLogPrefix = function (newLogPrefix) {
+      L.Logger.logPrefix = logPrefix;
+    };
+
     // Generic function to print logs for a given level:
     //  L.Logger.[DEBUG, TRACE, INFO, WARNING, ERROR]
     log = function (level) {
-        var out = '';
+        var out = logPrefix;
         if (level < L.Logger.logLevel) {
             return;
         }
@@ -75,7 +91,7 @@ L.Logger = (function (L) {
             }
             L.Logger.panel.value = L.Logger.panel.value + '\n' + tmp;
         } else {
-            console.log.apply(console, args);
+            L.Logger.outputFunction.apply(L.Logger, [args]);
         }
     };
 
@@ -133,6 +149,10 @@ L.Logger = (function (L) {
         NONE: NONE,
         enableLogPanel: enableLogPanel,
         setLogLevel: setLogLevel,
+        setOutputFunction: setOutputFunction,
+        setLogPrefix: setLogPrefix,
+        outputFunction: outputFunction,
+        logPrefix, logPrefix,
         log: log,
         debug: debug,
         trace: trace,


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR allows passing a desktopStreamId to `Erizo.Stream` for screensharing instead of using the extension through Licode. This allows for more flexibility.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**
You can add a new option when constructing `Erizo.Stream` called `desktopStreamId`

- [X] It includes documentation for these changes in `/doc`.