### PR TITLE
Add connectivity stats to spine

### DIFF
--- a/spine/nativeClient.js
+++ b/spine/nativeClient.js
@@ -25,6 +25,7 @@ exports.ErizoNativeConnection = function (spec){
     oneToMany,
     externalOutput;
 
+    that.connected = false;
 
     var CONN_INITIAL = 101,
         // CONN_STARTED = 102,
@@ -72,11 +73,13 @@ exports.ErizoNativeConnection = function (spec){
 
                 case CONN_FAILED:
                     log.warn('Connection failed the ICE process');
+                    that.connected = false;
                     //   callback('callback', {type: 'failed', sdp: mess});
                     break;
 
                 case CONN_READY:
                     log.info('Connection ready');
+                    that.connected = true;
                     if (externalInput !== undefined){
                         log.info('Will start External Input');
                         externalInput.init();
@@ -186,6 +189,7 @@ exports.ErizoNativeConnection = function (spec){
         if (syntheticInput!==undefined){
             syntheticInput.close();
         }
+        that.connected = false;
         wrtc.close();
     };
 

--- a/spine/runSpineClients.js
+++ b/spine/runSpineClients.js
@@ -89,7 +89,7 @@ setInterval(function() {
       down++;
     }
   }
-  console.log("[STATS] up:", up, "; down:", down);
+  console.log('[STATS] up:', up, '; down:', down);
 }, statsInterval);
 
 console.log('Starting ', streamConfig.numSubscribers, 'subscriber streams',

--- a/spine/runSpineClients.js
+++ b/spine/runSpineClients.js
@@ -4,12 +4,15 @@ var efc = require ('./simpleNativeConnection');
 
 var getopt = new Getopt([
   ['s' , 'stream-config=ARG'             , 'file containing the stream config JSON'],
+  ['t' , 'time=ARG'                      , 'interval time to show stats (default 10 seconds)'],
   ['h' , 'help'                          , 'display this help']
 ]);
 
 var opt = getopt.parse(process.argv.slice(2));
 
 var streamConfig;
+
+var statsInterval = 10000;
 
 for (var prop in opt.options) {
     if (opt.options.hasOwnProperty(prop)) {
@@ -21,6 +24,9 @@ for (var prop in opt.options) {
                 break;
             case 'stream-config':
                 streamConfig = value;
+                break;
+            case 'time':
+                statsInterval = value * 1000;
                 break;
             default:
                 console.log('Default');
@@ -55,7 +61,7 @@ if (streamConfig.subscribeConfig){
     console.log('StreamSubscribe', streamSubscribeConfig);
 }
 
-
+var streams = [];
 
 var startStreams = function(stConf, num, time){
     var started = 0;
@@ -65,13 +71,26 @@ var startStreams = function(stConf, num, time){
             clearInterval(interval);
         }
         console.log('Will start stream with config', stConf);
-        efc.ErizoSimpleNativeConnection (stConf, function(msg){
+        streams.push(efc.ErizoSimpleNativeConnection (stConf, function(msg){
             console.log('Getting Callback', msg);
         }, function(msg){
             console.error('Error message', msg);
-        });
+        }));
     }, time);
 };
+
+setInterval(function() {
+  var up = 0;
+  var down = 0;
+  for (var stream of streams) {
+    if (stream.getStatus() === 'connected') {
+      up++;
+    } else {
+      down++;
+    }
+  }
+  console.log("[STATS] up:", up, "; down:", down);
+}, statsInterval);
 
 console.log('Starting ', streamConfig.numSubscribers, 'subscriber streams',
         'and', streamConfig.numPublishers, 'publisherStreams');

--- a/spine/simpleNativeConnection.js
+++ b/spine/simpleNativeConnection.js
@@ -15,6 +15,7 @@ exports.ErizoSimpleNativeConnection = function (spec, callback, error){
     var that = {};
 
     var localStream = {};
+    var subscribedStreams = [];
     var room = '';
     that.isActive = false;
     localStream.getID = function() {return 0;};
@@ -108,9 +109,10 @@ exports.ErizoSimpleNativeConnection = function (spec, callback, error){
 
             });
 
-            room.addEventListener('stream-subscribed', function() {
+            room.addEventListener('stream-subscribed', function(streamEvent) {
                 log.info('stream-subscribed');
                 callback('stream-subscribed');
+                subscribedStreams.push(streamEvent.stream);
             });
 
             room.addEventListener('room-error', function(roomEvent) {
@@ -134,6 +136,18 @@ exports.ErizoSimpleNativeConnection = function (spec, callback, error){
     that.close = function(){
         log.info('Close');
         room.disconnect();
+    };
+
+    that.getStatus = function() {
+      if (subscribedStreams.length === 0) {
+        return 'disconnected';
+      }
+      for (var stream of subscribedStreams) {
+        if (!stream.pc || !stream.pc.peerConnection || !stream.pc.peerConnection.connected) {
+          return 'disconnected';
+        }
+      }
+      return 'connected';
     };
 
     createConnection();


### PR DESCRIPTION
**Description**

Add info about subscriptions to Spine. It will show how many subscribers are connected or not every few seconds (it's configurable).

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed. 

[] It includes documentation for these changes in `/doc`.