### PR TITLE
Avoiding rewriting old erizo.js when launching basic example

### DIFF
--- a/scripts/initBasicExample.sh
+++ b/scripts/initBasicExample.sh
@@ -9,7 +9,6 @@ CURRENT_DIR=`pwd`
 NVM_CHECK="$PATHNAME"/checkNvm.sh
 EXTRAS=$ROOT/extras
 
-cp $ROOT/erizo_controller/erizoClient/dist/erizo.js $EXTRAS/basic_example/public/
 cp $ROOT/nuve/nuveClient/dist/nuve.js $EXTRAS/basic_example/
 
 . $NVM_CHECK


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR fixes a bug that rewrote erizo.js file if you had an old compiled version 

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.