### PR TITLE
Avoid sending messages when socket is not connected

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -484,6 +484,7 @@ const Room = (altIo, altConnection, specInput) => {
 
   const clearAll = () => {
     that.state = DISCONNECTED;
+    socket.state = socket.DISCONNECTED;
 
     // Remove all streams
     remoteStreams.forEach((stream, id) => {

--- a/erizo_controller/erizoClient/src/Socket.js
+++ b/erizo_controller/erizoClient/src/Socket.js
@@ -71,8 +71,17 @@ const Socket = (newIo) => {
     }, error);
   };
 
+  that.disconnect = () => {
+    that.state = that.DISCONNECTED;
+    socket.disconnect();
+  };
+
   // Function to send a message to the server using socket.io
   that.sendMessage = (type, msg, callback = defaultCallback, error = defaultCallback) => {
+    if (that.state === that.DISCONNECTED && type !== 'token') {
+      Logger.error('Trying to send a message over a disconnected Socket');
+      return;
+    }
     socket.emit(type, msg, (respType, resp) => {
       if (respType === 'success') {
         callback(resp);
@@ -87,7 +96,7 @@ const Socket = (newIo) => {
   // It sends a SDP message to the server using socket.io
   that.sendSDP = (type, options, sdp, callback = defaultCallback) => {
     if (that.state === that.DISCONNECTED) {
-      Logger.warning('Trying to send a message over a disconnected Socket');
+      Logger.error('Trying to send a message over a disconnected Socket');
       return;
     }
     socket.emit(type, options, sdp, (response, respCallback) => {

--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -476,6 +476,11 @@ var listen = function () {
         };
 
         socket.on('signaling_message', function (msg) {
+            if (socket.room === undefined) {
+              log.error('message: singaling_message for user in undefined room ' +
+              msg.streamId + ' user: ' + socket.user);
+              socket.disconnect();
+            }
             if (socket.room.p2p) {
                 sendToSocket(msg.peerSocket, 'signaling_message_peer',
                         {streamId: msg.streamId, peerSocket: socket.id, msg: msg.msg});


### PR DESCRIPTION
**Description**
Messages could be sent even if the Room was not connected yet. 
Also `socket.disconnect` no longer existed.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.