### PR TITLE
Add support for Electron screensharing

### DIFF
--- a/erizo_controller/erizoClient/src/Connection.js
+++ b/erizo_controller/erizoClient/src/Connection.js
@@ -20,7 +20,7 @@ Erizo.Connection = function (spec) {
     } else if (that.browser === 'bowser'){
         L.Logger.debug('Bowser Stack');
         that = Erizo.BowserStack(spec);
-    } else if (that.browser === 'chrome-stable') {
+    } else if (that.browser === 'chrome-stable' || that.browser === 'electron') {
         L.Logger.debug('Chrome Stable Stack');
         that = Erizo.ChromeStableStack(spec);
     } else {
@@ -49,18 +49,22 @@ Erizo.getBrowser = function () {
     } else if (window.navigator.userAgent.match('Bowser') !== null){
         browser = 'bowser';
     } else if (window.navigator.userAgent.match('Chrome') !== null) {
-        if (window.navigator.appVersion.match(/Chrome\/([\w\W]*?)\./)[1] >= 26) {
-            browser = 'chrome-stable';
+        browser = 'chrome-stable';
+        if (window.navigator.userAgent.match('Electron') !== null) {
+            browser = 'electron'
         }
-    } else if (window.navigator.userAgent.match('Safari') !== null) {
+    }
+    else if (window.navigator.userAgent.match('Safari') !== null) {
         browser = 'bowser';
     } else if (window.navigator.userAgent.match('AppleWebKit') !== null) {
         browser = 'bowser';
     }
-    return browser;
+return browser;
 };
 
-
+var isElectron = function() {
+    return (window.navigator.userAgent.match('Electron') !== null);
+};
 Erizo.GetUserMedia = function (config, callback, error) {
     var promise;
     navigator.getMedia = ( navigator.getUserMedia ||
@@ -71,6 +75,15 @@ Erizo.GetUserMedia = function (config, callback, error) {
     if (config.screen) {
         L.Logger.debug('Screen access requested');
         switch (Erizo.getBrowser()) {
+            case 'electron' :
+                 L.Logger.debug('Screen sharing in Electron');
+                var screenConfig = {};
+                screenConfig.video = config.video || {};
+                screenConfig.video.mandatory = config.video.mandatory || {};
+                screenConfig.video.mandatory.chromeMediaSource = 'screen';
+                var theConfig = {video: { mandatory: { chromeMediaSource: 'screen' } } };
+                navigator.getMedia(screenConfig, callback, error);
+                break;
             case 'mozilla':
                 L.Logger.debug('Screen sharing in Firefox');
                 var screenCfg = {};

--- a/erizo_controller/erizoClient/src/Connection.js
+++ b/erizo_controller/erizoClient/src/Connection.js
@@ -53,18 +53,14 @@ Erizo.getBrowser = function () {
         if (window.navigator.userAgent.match('Electron') !== null) {
             browser = 'electron'
         }
-    }
-    else if (window.navigator.userAgent.match('Safari') !== null) {
+    } else if (window.navigator.userAgent.match('Safari') !== null) {
         browser = 'bowser';
     } else if (window.navigator.userAgent.match('AppleWebKit') !== null) {
         browser = 'bowser';
     }
-return browser;
+    return browser;
 };
 
-var isElectron = function() {
-    return (window.navigator.userAgent.match('Electron') !== null);
-};
 Erizo.GetUserMedia = function (config, callback, error) {
     var promise;
     navigator.getMedia = ( navigator.getUserMedia ||
@@ -81,7 +77,6 @@ Erizo.GetUserMedia = function (config, callback, error) {
                 screenConfig.video = config.video || {};
                 screenConfig.video.mandatory = config.video.mandatory || {};
                 screenConfig.video.mandatory.chromeMediaSource = 'screen';
-                var theConfig = {video: { mandatory: { chromeMediaSource: 'screen' } } };
                 navigator.getMedia(screenConfig, callback, error);
                 break;
             case 'mozilla':

--- a/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
@@ -266,7 +266,7 @@ Erizo.ChromeStableStack = function (spec) {
 
             localDesc.sdp = setMaxBW(localDesc.sdp);
             if (config.Sdp || config.maxAudioBW){
-                L.Logger.debug ('Updating with SDP renegotiation', spec.maxVideoBW);
+                L.Logger.debug ('Updating with SDP renegotiation', spec.maxVideoBW, spec.maxAudioBW);
                 that.peerConnection.setLocalDescription(localDesc, function () {
                     remoteDesc.sdp = setMaxBW(remoteDesc.sdp);
                     that.peerConnection.setRemoteDescription(


### PR DESCRIPTION
**Description**
This PR adds support for Electron screensharing. Electron does not have to use an extension like Chrome does.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

No changes in the API, it should work transparently.

[] It includes documentation for these changes in `/doc`.