### PR TITLE
Add default functions to callbacks in Erizo Client

### DIFF
--- a/erizo_controller/erizoClient/src/Connection.js
+++ b/erizo_controller/erizoClient/src/Connection.js
@@ -29,9 +29,9 @@ Erizo.Connection = (specInput) => {
     throw new Error('WebRTC stack not available');
   }
   if (!that.updateSpec) {
-    that.updateSpec = (newSpec, callback) => {
+    that.updateSpec = (newSpec, callback = () => {}) => {
       L.Logger.error('Update Configuration not implemented in this browser');
-      if (callback) { callback('unimplemented'); }
+      callback('unimplemented');
     };
   }
 
@@ -59,7 +59,7 @@ Erizo.getBrowser = () => {
   return browser;
 };
 
-Erizo.GetUserMedia = (config, callback, error) => {
+Erizo.GetUserMedia = (config, callback = () => {}, error = () => {}) => {
   let screenConfig;
 
   const getUserMedia = (userMediaConfig, cb, errorCb) => {

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -302,7 +302,7 @@ Erizo.Stream = (specInput) => {
     }
   };
 
-  const muteStream = (callback) => {
+  const muteStream = (callback = () => {}) => {
     if (that.room && that.room.p2p) {
       L.Logger.warning('muteAudio/muteVideo are not implemented in p2p streams');
       callback('error');
@@ -319,18 +319,18 @@ Erizo.Stream = (specInput) => {
     that.pc.updateSpec(config, callback);
   };
 
-  that.muteAudio = (isMuted, callback) => {
+  that.muteAudio = (isMuted, callback = () => {}) => {
     that.audioMuted = isMuted;
     muteStream(callback);
   };
 
-  that.muteVideo = (isMuted, callback) => {
+  that.muteVideo = (isMuted, callback = () => {}) => {
     that.videoMuted = isMuted;
     muteStream(callback);
   };
 
   // eslint-disable-next-line no-underscore-dangle
-  that._setQualityLayer = (spatialLayer, temporalLayer, callback) => {
+  that._setQualityLayer = (spatialLayer, temporalLayer, callback = () => {}) => {
     if (that.room && that.room.p2p) {
       L.Logger.warning('setQualityLayer is not implemented in p2p streams');
       callback('error');
@@ -367,7 +367,7 @@ Erizo.Stream = (specInput) => {
     controlHandler(handlers, publisherSide, true);
   };
 
-  that.updateConfiguration = (config, callback) => {
+  that.updateConfiguration = (config, callback = () => {}) => {
     if (config === undefined) { return; }
     if (that.pc) {
       that.checkOptions(config, true);

--- a/erizo_controller/erizoClient/src/utils/L.Resizer.js
+++ b/erizo_controller/erizoClient/src/utils/L.Resizer.js
@@ -284,7 +284,7 @@ const customRequestAnimationFrame = window.requestAnimationFrame ||
    * @param {HTMLElement|HTMLElement[]} elements
    * @param {Function}                  callback
    */
-function forEachElement(elements, callback) {
+function forEachElement(elements, callback = () => {}) {
   const elementsType = Object.prototype.toString.call(elements);
   const isCollectionTyped = (elementsType === '[object Array]' ||
           (elementsType === '[object NodeList]') ||
@@ -310,7 +310,7 @@ function forEachElement(elements, callback) {
    *
    * @constructor
    */
-L.ResizeSensor = function ResizeSensor(element, callback) {
+L.ResizeSensor = function ResizeSensor(element, callback = () => {}) {
       /**
        *
        * @constructor

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -197,7 +197,7 @@ Erizo.BaseStack = (specInput) => {
     that.peerConnection.close();
   };
 
-  that.updateSpec = (configInput, callback) => {
+  that.updateSpec = (configInput, callback = () => {}) => {
     const config = configInput;
     if (config.maxVideoBW || config.maxAudioBW) {
       if (config.maxVideoBW) {

--- a/erizo_controller/erizoClient/src/webrtc-stacks/FcStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/FcStack.js
@@ -38,7 +38,7 @@ Erizo.FcStack = (spec) => {
     spec.callback(msg);
   };
 
-  that.setSignalingCallback = (callback) => {
+  that.setSignalingCallback = (callback = () => {}) => {
     L.Logger.debug('FCSTACK: Setting signalling callback');
     that.signalCallback = callback;
   };


### PR DESCRIPTION
**Description**

Add default functions to callbacks passed as arguments to Erizo Client API.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.