### PR TITLE
Added a gulp task per target

### DIFF
--- a/erizo_controller/erizoClient/gulpfile.js
+++ b/erizo_controller/erizoClient/gulpfile.js
@@ -34,14 +34,19 @@ taskFunctions.erizofc = require('./gulp/erizoFcTasks.js')(gulp, plugins, config)
 
 targets.forEach(
   (target) => {
+    const targetTasks = ['lint'];
     tasks.forEach(
       (task) => {
         const taskName = `${task}_${target}`;
         allTasks.push(taskName);
+        targetTasks.push(taskName);
         gulp.task(taskName, () => {
           return taskFunctions[target][task]()
         });
       });
+    gulp.task(target, () => {
+      plugins.runSequence(...targetTasks);
+    })
   });
 
 gulp.task('lint', () => {

--- a/erizo_controller/installErizo_controller.sh
+++ b/erizo_controller/installErizo_controller.sh
@@ -20,6 +20,6 @@ echo [erizo_controller] Done, node_modules installed
 
 cd ./erizoClient/
 
-gulp
+gulp erizo
 
 echo [erizo_controller] Done, erizo.js compiled

--- a/spine/installSpine.sh
+++ b/spine/installSpine.sh
@@ -21,6 +21,6 @@ echo [spine] Done, node_modules installed
 
 cd ../erizo_controller/erizoClient/
 
-gulp
+gulp erizofc
 
 echo [spine] Done, erizofc.js compiled


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
We were repeating work when installing licode as the gulp default task builds both `erizofc` and `erizo`. This PR adds a new task per target in gulp for `ErizoClient`. The installation scripts are also updated to use these tasks.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.