### PR TITLE
Cap max bitrate in sender bwe

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -173,8 +173,10 @@ bool WebRtcConnection::setRemoteSdp(const std::string &sdp) {
     this->rtcp_processor_->setMaxVideoBW(remoteSdp_.videoBandwidth*1000);
   }
 
-  if (pipeline_initialized_)
+  if (pipeline_initialized_) {
+    pipeline_->notifyUpdate();
     return true;
+  }
 
 
   bundle_ = remoteSdp_.isBundle;

--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
@@ -42,7 +42,7 @@ BandwidthEstimationHandler::BandwidthEstimationHandler(std::shared_ptr<RemoteBit
   picker_{picker},
   using_absolute_send_time_{false}, packets_since_absolute_send_time_{0},
   min_bitrate_bps_{kMinBitRateAllowed},
-  bitrate_{0}, last_send_bitrate_{0}, last_remb_time_{0},
+  bitrate_{0}, last_send_bitrate_{0}, max_video_bw_{300}, last_remb_time_{0},
   running_{false}, active_{true}, initialized_{false} {
     rtc::LogMessage::SetLogToStderr(false);
 }
@@ -68,11 +68,14 @@ void BandwidthEstimationHandler::notifyUpdate() {
   }
   worker_ = connection_->getWorker();
   stats_ = pipeline->getService<Stats>();
-  RtpExtensionProcessor& processor_ = connection_->getRtpExtensionProcessor();
-  if (processor_.getVideoExtensionMap().size() == 0) {
+  RtpExtensionProcessor& ext_processor = connection_->getRtpExtensionProcessor();
+  if (ext_processor.getVideoExtensionMap().size() == 0) {
     return;
   }
-  updateExtensionMaps(processor_.getVideoExtensionMap(), processor_.getAudioExtensionMap());
+  updateExtensionMaps(ext_processor.getVideoExtensionMap(), ext_processor.getAudioExtensionMap());
+
+  auto rtcp_processor = pipeline->getService<RtcpProcessor>();
+  max_video_bw_ = rtcp_processor->getMaxVideoBW();
   pickEstimator();
   initialized_ = true;
 }
@@ -210,7 +213,9 @@ void BandwidthEstimationHandler::sendREMBPacket() {
   //  todo(pedro) figure out which sourceSSRC to use here
   remb_packet_.setSourceSSRC(connection_->getVideoSourceSSRC());
   remb_packet_.setLength(5);
-  remb_packet_.setREMBBitRate(bitrate_);
+  uint32_t capped_bitrate = std::min(max_video_bw_, bitrate_);
+  ELOG_DEBUG("Bitrates min(%u,%u) = %u", bitrate_, max_video_bw_, capped_bitrate);
+  remb_packet_.setREMBBitRate(capped_bitrate);
   remb_packet_.setREMBNumSSRC(1);
   remb_packet_.setREMBFeedSSRC(connection_->getVideoSourceSSRC());
   int remb_length = (remb_packet_.getLength() + 1) * 4;

--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.h
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.h
@@ -82,6 +82,7 @@ class BandwidthEstimationHandler: public Handler, public RemoteBitrateObserver,
   RtpHeaderExtensionMap ext_map_audio_, ext_map_video_;
   uint32_t bitrate_;
   uint32_t last_send_bitrate_;
+  uint32_t max_video_bw_;
   uint64_t last_remb_time_;
   bool running_;
   bool active_;


### PR DESCRIPTION
**Description**

Cap the maximum bitrate sent in the REMBs generated by the sender bitrate estimator, with the value obtained in the SDP.

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.