### PR TITLE
Added logger to ErizoFC

### DIFF
--- a/doc/client_api.md
+++ b/doc/client_api.md
@@ -899,17 +899,21 @@ You can configure and customize the way ErizoClient:
 
 Running erizo clients in your node.js applications.
 
-You can also run erizo clients in your node.js applications with the same API explained here. You can connect to rooms, publish and subscribe to streams and manage events. You need only to import the node module **erizofc.js**
+You can also run erizo clients in your node.js applications with the same API explained here. You can connect to rooms, publish and subscribe to streams and manage events. You need only to import the node module **erizofc.js**. This adds a new dependency that you will need to install: ` npm install socket.io-client`
 
 ```
-var Erizo = require('.erizofc').Erizo;
+var newIo = require('socket.io-client');
+var Erizo = require('.erizofc');
+```
+
+The line to initialize a room changes slightly. So, once you have a token:
+```
+var room = Erizo.Room(newIo, undefined, {token:'theToken'});
 ```
 
 And now you can use the API like explained for the browser case, calling `Erizo.Room`, `Erizo.Stream` and `Erizo.Events`. Note that you can not publish/subscribe streams with video and/or audio. We are working on this feature in order to develop another way of distribute video/audio streams.
 
 You can also use Erizo Client Logger for managing log levels, etc.
-
 ```
-var L = require('.erizofc').L;
-L.Logger.setLogLevel(2);
+Erizo.Logger.setLogLevel(Erizo.Logger.ERROR);
 ```

--- a/erizo_controller/erizoClient/src/ErizoFc.js
+++ b/erizo_controller/erizoClient/src/ErizoFc.js
@@ -1,7 +1,7 @@
 import Room from './Room';
 import { LicodeEvent, RoomEvent, StreamEvent } from './Events';
 import Stream from './Stream';
-
+import Logger from './utils/Logger';
 // Using script-loader to load global variables
 
 const Erizo = {
@@ -10,6 +10,7 @@ const Erizo = {
   RoomEvent,
   StreamEvent,
   Stream,
+  Logger,
 };
 
 export default Erizo;


### PR DESCRIPTION
**Description**

This PR adds exporting the Logger in ErizoFc and fixes the docs for it as they were outdated since we refactored ErizoClient.

Fixes #996 

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**


- [x] It includes documentation for these changes in `/doc`.