### PR TITLE
Enable sourcemap for bundle

### DIFF
--- a/erizo_controller/erizoClient/webpack.config.erizo.js
+++ b/erizo_controller/erizoClient/webpack.config.erizo.js
@@ -9,4 +9,5 @@ module.exports = {
     library: 'Erizo',
     libraryTarget: 'var',
   },
+  devtool: 'source-map', // Default development sourcemap
 };


### PR DESCRIPTION
**Description**

Enabled the generation of source maps for erizo when creating the bundle. In order to debug Licode, you can use the `debug` version of `erizo.js` with its source map now. 

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.