### PR TITLE
Fix docker push with multiple tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,8 @@ jobs:
               docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
               echo Tagging to lynckia/licode:${SHORT_GIT_HASH}
               docker tag lynckia/licode:develop lynckia/licode:${SHORT_GIT_HASH}
-              docker push lynckia/licode:develop lynckia/licode:${SHORT_GIT_HASH}
+              docker push lynckia/licode:develop
+              docker push lynckia/licode:${SHORT_GIT_HASH}
             fi
 
 prerelease:

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .project
 .cproject
 .git
+.circleci
 licode_config.js
 rtp_media_config.js
 utils/release.sh

--- a/utils/release.sh
+++ b/utils/release.sh
@@ -80,7 +80,8 @@ if [ "$MODE" = "PRERELEASE" ]; then
   # Tag with minor version and staging
   docker tag lynckia/licode:${SHORT_GIT_HASH} lynckia/licode:${NEXT_PRERELEASE_NAME}
   docker tag lynckia/licode:${SHORT_GIT_HASH} lynckia/licode:staging
-  docker push lynckia/licode:${NEXT_PRERELEASE_NAME} lynckia/licode:staging
+  docker push lynckia/licode:${NEXT_PRERELEASE_NAME}
+  docker push lynckia/licode:staging
 
   LOGS=`git log $PREVIOUS_VERSION..$COMMIT --oneline | perl -p -e 's/\n/\\\\n/'`
   DESCRIPTION="### Detailed PR List:\\n$LOGS"
@@ -108,7 +109,8 @@ elif [ "$MODE" = "RELEASE" ]; then
   # Tag with minor version and staging
   docker tag lynckia/licode:${LATEST_PRERELEASE_NAME} lynckia/licode:${RELEASE_NAME}
   docker tag lynckia/licode:${LATEST_PRERELEASE_NAME} lynckia/licode:latest
-  docker push lynckia/licode:${RELEASE_NAME} lynckia/licode:latest
+  docker push lynckia/licode:${RELEASE_NAME}
+  docker push lynckia/licode:latest
 
   # TODO(javier): Remove lynckia/licode:XXX that belongs to this release
 


### PR DESCRIPTION
**Description**

`docker push` does not accept multiple tags in the same command.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

[] It includes documentation for these changes in `/doc`.