### PR TITLE
Added location curl option

### DIFF
--- a/scripts/installMacDeps.sh
+++ b/scripts/installMacDeps.sh
@@ -105,12 +105,12 @@ download_openssl() {
   OPENSSL_VERSION=$1
   OPENSSL_MAJOR="${OPENSSL_VERSION%?}"
   echo "Downloading OpenSSL from https://www.openssl.org/source/$OPENSSL_MAJOR/openssl-$OPENSSL_VERSION.tar.gz"
-  curl -O https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
+  curl -OL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
   tar -zxvf openssl-$OPENSSL_VERSION.tar.gz || DOWNLOAD_SUCCESS=$?
   if [ "$DOWNLOAD_SUCCESS" -eq 1 ]
   then
     echo "Downloading OpenSSL from https://www.openssl.org/source/old/$OPENSSL_MAJOR/openssl-$OPENSSL_VERSION.tar.gz"
-    curl -O https://www.openssl.org/source/old/$OPENSSL_MAJOR/openssl-$OPENSSL_VERSION.tar.gz
+    curl -OL https://www.openssl.org/source/old/$OPENSSL_MAJOR/openssl-$OPENSSL_VERSION.tar.gz
     tar -zxvf openssl-$OPENSSL_VERSION.tar.gz
   fi
 }
