### PR TITLE
changing the option for generating source map to 'cheap-module-eval-s…

### DIFF
--- a/erizo_controller/erizoClient/webpack.config.erizo.js
+++ b/erizo_controller/erizoClient/webpack.config.erizo.js
@@ -9,5 +9,5 @@ module.exports = {
     library: 'Erizo',
     libraryTarget: 'var',
   },
-  devtool: 'source-map', // Default development sourcemap
+  devtool: 'cheap-module-eval-source-map', // Default development sourcemap
 };


### PR DESCRIPTION
Let's use this: 
'cheap-module-eval-source-map'
Reasons: 
File name displayed correctly
Line number displayed correctly 
The original source code is displayed