### PR TITLE
Disable docs in libav configure

### DIFF
--- a/scripts/installMacDeps.sh
+++ b/scripts/installMacDeps.sh
@@ -178,7 +178,7 @@ install_mediadeps(){
     cd libav-11.6
     curl -OL https://github.com/libav/libav/commit/4d05e9392f84702e3c833efa86e84c7f1cf5f612.patch
     patch libavcodec/libvpxenc.c 4d05e9392f84702e3c833efa86e84c7f1cf5f612.patch && \
-    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus && \
+    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus --disable-doc && \
     make $FAST_MAKE -s V=0 && \
     make install
     check_result $?
@@ -198,7 +198,7 @@ install_mediadeps_nogpl(){
     cd libav-11.6
     curl -OL https://github.com/libav/libav/commit/4d05e9392f84702e3c833efa86e84c7f1cf5f612.patch
     patch libavcodec/libvpxenc.c 4d05e9392f84702e3c833efa86e84c7f1cf5f612.patch && \
-    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-libvpx --enable-libopus && \
+    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-libvpx --enable-libopus --disable-doc && \
     make $FAST_MAKE -s V=0 && \
     make install
     check_result $?

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -161,7 +161,7 @@ install_mediadeps(){
       curl -O -L https://github.com/libav/libav/archive/v11.1.tar.gz
       tar -zxvf v11.1.tar.gz
       cd libav-11.1
-      PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus
+      PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus --disable-doc
       make $FAST_MAKE -s V=0
       make install
     else
@@ -184,7 +184,7 @@ install_mediadeps_nogpl(){
       curl -O -L https://github.com/libav/libav/archive/v11.1.tar.gz
       tar -zxvf v11.1.tar.gz
       cd libav-11.1
-      PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libopus
+      PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libopus --disable-doc
       make $FAST_MAKE -s V=0
       make install
     else

--- a/scripts/travisInstallDeps.sh
+++ b/scripts/travisInstallDeps.sh
@@ -136,7 +136,7 @@ install_mediadeps(){
       curl -O -L https://github.com/libav/libav/archive/v11.1.tar.gz
       tar -zxvf v11.1.tar.gz
       cd libav-11.1
-      PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus
+      PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus --disable-doc 
       make -s V=0
       make install
     else
@@ -158,7 +158,7 @@ install_mediadeps_nogpl(){
       curl -O -L https://github.com/libav/libav/archive/v11.1.tar.gz
       tar -zxvf v11.1.tar.gz
       cd libav-11.1
-      PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libopus
+      PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libopus --disable-doc
       make -s V=0
       make install
     else


### PR DESCRIPTION
**Description**

Disable docs in libav installation. Was problematic in Mac and removed them from the others as we don't really need them 

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

[] It includes documentation for these changes in `/doc`.