### PR TITLE
Fixed spine publishing and publishing and subscribing in the same process

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -157,8 +157,8 @@ const Room = (altIo, altConnection, specInput) => {
       limitMaxVideoBW: spec.maxVideoBW,
       iceServers: that.iceServers };
     if (isRemote) {
-      connectionOpts.audio = connectionOpts.audio && stream.hasAudio();
-      connectionOpts.video = connectionOpts.video && stream.hasVideo();
+      connectionOpts.audio = connectionOpts.audio && connectionOpts.audio !== undefined;
+      connectionOpts.video = connectionOpts.video && connectionOpts.audio !== undefined;
     } else {
       connectionOpts.simulcast = options.simulcast;
     }

--- a/spine/simpleNativeConnection.js
+++ b/spine/simpleNativeConnection.js
@@ -80,7 +80,7 @@ exports.ErizoSimpleNativeConnection = function (spec, callback, error){
                 subscribeToStreams(roomEvent.streams);
                 if (spec.publishConfig){
                     log.info('Will publish with config', spec.publishConfig);
-                    localStream = Erizo.Stream(spec.publishConfig);
+                    localStream = Erizo.Stream(fakeConnection, spec.publishConfig);
                     room.publish(localStream, spec.publishConfig, function(id, message){
                         if (id === undefined){
                             log.error('ERROR when publishing', message);


### PR DESCRIPTION
**Description**
This PR fixes two problems:
1. Spine was not properly creating Streams for publication - this PR updates it to use the new API
2. `hasAudio()` and `hasVideo()` were returning the full `video` or `audio` entries of the configuration.  When creating the Connection `getErizoConnectionOpts` was passing in the subscribing side, where we only need `true` or `false`

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.