@@ -137,7 +137,7 @@ install_openssl(){
 install_libnice(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O https://nice.freedesktop.org/releases/libnice-0.1.4.tar.gz
+    curl -OL https://nice.freedesktop.org/releases/libnice-0.1.4.tar.gz
     tar -zxvf libnice-0.1.4.tar.gz
     cd libnice-0.1.4
     check_result $?
@@ -171,10 +171,10 @@ install_mediadeps(){
   brew install opus libvpx x264
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O https://www.libav.org/releases/libav-11.6.tar.gz
+    curl -OL https://www.libav.org/releases/libav-11.6.tar.gz
     tar -zxvf libav-11.6.tar.gz
     cd libav-11.6
-    curl -O https://github.com/libav/libav/commit/4d05e9392f84702e3c833efa86e84c7f1cf5f612.patch
+    curl -OL https://github.com/libav/libav/commit/4d05e9392f84702e3c833efa86e84c7f1cf5f612.patch
     patch libavcodec/libvpxenc.c 4d05e9392f84702e3c833efa86e84c7f1cf5f612.patch && \
     PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus && \
     make $FAST_MAKE -s V=0 && \
@@ -191,10 +191,10 @@ install_mediadeps_nogpl(){
   brew install opus libvpx
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O https://www.libav.org/releases/libav-11.6.tar.gz
+    curl -OL https://www.libav.org/releases/libav-11.6.tar.gz
     tar -zxvf libav-11.6.tar.gz
     cd libav-11.6
-    curl -O https://github.com/libav/libav/commit/4d05e9392f84702e3c833efa86e84c7f1cf5f612.patch
+    curl -OL https://github.com/libav/libav/commit/4d05e9392f84702e3c833efa86e84c7f1cf5f612.patch
     patch libavcodec/libvpxenc.c 4d05e9392f84702e3c833efa86e84c7f1cf5f612.patch && \
     PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-libvpx --enable-libopus && \
     make $FAST_MAKE -s V=0 && \

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -79,12 +79,12 @@ download_openssl() {
   OPENSSL_VERSION=$1
   OPENSSL_MAJOR="${OPENSSL_VERSION%?}"
   echo "Downloading OpenSSL from https://www.openssl.org/source/$OPENSSL_MAJOR/openssl-$OPENSSL_VERSION.tar.gz"
-  curl -O https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
+  curl -OL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
   tar -zxvf openssl-$OPENSSL_VERSION.tar.gz || DOWNLOAD_SUCCESS=$?
   if [ "$DOWNLOAD_SUCCESS" -eq 1 ]
   then
     echo "Downloading OpenSSL from https://www.openssl.org/source/old/$OPENSSL_MAJOR/openssl-$OPENSSL_VERSION.tar.gz"
-    curl -O https://www.openssl.org/source/old/$OPENSSL_MAJOR/openssl-$OPENSSL_VERSION.tar.gz
+    curl -OL https://www.openssl.org/source/old/$OPENSSL_MAJOR/openssl-$OPENSSL_VERSION.tar.gz
     tar -zxvf openssl-$OPENSSL_VERSION.tar.gz
   fi
 }
@@ -113,7 +113,7 @@ install_libnice(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
     if [ ! -f ./libnice-0.1.4.tar.gz ]; then
-      curl -O https://nice.freedesktop.org/releases/libnice-0.1.4.tar.gz
+      curl -OL https://nice.freedesktop.org/releases/libnice-0.1.4.tar.gz
       tar -zxvf libnice-0.1.4.tar.gz
       cd libnice-0.1.4
       patch -R ./agent/conncheck.c < $PATHNAME/libnice-014.patch0
@@ -134,7 +134,7 @@ install_opus(){
   [ -d $LIB_DIR ] || mkdir -p $LIB_DIR
   cd $LIB_DIR
   if [ ! -f ./opus-1.1.tar.gz ]; then
-    curl -O http://downloads.xiph.org/releases/opus/opus-1.1.tar.gz
+    curl -OL http://downloads.xiph.org/releases/opus/opus-1.1.tar.gz
     tar -zxvf opus-1.1.tar.gz
     cd opus-1.1
     ./configure --prefix=$PREFIX_DIR
@@ -152,7 +152,7 @@ install_mediadeps(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
     if [ ! -f ./libav-11.1.tar.gz ]; then
-      curl -O https://www.libav.org/releases/libav-11.1.tar.gz
+      curl -OL https://www.libav.org/releases/libav-11.1.tar.gz
       tar -zxvf libav-11.1.tar.gz
       cd libav-11.1
       PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus
@@ -175,7 +175,7 @@ install_mediadeps_nogpl(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
     if [ ! -f ./libav-11.1.tar.gz ]; then
-      curl -O https://www.libav.org/releases/libav-11.1.tar.gz
+      curl -OL https://www.libav.org/releases/libav-11.1.tar.gz
       tar -zxvf libav-11.1.tar.gz
       cd libav-11.1
       PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libopus

--- a/scripts/travisInstallDeps.sh
+++ b/scripts/travisInstallDeps.sh
@@ -59,12 +59,12 @@ download_openssl() {
   OPENSSL_VERSION=$1
   OPENSSL_MAJOR="${OPENSSL_VERSION%?}"
   echo "Downloading OpenSSL from https://www.openssl.org/source/$OPENSSL_MAJOR/openssl-$OPENSSL_VERSION.tar.gz"
-  curl -O https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
+  curl -OL https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz
   tar -zxvf openssl-$OPENSSL_VERSION.tar.gz || DOWNLOAD_SUCCESS=$?
   if [ "$DOWNLOAD_SUCCESS" -eq 1 ]
   then
     echo "Downloading OpenSSL from https://www.openssl.org/source/old/$OPENSSL_MAJOR/openssl-$OPENSSL_VERSION.tar.gz"
-    curl -O https://www.openssl.org/source/old/$OPENSSL_MAJOR/openssl-$OPENSSL_VERSION.tar.gz
+    curl -OL https://www.openssl.org/source/old/$OPENSSL_MAJOR/openssl-$OPENSSL_VERSION.tar.gz
     tar -zxvf openssl-$OPENSSL_VERSION.tar.gz
   fi
 }
@@ -93,7 +93,7 @@ install_libnice(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
     if [ ! -f ./libnice-0.1.4.tar.gz ]; then
-      curl -O https://nice.freedesktop.org/releases/libnice-0.1.4.tar.gz
+      curl -OL https://nice.freedesktop.org/releases/libnice-0.1.4.tar.gz
       tar -zxvf libnice-0.1.4.tar.gz
       cd libnice-0.1.4
       patch -R ./agent/conncheck.c < $PATHNAME/libnice-014.patch0
@@ -114,7 +114,7 @@ install_opus(){
   [ -d $LIB_DIR ] || mkdir -p $LIB_DIR
   cd $LIB_DIR
   if [ ! -f ./opus-1.1.tar.gz ]; then
-    curl -O http://downloads.xiph.org/releases/opus/opus-1.1.tar.gz
+    curl -OL http://downloads.xiph.org/releases/opus/opus-1.1.tar.gz
     tar -zxvf opus-1.1.tar.gz
     cd opus-1.1
     ./configure --prefix=$PREFIX_DIR
@@ -132,7 +132,7 @@ install_mediadeps(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
     if [ ! -f ./libav-11.1.tar.gz ]; then
-      curl -O https://www.libav.org/releases/libav-11.1.tar.gz
+      curl -OL https://www.libav.org/releases/libav-11.1.tar.gz
       tar -zxvf libav-11.1.tar.gz
       cd libav-11.1
       PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus
@@ -154,7 +154,7 @@ install_mediadeps_nogpl(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
     if [ ! -f ./libav-11.1.tar.gz ]; then
-      curl -O https://www.libav.org/releases/libav-11.1.tar.gz
+      curl -OL https://www.libav.org/releases/libav-11.1.tar.gz
       tar -zxvf libav-11.1.tar.gz
       cd libav-11.1
       PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libopus


### PR DESCRIPTION
**Description**

Following command in [installUbuntuDeps.sh](https://github.com/lynckia/licode/blob/master/scripts/installUbuntuDeps.sh#L137-L138) returns "gzip: stdin: not in gzip format" because opus-1.1.tar.gz has been redirected to other location.

```
curl -O http://downloads.xiph.org/releases/opus/opus-1.1.tar.gz
tar -zxvf opus-1.1.tar.gz
```

**Changes**

I changed "curl -O http://xxx" to "curl -OL http://xxx"  in all installXXX.sh files.