### PR TITLE
LayerDetectorHandler reads also resolution and framerate

### DIFF
--- a/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
+++ b/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
@@ -53,7 +53,7 @@ void LayerDetectorHandler::notifyLayerInfoChangedEvent() {
               spatial_layer, video_frame_width_list_[spatial_layer], video_frame_height_list_[spatial_layer]);
   }
   for (uint32_t temporal_layer = 0; temporal_layer < video_frame_rate_list_.size(); temporal_layer++) {
-    ELOG_DEBUG(" TEMPORAL LAYER (%u): %u",
+    ELOG_DEBUG(" TEMPORAL LAYER (%u): %lu",
               temporal_layer, video_frame_rate_list_[temporal_layer].value());
   }
 
@@ -106,7 +106,7 @@ void LayerDetectorHandler::parseLayerInfoFromVP8(std::shared_ptr<DataPacket> pac
     packet->is_keyframe = false;
   }
 
-  if (payload->frameWidth != -1 && payload->frameWidth != video_frame_width_list_[position]) {
+  if (payload->frameWidth != -1 && static_cast<int>(payload->frameWidth) != video_frame_width_list_[position]) {
     video_frame_width_list_[position] = payload->frameWidth;
     video_frame_height_list_[position] = payload->frameHeight;
     notifyLayerInfoChangedEvent();
@@ -155,7 +155,7 @@ void LayerDetectorHandler::parseLayerInfoFromVP9(std::shared_ptr<DataPacket> pac
   }
   bool resolution_changed = false;
   if (payload->resolutions.size() > 0) {
-    for (int position = 0; position < payload->resolutions.size(); position++) {
+    for (uint position = 0; position < payload->resolutions.size(); position++) {
       resolution_changed = true;
       video_frame_width_list_[position] = payload->resolutions[position].width;
       video_frame_height_list_[position] = payload->resolutions[position].height;

--- a/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
+++ b/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
@@ -9,6 +9,7 @@ namespace erizo {
 
 static constexpr uint32_t kMaxTemporalLayers = 4;
 static constexpr uint32_t kMaxSpatialLayers = 4;
+static constexpr erizo::duration kMinNotifyLayerInfoInterval = std::chrono::seconds(5);
 
 DEFINE_LOGGER(LayerDetectorHandler, "rtp.LayerDetectorHandler");
 
@@ -63,7 +64,7 @@ void LayerDetectorHandler::notifyLayerInfoChangedEvent() {
 }
 
 void LayerDetectorHandler::notifyLayerInfoChangedEventMaybe() {
-  if (clock_->now() - last_event_sent_ > std::chrono::seconds(5)) {
+  if (clock_->now() - last_event_sent_ > kMinNotifyLayerInfoInterval) {
     notifyLayerInfoChangedEvent();
   }
 }

--- a/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
+++ b/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
@@ -15,7 +15,7 @@ DEFINE_LOGGER(LayerDetectorHandler, "rtp.LayerDetectorHandler");
 LayerDetectorHandler::LayerDetectorHandler(std::shared_ptr<erizo::Clock> the_clock)
     : clock_{the_clock}, connection_{nullptr}, enabled_{true}, initialized_{false},
     last_event_sent_{clock_->now()} {
-  for (int temporal_layer = 0; temporal_layer <= kMaxTemporalLayers; temporal_layer++) {
+  for (uint32_t temporal_layer = 0; temporal_layer <= kMaxTemporalLayers; temporal_layer++) {
     video_frame_rate_list_.push_back(MovingIntervalRateStat{std::chrono::milliseconds(500), 10, .5, clock_});
   }
   video_frame_width_list_ = std::vector<uint32_t>(kMaxSpatialLayers);
@@ -48,12 +48,12 @@ void LayerDetectorHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet
 
 void LayerDetectorHandler::notifyLayerInfoChangedEvent() {
   ELOG_DEBUG("LAYER INFO CHANGED");
-  for (int spatial_layer = 0; spatial_layer < video_frame_width_list_.size(); spatial_layer++) {
-    ELOG_DEBUG(" SPATIAL LAYER (%d): %d %d",
+  for (uint32_t spatial_layer = 0; spatial_layer < video_frame_width_list_.size(); spatial_layer++) {
+    ELOG_DEBUG(" SPATIAL LAYER (%u): %u %u",
               spatial_layer, video_frame_width_list_[spatial_layer], video_frame_height_list_[spatial_layer]);
   }
-  for (int temporal_layer = 0; temporal_layer < video_frame_rate_list_.size(); temporal_layer++) {
-    ELOG_DEBUG(" TEMPORAL LAYER (%d): %d",
+  for (uint32_t temporal_layer = 0; temporal_layer < video_frame_rate_list_.size(); temporal_layer++) {
+    ELOG_DEBUG(" TEMPORAL LAYER (%u): %u",
               temporal_layer, video_frame_rate_list_[temporal_layer].value());
   }
 

--- a/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
+++ b/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
@@ -106,7 +106,7 @@ void LayerDetectorHandler::parseLayerInfoFromVP8(std::shared_ptr<DataPacket> pac
     packet->is_keyframe = false;
   }
 
-  if (payload->frameWidth != -1 && static_cast<int>(payload->frameWidth) != video_frame_width_list_[position]) {
+  if (payload->frameWidth != -1 && static_cast<uint>(payload->frameWidth) != video_frame_width_list_[position]) {
     video_frame_width_list_[position] = payload->frameWidth;
     video_frame_height_list_[position] = payload->frameHeight;
     notifyLayerInfoChangedEvent();


### PR DESCRIPTION
**Description**

LayerDetectorHandler now reads frame width, height and rate for each Spatial and Temporal layer (VP9 and VP8). In another PR I will send this information to each subscriber to let them decide which layer they'll filter based on client's capabilities.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.