### PR TITLE
Fix wrong REMB detection with Chrome 60

### DIFF
--- a/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
@@ -57,7 +57,7 @@ void SenderBandwidthEstimationHandler::notifyUpdate() {
 
 void SenderBandwidthEstimationHandler::read(Context *ctx, std::shared_ptr<dataPacket> packet) {
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
-  if (chead->isFeedback() && chead->getSourceSSRC() == connection_->getVideoSinkSSRC()) {
+  if (chead->isFeedback()) {
     char* packet_pointer = packet->data;
     int rtcp_length = 0;
     int total_length = 0;
@@ -75,6 +75,9 @@ void SenderBandwidthEstimationHandler::read(Context *ctx, std::shared_ptr<dataPa
       switch (chead->packettype) {
         case RTCP_Receiver_PT:
           {
+            if (chead->getSourceSSRC() != connection_->getVideoSinkSSRC()) {
+              continue;
+            }
             ELOG_DEBUG("%s, Analyzing Video RR: PacketLost %u, Ratio %u, current_block %d, blocks %d"
                 ", sourceSSRC %u, ssrc %u",
                 connection_->toLog(),


### PR DESCRIPTION
**Description**

Fixes #938 

Thanks to @kekkokk for the heads up. Turned out to be that Chrome is sending REMB packets within compound audio RR. And they can sometimes have a SSRC different from video's. [1]

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.

[1] https://bugs.chromium.org/p/webrtc/issues/detail?id=7860