### PR TITLE
External input improvements

### DIFF
--- a/erizo_controller/common/amqper.js
+++ b/erizo_controller/common/amqper.js
@@ -205,10 +205,10 @@ exports.broadcast = function(topic, message, callback) {
 /*
  * Calls remotely the 'method' function defined in rpcPublic of 'to'.
  */
-exports.callRpc = function(to, method, args, callbacks) {
+exports.callRpc = function(to, method, args, callbacks, timeout) {
     corrID ++;
     map[corrID] = {};
     map[corrID].fn = callbacks;
-    map[corrID].to = setTimeout(callbackError, TIMEOUT, corrID);
+    map[corrID].to = setTimeout(callbackError, timeout || TIMEOUT, corrID);
     rpcExc.publish(to, {method: method, args: args, corrID: corrID, replyTo: clientQueue.name});
 };

--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -552,7 +552,7 @@ var listen = function () {
                         callback(id);
                         sendMsgToRoom(socket.room, 'onAddStream', st.getPublicStream());
                     } else {
-                        callback(null, 'Error adding External Input');
+                        callback(null, 'Error adding External Input:' + result);
                     }
                 });
             } else if (options.state === 'erizo') {

--- a/erizo_controller/erizoController/roomController.js
+++ b/erizo_controller/erizoController/roomController.js
@@ -102,7 +102,7 @@ exports.RoomController = function (spec) {
                 subscribers[publisherId] = [];
 
                 amqper.callRpc(getErizoQueue(publisherId), 'addExternalInput', args,
-                               {callback: callback});
+                               {callback: callback}, 20000);
 
                 erizos[erizoId].publishers.push(publisherId);
 


### PR DESCRIPTION
Improvements to external input functionality.

**8da578b log specific error on external input error**
Output the specific error when adding external input fails.

**9ea7fe4 add optional custom timeout for callRpc**
add optional Timeout param to `callRpc` function.

**2ceb3d5 increase timeout for ExternalInput callRpc call**
Start to consume a RTSP source could take more than the default 5000 timeout so this commit increase the wait to complete to 20000 for adding an external input call.

**Changes in Client or Server public APIs**
Changes in Server public API, see 9ea7fe4.

[NO] It includes documentation for these changes in `/doc`.