### PR TITLE
Remove wrong script command

### DIFF
--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -199,7 +199,6 @@ install_libsrtp(){
     cd libsrtp-2.1.0
     CFLAGS="-fPIC" ./configure --enable-openssl --prefix=$PREFIX_DIR --with-openssl-dir=$PREFIX_DIR
     make -s V=0 && make uninstall && make install
-    check_result $?
     cd $CURRENT_DIR
   else
     mkdir -p $LIB_DIR


### PR DESCRIPTION
**Description**

Remove a wrong script command, which is harmless but makes it hardest to understand.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed. 

[] It includes documentation for these changes in `/doc`.