### PR TITLE
Fix issues with audio only streams.

### DIFF
--- a/erizo_controller/erizoClient/src/Events.js
+++ b/erizo_controller/erizoClient/src/Events.js
@@ -24,6 +24,9 @@ const EventDispatcher = () => {
 
   // It removes an available event listener.
   that.removeEventListener = (eventType, listener) => {
+    if (!dispatcher.eventListeners[eventType]) {
+      return;
+    }
     const index = dispatcher.eventListeners[eventType].indexOf(listener);
     if (index !== -1) {
       dispatcher.eventListeners[eventType].splice(index, 1);

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -149,8 +149,8 @@ const Room = (altIo, altConnection, specInput) => {
           browser: stream.pc.browser }, undefined, () => {});
       },
       nop2p: true,
-      audio: stream.hasAudio(),
-      video: stream.hasVideo(),
+      audio: options.audio && stream.hasAudio(),
+      video: options.video && stream.hasVideo(),
       maxAudioBW: options.maxAudioBW,
       maxVideoBW: options.maxVideoBW,
       limitMaxAudioBW: spec.maxAudioBW,
@@ -437,7 +437,9 @@ const Room = (altIo, altConnection, specInput) => {
     if (options.maxVideoBW > spec.maxVideoBW) {
       options.maxVideoBW = spec.maxVideoBW;
     }
-    Logger.info('Checking subscribe options for', stream.getID());
+    options.audio = (options.audio === undefined) ? true : options.audio;
+    options.video = (options.video === undefined) ? true : options.video;
+    options.data = (options.data === undefined) ? true : options.data;
     stream.checkOptions(options);
     const constraint = { streamId: stream.getID(),
       audio: options.audio && stream.hasAudio(),

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -30,8 +30,8 @@ const BaseStack = (specInput) => {
   specBase.remoteDescriptionSet = false;
 
   that.mediaConstraints = {
-    offerToReceiveVideo: (specBase.video !== undefined),
-    offerToReceiveAudio: (specBase.audio !== undefined),
+    offerToReceiveVideo: (specBase.video !== undefined && specBase.video !== false),
+    offerToReceiveAudio: (specBase.audio !== undefined && specBase.audio !== false),
   };
 
   that.peerConnection = new RTCPeerConnection(that.pcConfig, that.con);


### PR DESCRIPTION
**Description**

We were not able to subscribe with {audio:true, video:false} to a stream published as {audio:true, video:false}. There were similar issues that this PR fixes.

Fixes #985 

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.