### PR TITLE
Add scripts to run performance tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ erizo_controller/erizoAgent/erizo-*.log
 .project
 .cproject
 spine/erizofc.js
+spine/testResult.json
 extras/basic_example/public/assets/
 rtp_media_config.js

--- a/spine/runSpineClients.js
+++ b/spine/runSpineClients.js
@@ -4,8 +4,8 @@ const Spine = require('./Spine.js');
 
 const getopt = new Getopt([
   ['s', 'stream-config=ARG', 'file containing the stream config JSON (default is spineClientsConfig.json)'],
-  ['i', 'interval=ARG', 'interval time to show stats (default 10 seconds)'],
-  ['t', 'total-intervals=ARG', 'total test intervals (default 10 intervals)'],
+  ['t', 'interval=ARG', 'interval time to show stats (default 10 seconds)'],
+  ['i', 'total-intervals=ARG', 'total test intervals (default 10 intervals)'],
   ['o', 'output=ARG', 'output file for the stat digest (default is testResult.json)'],
   ['h', 'help', 'display this help'],
 ]);
@@ -30,7 +30,7 @@ optionKeys.forEach((key) => {
     case 'interval':
       statsIntervalTime = value * 1000;
       break;
-    case 'totalIntervals':
+    case 'total-intervals':
       totalStatsIntervals = value;
       break;
     case 'output':
@@ -100,9 +100,7 @@ const gatherStatuses = () => {
 };
 
 const writeJsonToFile = (result) => {
-  fs.writeFile(statOutputFile, JSON.stringify(result), (err) => {
-    if (err) throw err;
-  });
+  fs.writeFileSync(statOutputFile, JSON.stringify(result));
   process.exit(0);
 };
 

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "mocha/test"
+}

--- a/test/licode_default.js
+++ b/test/licode_default.js
@@ -1,0 +1,183 @@
+var config = {}
+
+/*********************************************************
+ COMMON CONFIGURATION
+ It's used by Nuve, ErizoController, ErizoAgent and ErizoJS
+**********************************************************/
+config.rabbit = {};
+config.rabbit.host = 'localhost'; //default value: 'localhost'
+config.rabbit.port = 5672; //default value: 5672
+// Sets the AQMP heartbeat timeout to detect dead TCP Connections
+config.rabbit.heartbeat = 8; //default value: 8 seconds, 0 to disable
+config.logger = {};
+config.logger.configFile = '../log4js_configuration.json'; //default value: "../log4js_configuration.json"
+
+/*********************************************************
+ CLOUD PROVIDER CONFIGURATION
+ It's used by Nuve and ErizoController
+**********************************************************/
+config.cloudProvider = {};
+config.cloudProvider.name = '';
+
+/*********************************************************
+ NUVE CONFIGURATION
+**********************************************************/
+config.nuve = {};
+config.nuve.dataBaseURL = "localhost/nuvedb"; // default value: 'localhost/nuvedb'
+config.nuve.superserviceID = '_auto_generated_ID_'; // default value: ''
+config.nuve.superserviceKey = '_auto_generated_KEY_'; // default value: ''
+config.nuve.testErizoController = 'localhost:8080'; // default value: 'localhost:8080'
+// Nuve Cloud Handler policies are in nuve/nuveAPI/ch_policies/ folder
+config.nuve.cloudHandlerPolicy = 'default_policy.js'; // default value: 'default_policy.js'
+
+
+/*********************************************************
+ ERIZO CONTROLLER CONFIGURATION
+**********************************************************/
+config.erizoController = {};
+
+// Use undefined to run clients without Ice Servers
+//
+// Stun servers format
+// {
+//     "url": url
+// }
+//
+// Turn servers format
+// {
+//     "username": username,
+//     "credential": password,
+//     "url": url
+// }
+config.erizoController.iceServers = [{'url': 'stun:stun.l.google.com:19302'}]; // default value: [{'url': 'stun:stun.l.google.com:19302'}]
+
+// Default and max video bandwidth parameters to be used by clients
+config.erizoController.defaultVideoBW = 300; //default value: 300
+config.erizoController.maxVideoBW = 300; //default value: 300
+
+// Public erizoController IP for websockets (useful when behind NATs)
+// Use '' to automatically get IP from the interface
+config.erizoController.publicIP = ''; //default value: ''
+config.erizoController.networkinterface = ''; //default value: ''
+
+// This configuration is used by the clients to reach erizoController
+// Use '' to use the public IP address instead of a hostname
+config.erizoController.hostname = ''; //default value: ''
+config.erizoController.port = 8080; //default value: 8080
+// Use true if clients communicate with erizoController over SSL
+config.erizoController.ssl = true; //default value: false
+
+// This configuration is used by erizoController server to listen for connections
+// Use true if erizoController listens in HTTPS.
+config.erizoController.listen_ssl = true; //default value: false
+config.erizoController.listen_port = 8080; //default value: 8080
+
+// Custom location for SSL certificates. Default located in /cert
+//config.erizoController.ssl_key = '/full/path/to/ssl.key';
+//config.erizoController.ssl_cert = '/full/path/to/ssl.crt';
+//config.erizoController.sslCaCerts = ['/full/path/to/ca_cert1.crt', '/full/path/to/ca_cert2.crt'];
+
+// Use the name of the inferface you want to bind to for websockets
+// config.erizoController.networkInterface = 'eth1' // default value: undefined
+
+config.erizoController.warning_n_rooms = 15; // default value: 15
+config.erizoController.limit_n_rooms = 20; // default value: 20
+config.erizoController.interval_time_keepAlive = 1000; // default value: 1000
+
+// Roles to be used by services
+config.erizoController.roles =
+{"presenter": {"publish": true, "subscribe": true, "record": true, "stats": true, "controlhandlers": true},
+    "viewer": {"subscribe": true},
+    "viewerWithData": {"subscribe": true, "publish": {"audio": false, "video": false, "screen": false, "data": true}}}; // default value: {"presenter":{"publish": true, "subscribe":true, "record":true}, "viewer":{"subscribe":true}, "viewerWithData":{"subscribe":true, "publish":{"audio":false,"video":false,"screen":false,"data":true}}}
+
+// If true, erizoController sends report to rabbitMQ queue "report_handler"
+config.erizoController.report = {
+    session_events: false, 		// Session level events -- default value: false
+    connection_events: false, 	// Connection (ICE) level events -- default value: false
+    rtcp_stats: false				// RTCP stats -- default value: false
+};
+
+// Subscriptions to rtcp_stats via AMQP
+config.erizoController.reportSubscriptions = {
+	maxSubscriptions: 10,	// per ErizoJS -- set 0 to disable subscriptions -- default 10
+	minInterval: 1, 		// in seconds -- default 1
+	maxTimeout: 60			// in seconds -- default 60
+};
+
+// If undefined, the path will be /tmp/
+config.erizoController.recording_path = undefined; // default value: undefined
+
+// Erizo Controller Cloud Handler policies are in erizo_controller/erizoController/ch_policies/ folder
+config.erizoController.cloudHandlerPolicy = 'default_policy.js'; // default value: 'default_policy.js'
+
+/*********************************************************
+ ERIZO AGENT CONFIGURATION
+**********************************************************/
+config.erizoAgent = {};
+
+// Max processes that ErizoAgent can run
+config.erizoAgent.maxProcesses 	  = 1; // default value: 1
+// Number of precesses that ErizoAgent runs when it starts. Always lower than or equals to maxProcesses.
+config.erizoAgent.prerunProcesses = 1; // default value: 1
+
+// Public erizoAgent IP for ICE candidates (useful when behind NATs)
+// Use '' to automatically get IP from the interface
+config.erizoAgent.publicIP = ''; //default value: ''
+config.erizoAgent.networkinterface = ''; //default value: ''
+
+// Use the name of the inferface you want to bind for ICE candidates
+// config.erizoAgent.networkInterface = 'eth1' // default value: undefined
+
+//Use individual log files for each of the started erizoJS processes
+//This files will be named erizo-ERIZO_ID_HASH.log
+config.erizoAgent.useIndividualLogFiles = false;
+
+// Custom log directory for agent instance log files.
+// If useIndividualLogFiles is enabled, files will go here
+// Default is [licode_path]/erizo_controller/erizoAgent
+// config.erizoAgent.instanceLogDir = '/path/to/dir';
+
+
+/*********************************************************
+ ERIZO JS CONFIGURATION
+**********************************************************/
+config.erizo = {};
+
+//Erizo Logs are piped through erizoAgent by default
+//you can control log levels in [licode_path]/erizo_controller/erizoAgent/log4cxx.properties
+
+// Number of workers that will be used to handle WebRtcConnections
+config.erizo.numWorkers = 24;
+
+// Number of workers what will be used for IO (including ICE logic)
+config.erizo.numIOWorkers = 1;
+
+//STUN server IP address and port to be used by the server.
+//if '' is used, the address is discovered locally
+//Please note this is only needed if your server does not have a public IP
+config.erizo.stunserver = ''; // default value: ''
+config.erizo.stunport = 0; // default value: 0
+
+//TURN server IP address and port to be used by the server.
+//Please note this is not needed in most cases, setting TURN in erizoController for the clients
+//is the recommended configuration
+//if '' is used, no relay for the server is used
+config.erizo.turnserver = ''; // default value: ''
+config.erizo.turnport = 0; // default value: 0
+config.erizo.turnusername = '';
+config.erizo.turnpass = '';
+config.erizo.networkinterface = ''; //default value: ''
+
+//note, this won't work with all versions of libnice. With 0 all the available ports are used
+config.erizo.minport = 0; // default value: 0
+config.erizo.maxport = 0; // default value: 0
+
+//Use of internal nICEr library instead of libNice.
+config.erizo.useNicer = false;  // default value: false
+
+config.erizo.disabledHandlers = []; // there are no handlers disabled by default
+
+/***** END *****/
+// Following lines are always needed.
+var module = module || {};
+module.exports = config;

--- a/test/package.json
+++ b/test/package.json
@@ -1,9 +1,11 @@
 {
-  "name" : "erizo-tests",
+  "name": "erizo-tests",
   "version": "0.0.1",
   "private": true,
   "dependencies": {
-    "node-getopt":"0.2.3",
-    "chai":"3.5.0"
+    "aws-sdk": "^2.102.0",
+    "chai": "3.5.0",
+    "node-getopt": "0.2.3",
+    "node-ssh": "^4.2.3"
   }
 }

--- a/test/perf-tests.js
+++ b/test/perf-tests.js
@@ -1,0 +1,46 @@
+const InstanceFactory = require('./utils/remote-spine').Factory;
+
+describe('Licode Performance', function() {
+  this.timeout(60 * 60 * 1000);
+  let factory;
+
+  getLicodeInstance = () => factory.instances[0];
+  getSpineInstance = () => factory.instances[1];
+
+  before(() => {
+    let settings = {
+      numberOfInstances: 2,
+      imageId: 'ami-2ff3e756',
+      username: 'ec2-user',
+      instanceType: process.env.PERF_INSTANCE_TYPE || 't1.micro',
+      keyName: process.env.PERF_KEY_NAME || 'staging',
+      privateKey: process.env.PERF_PRIVATE_KEY || '~/.ssh/id_rsa',
+      dockerTag: process.env.PERF_DOCKER_TAG || 'staging',
+      region: process.env.PERF_REGION || 'us-west-2',
+      securityGroup: process.env.PERF_SECURITY_GROUP || 'Licode'
+    };
+    factory = new InstanceFactory(settings);
+    return factory.run();
+  });
+
+  beforeEach(() => {
+    return getLicodeInstance().runLicode();
+  });
+
+  it('Test setup', (done) => {
+    console.log('Starting test');
+    console.log('ssh -i', process.env.PERF_PRIVATE_KEY, 'ec2-user@' + getLicodeInstance().host);
+    setTimeout(() => {
+      console.log('Finished');
+      done();
+    }, 20 * 60 * 1000);
+  });
+
+  afterEach(() => {
+    return getLicodeInstance().stopLicode();
+  });
+
+  after(() => {
+    return factory.terminate();
+  });
+});

--- a/test/rtp_media_config_default.js
+++ b/test/rtp_media_config_default.js
@@ -1,0 +1,139 @@
+var mediaConfig = {};
+
+mediaConfig.extMappings = [
+  "urn:ietf:params:rtp-hdrext:ssrc-audio-level",
+  "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time",
+  "urn:ietf:params:rtp-hdrext:toffset",
+  "urn:3gpp:video-orientation",
+  // "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01",
+  "http://www.webrtc.org/experiments/rtp-hdrext/playout-delay",
+  "urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id"
+];
+
+mediaConfig.rtpMappings = {};
+
+mediaConfig.rtpMappings.vp8 = {
+    payloadType: 100,
+    encodingName: 'VP8',
+    clockRate: 90000,
+    channels: 1,
+    mediaType: 'video',
+    feedbackTypes: [
+        'ccm fir',
+        'nack',
+        'nack pli',
+        'goog-remb',
+//        'transport-cc',
+    ],
+};
+/*
+mediaConfig.rtpMappings.red = {
+    payloadType: 116,
+    encodingName: 'red',
+    clockRate: 90000,
+    channels: 1,
+    mediaType: 'video',
+};
+
+mediaConfig.rtpMappings.rtx = {
+    payloadType: 96,
+    encodingName: 'rtx',
+    clockRate: 90000,
+    channels: 1,
+    mediaType: 'video',
+    formatParameters: {
+        apt: '100'
+    },
+};
+
+mediaConfig.rtpMappings.ulpfec = {
+    payloadType: 117,
+    encodingName: 'ulpfec',
+    clockRate: 90000,
+    channels: 1,
+    mediaType: 'video',
+};
+
+mediaConfig.rtpMappings.opus = {
+    payloadType: 111,
+    encodingName: 'opus',
+    clockRate: 48000,
+    channels: 2,
+    mediaType: 'audio',
+};
+
+mediaConfig.rtpMappings.isac16 = {
+    payloadType: 103,
+    encodingName: 'ISAC',
+    clockRate: 16000,
+    channels: 1,
+    mediaType: 'audio',
+};
+
+mediaConfig.rtpMappings.isac32 = {
+    payloadType: 104,
+    encodingName: 'ISAC',
+    clockRate: 32000,
+    channels: 1,
+    mediaType: 'audio',
+};
+
+*/
+mediaConfig.rtpMappings.pcmu = {
+    payloadType: 0,
+    encodingName: 'PCMU',
+    clockRate: 8000,
+    channels: 1,
+    mediaType: 'audio',
+};
+/*
+mediaConfig.rtpMappings.pcma = {
+    payloadType: 8,
+    encodingName: 'PCMA',
+    clockRate: 8000,
+    channels: 1,
+    mediaType: 'audio',
+};
+
+mediaConfig.rtpMappings.cn8 = {
+    payloadType: 13,
+    encodingName: 'CN',
+    clockRate: 8000,
+    channels: 1,
+    mediaType: 'audio',
+};
+
+mediaConfig.rtpMappings.cn16 = {
+    payloadType: 105,
+    encodingName: 'CN',
+    clockRate: 16000,
+    channels: 1,
+    mediaType: 'audio',
+};
+
+mediaConfig.rtpMappings.cn32 = {
+    payloadType: 106,
+    encodingName: 'CN',
+    clockRate: 32000,
+    channels: 1,
+    mediaType: 'audio',
+};
+
+mediaConfig.rtpMappings.cn48 = {
+    payloadType: 107,
+    encodingName: 'CN',
+    clockRate: 48000,
+    channels: 1,
+    mediaType: 'audio',
+};
+*/
+mediaConfig.rtpMappings.telephoneevent = {
+    payloadType: 126,
+    encodingName: 'telephone-event',
+    clockRate: 8000,
+    channels: 1,
+    mediaType: 'audio',
+};
+
+var module = module || {};
+module.exports = mediaConfig;

--- a/test/runSpineTest.sh
+++ b/test/runSpineTest.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+SCRIPT=`pwd`/$0
+
+FILENAME=`basename $SCRIPT`
+PATHNAME=`dirname $SCRIPT`
+NVM_CHECK="$PATHNAME"/checkNvm.sh
+ROOT=$PATHNAME/..
+NVM_CHECK="$ROOT"/scripts/checkNvm.sh
+
+echo `pwd`
+echo $0
+echo $NVM_CHECK
+echo $PATHNAME
+echo $SCRIPT
+echo $FILENAME
+
+. $NVM_CHECK
+
+export LD_LIBRARY_PATH=/opt/licode/erizo/build/erizo
+
+cd $ROOT/spine
+node runSpineClients -s spineClientsConfig.json -t 10 -i 1 -o $ROOT/results/output.json

--- a/test/utils/remote-spine.js
+++ b/test/utils/remote-spine.js
@@ -1,0 +1,208 @@
+const SSH = require('node-ssh');
+const AWS = require('aws-sdk');
+
+const SPINE_WRITE_CONFIG_FILE_COMMAND = 'echo DATA >> config.json';
+const SPINE_DOCKER_PULL_COMMAND = 'sudo docker pull lynckia/licode:TAG';
+const SPINE_RUN_COMMAND = 'sudo docker image ls';
+const SPINE_GET_RESULT_COMMAND = 'ls';
+
+const LICODE_RUN_COMMAND = 'sudo docker image ls';
+const LICODE_STOP_COMMAND= 'sudo docker image ls';
+
+const EC2_API_VERSION = '2016-11-15';
+const SSH_RETRY_TIMEOUT = 5000;
+const SSH_MAX_RETRIES = 10;
+
+const EC2_INSTANCE_LIFETIME = 50; // minutes
+
+
+class RemoteInstance {
+  constructor(host, username, privateKey, dockerTag) {
+    this.ssh = new SSH();
+    this.host = host;
+    this.username = username;
+    this.privateKey = privateKey;
+    this.dockerTag = dockerTag;
+    this.retries = 0;
+  }
+
+  _connect(success = () => {}, fail = () => {}) {
+    this.ssh.connect({
+      host: this.host,
+      username: this.username,
+      privateKey: this.privateKey,
+    }).then(() => {
+      success();
+    }).catch(() => {
+      this.retries += 1;
+      if (this.retries > SSH_MAX_RETRIES) {
+        fail('unable to connect');
+        return;
+      }
+      setTimeout(() => {
+        this._connect(success, fail);
+      }, SSH_RETRY_TIMEOUT);
+
+    });
+  }
+
+  connect() {
+    return new Promise((resolve, reject) => {
+      this._connect(resolve, reject);
+    });
+  }
+
+  _execCommand(...args) {
+    return this.ssh.execCommand(...args)
+      .then(data => {
+        if (data.code === 0) {
+          return data.stdout;
+        } else {
+          throw Error(data.stderr);
+        }
+      });
+  }
+
+  setup() {
+    return this._execCommand('sudo yum update -y')
+      .then(() => this._execCommand('sudo yum install -y docker'))
+      .then(() => this._execCommand('sudo service docker start'))
+      .then(() => this._execCommand(SPINE_DOCKER_PULL_COMMAND.replace(/TAG/, this.dockerTag)));
+  }
+
+  runLicode() {
+    return this._execCommand(LICODE_RUN_COMMAND);
+  }
+
+  stopLicode() {
+    return this._execCommand(LICODE_STOP_COMMAND)
+  }
+
+  runTest(settings) {
+    const settingsText = JSON.stringify(settings);
+    return this._execCommand(SPINE_WRITE_CONFIG_FILE_COMMAND.replace(/DATA/, `'${settingsText}'`))
+      .then(() => this._execCommand(SPINE_RUN_COMMAND))
+      .then(() => this.getResult());
+  }
+
+  getResult() {
+    const promise = this._execCommand(SPINE_GET_RESULT_COMMAND);
+    promise.then((data) => {
+      this.result = JSON.parse(data);
+    });
+    return promise;
+  }
+
+  disconnect() {
+    this.ssh.dispose();
+  }
+}
+
+// more info: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/EC2.html
+class Factory {
+  constructor(settings) {
+    this.ec2 = new AWS.EC2({ apiVersion: EC2_API_VERSION, region: settings.region });
+    this.numberOfInstances = settings.numberOfInstances;
+    this.imageId = settings.imageId;
+    this.instanceType = settings.instanceType;
+    this.username = settings.username;
+    this.privateKey = settings.privateKey;
+    this.keyName = settings.keyName;
+    this.dockerTag = settings.dockerTag;
+    this.securityGroup = settings.securityGroup;
+    this.instances = [];
+  }
+
+  run() {
+    return new Promise((resolve, reject) => {
+      this.params = {
+        ImageId: this.imageId,
+        MaxCount: this.numberOfInstances,
+        MinCount: this.numberOfInstances,
+        KeyName: this.keyName,
+        Monitoring: {
+          Enabled: false,
+        },
+        SecurityGroups: [ this.securityGroup, ],
+        InstanceType: this.InstanceType,
+        InstanceInitiatedShutdownBehavior: 'terminate',
+        UserData: new Buffer(`#!/bin/bash
+          sudo shutdown -h +${EC2_INSTANCE_LIFETIME}`).toString('base64'), // automatically terminate instances
+        TagSpecifications: [ {
+          ResourceType: 'instance',
+          Tags: [ {
+              Key: 'Name',
+              Value: 'Tests - licode-stress-test',
+            }, ]
+        }, ],
+      };
+      this.ec2.runInstances(this.params, (err, data) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        this.data = data;
+        this.waitForRunning()
+        .then(() => {
+          resolve();
+        }).catch((reason) => {
+          reject(reason);
+        });
+      });
+    });
+  }
+
+  waitForRunning() {
+    return new Promise((resolve, reject) => {
+      const params = {
+        Filters: [{
+          Name: 'reservation-id',
+          Values: [this.data.ReservationId],
+        }],
+      };
+      this.ec2.waitFor('instanceRunning', params, (err, data) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        let promises = [];
+        data.Reservations[0].Instances.forEach((instance) => {
+          const host = instance.PublicDnsName;
+          const spine = new RemoteInstance(host, this.username, this.privateKey, this.dockerTag);
+          this.instances.push(spine);
+          let promise = spine.connect()
+                             .then(() => spine.setup());
+          promises.push(promise);
+        });
+        Promise.all(promises)
+          .then(() => {
+            resolve();
+          })
+          .catch((reason) => {
+            reject(reason);
+          });
+      });
+
+    });
+  }
+
+  terminate() {
+    return new Promise((resolve, reject) => {
+      const params = {
+        InstanceIds: [],
+      };
+      this.data.Instances.forEach((instance) => {
+        params.InstanceIds.push(instance.InstanceId);
+      });
+      this.ec2.terminateInstances(params, (err, data) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+}
+
+exports.Factory = Factory;


### PR DESCRIPTION
**Description**

Add the option to run performance tests in the future. It's focused to run Licode and Spine clients on Amazon EC2 instances.

This is still in progress, so please do not merge it.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed?

[] It includes documentation for these changes in `/doc`.