### PR TITLE
Add options to erizo build process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,8 @@ jobs:
       - run:
           name: Unit Tests Erizo
           command: |
-            docker run --rm -ti -w /opt/licode/erizo/build/ --entrypoint /bin/bash lynckia/licode:develop -c "ctest --verbose"
+            docker run --rm -ti -w /opt/licode/erizo/build/debug --entrypoint /bin/bash lynckia/licode:develop -c "ctest --verbose"
+            docker run --rm -ti -w /opt/licode/erizo/build/release --entrypoint /bin/bash lynckia/licode:develop -c "ctest --verbose"
 
       - run:
           name: Lint Javascript

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - run:
           name: Lint Erizo
           command: |
-            docker run --rm -ti -w /opt/licode/erizo/build/ --entrypoint /bin/bash lynckia/licode:develop -c "make lint"
+            docker run --rm -ti -w /opt/licode/erizo/build/release --entrypoint /bin/bash lynckia/licode:develop -c "make lint"
 
       - run:
           name: Unit Tests Erizo

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir /opt/licode/.git
 # Clone and install licode
 WORKDIR /opt/licode/scripts
 
-RUN ./installErizo.sh -feacs && \
+RUN ./installErizo.sh -feacso && \
     ./../nuve/installNuve.sh && \
     ./installBasicExample.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir /opt/licode/.git
 # Clone and install licode
 WORKDIR /opt/licode/scripts
 
-RUN ./installErizo.sh -feacso && \
+RUN ./installErizo.sh -dfeacs && \
     ./../nuve/installNuve.sh && \
     ./installBasicExample.sh
 

--- a/erizo/buildProject.sh
+++ b/erizo/buildProject.sh
@@ -22,4 +22,4 @@ buildAll() {
 
 
 
-buildAll
+buildAll $*

--- a/erizo/buildProject.sh
+++ b/erizo/buildProject.sh
@@ -3,9 +3,23 @@
 set -e
 
 BIN_DIR="build"
-if [ -d $BIN_DIR ]; then
-  cd $BIN_DIR
-  make $*
-else
-  echo "Error, build directory does not exist, run generateProject.sh first"
-fi
+OBJ_DIR="CMakeFiles"
+
+buildAll() {
+  if [ -d $BIN_DIR ]; then
+    cd $BIN_DIR
+    for d in */ ; do
+      echo "Building $d - $*"
+      cd $d
+      make $*
+      cd ..
+    done
+    cd ..
+  else
+    echo "Error, build directory does not exist, run generateProject.sh first"
+  fi
+}
+
+
+
+buildAll

--- a/erizo/cleanObjectFiles.sh
+++ b/erizo/cleanObjectFiles.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+
+BIN_DIR="build"
+OBJ_DIR="CMakeFiles"
+
+maybeRemoveObjDir() {
+  if [ -d $OBJ_DIR ]; then
+    rm -rf $OBJ_DIR
+  fi
+}
+
+cleanAll() {
+  if [ -d $BIN_DIR ]; then
+    cd $BIN_DIR
+    for RELEASE_DIR in */ ; do
+      echo "cleaning $d"
+      cd $RELEASE_DIR
+      maybeRemoveObjDir
+      for INTERNAL_DIR in */ ; do
+        cd $INTERNAL_DIR
+        maybeRemoveObjDir
+        cd ..
+      done
+      cd ..
+    done
+    cd ..
+  fi
+}
+
+cleanAll

--- a/erizo/cleanObjectFiles.sh
+++ b/erizo/cleanObjectFiles.sh
@@ -15,7 +15,7 @@ cleanAll() {
   if [ -d $BIN_DIR ]; then
     cd $BIN_DIR
     for RELEASE_DIR in */ ; do
-      echo "cleaning $d"
+      echo "cleaning $RELEASE_DIR"
       cd $RELEASE_DIR
       maybeRemoveObjDir
       for INTERNAL_DIR in */ ; do

--- a/erizo/generateProject.sh
+++ b/erizo/generateProject.sh
@@ -1,17 +1,25 @@
 #!/usr/bin/env bash
-
 set -e
 
-runcmake() {
-   cmake ../src
-   echo "Done"
+SCRIPT=`pwd`/$0
+FILENAME=`basename $SCRIPT`
+PATHNAME=`dirname $SCRIPT`
+BASE_BIN_DIR="build"
+
+
+generateVersion() {
+  echo "generating $1"
+  BIN_DIR="$BASE_BIN_DIR/$1"
+  if [ -d $BIN_DIR ]; then
+    cd $BIN_DIR
+  else
+    mkdir -p $BIN_DIR
+    cd $BIN_DIR
+  fi
+  cmake ../../src "-DERIZO_BUILD_TYPE=$1"
+  cd $PATHNAME
 }
-BIN_DIR="build"
-if [ -d $BIN_DIR ]; then
-  cd $BIN_DIR
-  runcmake
-else
-  mkdir $BIN_DIR
-  cd $BIN_DIR
-  runcmake
-fi
+
+
+generateVersion release
+generateVersion debug

--- a/erizo/src/erizo/CMakeLists.txt
+++ b/erizo/src/erizo/CMakeLists.txt
@@ -9,7 +9,7 @@ if(${ERIZO_BUILD_TYPE} STREQUAL "debug")
   set(CMAKE_CXX_FLAGS "-g -Wall -std=c++11 ${ERIZO_CMAKE_CXX_FLAGS}")
 else()
   message("Generating RELEASE project")
-  set(CMAKE_CXX_FLAGS "-g -O3 -std=c++11 ${ERIZO_CMAKE_CXX_FLAGS}")
+  set(CMAKE_CXX_FLAGS "-g -Wall -O3 -std=c++11 ${ERIZO_CMAKE_CXX_FLAGS}")
 endif()
 
 

--- a/erizo/src/erizo/CMakeLists.txt
+++ b/erizo/src/erizo/CMakeLists.txt
@@ -22,5 +22,3 @@ add_library(erizo SHARED ${ERIZO_SOURCES})
 #message("Libs ${SRTP} ${NICE} ${GTHREAD} ${SSL} ${CRYPTO} ${LIBS} ${LOG}")
 
 target_link_libraries(erizo ${GLIB_LIBRARIES} ${Boost_LIBRARIES} ${SRTP} ${NICE} ${GTHREAD} ${SSL} ${CRYPTO} ${LIBS} ${LOG} webrtc nicer nrappkit)
-
-set(CMAKE_BUILD_TYPE "")

--- a/erizo/src/erizo/CMakeLists.txt
+++ b/erizo/src/erizo/CMakeLists.txt
@@ -1,10 +1,17 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8)
 
 project (ERIZO)
 
 set(ERIZO_VERSION_MAJOR 0)
 set(ERIZO_VERSION_MINOR 1)
-set(CMAKE_CXX_FLAGS "-g -Wall -std=c++11 ${ERIZO_CMAKE_CXX_FLAGS}")
+if(${ERIZO_BUILD_TYPE} STREQUAL "debug")
+  message("Generating DEBUG project")
+  set(CMAKE_CXX_FLAGS "-g -Wall -std=c++11 ${ERIZO_CMAKE_CXX_FLAGS}")
+else()
+  message("Generating RELEASE project")
+  set(CMAKE_CXX_FLAGS "-g -O3 -std=c++11 ${ERIZO_CMAKE_CXX_FLAGS}")
+endif()
+
 
 include_directories("${ERIZO_SOURCE_DIR}" "${THIRD_PARTY_INCLUDE}" "${NICER_INCLUDE}")
 
@@ -15,3 +22,5 @@ add_library(erizo SHARED ${ERIZO_SOURCES})
 #message("Libs ${SRTP} ${NICE} ${GTHREAD} ${SSL} ${CRYPTO} ${LIBS} ${LOG}")
 
 target_link_libraries(erizo ${GLIB_LIBRARIES} ${Boost_LIBRARIES} ${SRTP} ${NICE} ${GTHREAD} ${SSL} ${CRYPTO} ${LIBS} ${LOG} webrtc nicer nrappkit)
+
+set(CMAKE_BUILD_TYPE "")

--- a/erizo/src/erizo/SrtpChannel.cpp
+++ b/erizo/src/erizo/SrtpChannel.cpp
@@ -37,7 +37,6 @@ std::string octet_string_hex_string(const void *s, int length) {
       bit_string[i]   = nibble_to_hex_char(*str >> 4);
       bit_string[i + 1] = nibble_to_hex_char(*str++ & 0xF);
   }
-  bit_string[i] = 0; /* null terminate string */
   return std::string(bit_string);
 }
 

--- a/erizo/src/erizo/SrtpChannel.cpp
+++ b/erizo/src/erizo/SrtpChannel.cpp
@@ -29,7 +29,7 @@ std::string octet_string_hex_string(const void *s, int length) {
   }
 
   const uint8_t *str = (const uint8_t*)s;
-  int i;
+  int i = 0;
 
   char bit_string[kKeyStringLength * 2];
 

--- a/erizo/src/erizo/media/ExternalInput.cpp
+++ b/erizo/src/erizo/media/ExternalInput.cpp
@@ -59,7 +59,8 @@ int ExternalInput::init() {
 
   // VideoCodecInfo info;
   MediaInfo om;
-  AVStream *st, *audio_st;
+  AVStream *st = nullptr;
+  AVStream *audio_st = nullptr;
 
   int streamNo = av_find_best_stream(context_, AVMEDIA_TYPE_VIDEO, -1, -1, NULL, 0);
   if (streamNo < 0) {
@@ -108,16 +109,18 @@ int ExternalInput::init() {
     decodedBuffer_.reset((unsigned char*) malloc(100000));
     MediaInfo om;
     om.processorType = PACKAGE_ONLY;
-    if (audio_st->codec->codec_id == AV_CODEC_ID_PCM_MULAW) {
-      ELOG_DEBUG("PCM U8");
-      om.audioCodec.sampleRate = 8000;
-      om.audioCodec.codec = AUDIO_CODEC_PCM_U8;
-      om.rtpAudioInfo.PT = PCMU_8000_PT;
-    } else if (audio_st->codec->codec_id == AV_CODEC_ID_OPUS) {
-      ELOG_DEBUG("OPUS");
-      om.audioCodec.sampleRate = 48000;
-      om.audioCodec.codec = AUDIO_CODEC_OPUS;
-      om.rtpAudioInfo.PT = OPUS_48000_PT;
+    if (audio_st) {
+      if (audio_st->codec->codec_id == AV_CODEC_ID_PCM_MULAW) {
+        ELOG_DEBUG("PCM U8");
+        om.audioCodec.sampleRate = 8000;
+        om.audioCodec.codec = AUDIO_CODEC_PCM_U8;
+        om.rtpAudioInfo.PT = PCMU_8000_PT;
+      } else if (audio_st->codec->codec_id == AV_CODEC_ID_OPUS) {
+        ELOG_DEBUG("OPUS");
+        om.audioCodec.sampleRate = 48000;
+        om.audioCodec.codec = AUDIO_CODEC_OPUS;
+        om.rtpAudioInfo.PT = OPUS_48000_PT;
+      }
     }
     op_.reset(new OutputProcessor());
     op_->init(om, this);

--- a/erizo/src/erizo/media/MediaProcessor.cpp
+++ b/erizo/src/erizo/media/MediaProcessor.cpp
@@ -169,7 +169,7 @@ int InputProcessor::decodeAudio(unsigned char* inBuff, int inBuffLen, unsigned c
   }
 
   AVPacket avpkt;
-  int outSize;
+  int outSize = 0;
   int decSize = 0;
   int len = -1;
   uint8_t *decBuff = reinterpret_cast<uint8_t*>(malloc(16000));

--- a/erizo/src/erizo/media/codecs/AudioCodec.cpp
+++ b/erizo/src/erizo/media/codecs/AudioCodec.cpp
@@ -165,7 +165,7 @@ int AudioDecoder::initDecoder(AVCodecContext* context) {
 int AudioDecoder::decodeAudio(unsigned char* inBuff, int inBuffLen,
     unsigned char* outBuff, int outBuffLen, int* gotFrame) {
   AVPacket avpkt;
-  int outSize;
+  int outSize = 0;
   int decSize = 0;
   int len = -1;
   uint8_t *decBuff = reinterpret_cast<uint8_t*>(malloc(16000));

--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
@@ -104,7 +104,7 @@ void BandwidthEstimationHandler::updateExtensionMaps(std::array<RTPExtensions, 1
 }
 
 void BandwidthEstimationHandler::updateExtensionMap(bool is_video, std::array<RTPExtensions, 10> map) {
-  webrtc::RTPExtensionType type;
+  webrtc::RTPExtensionType type = webrtc::kRtpExtensionNone;
   for (uint8_t id = 0; id < 10; id++) {
     RTPExtensions extension = map[id];
     switch (extension) {
@@ -130,6 +130,9 @@ void BandwidthEstimationHandler::updateExtensionMap(bool is_video, std::array<RT
       case PLAYBACK_TIME:
         type = webrtc::kRtpExtensionPlayoutDelay;
         break;
+    }
+    if (type === webrtc::kRtpExtensionNone) {
+      continue;
     }
     if (is_video) {
       ext_map_video_.RegisterByType(id, type);

--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
@@ -131,7 +131,7 @@ void BandwidthEstimationHandler::updateExtensionMap(bool is_video, std::array<RT
         type = webrtc::kRtpExtensionPlayoutDelay;
         break;
     }
-    if (type === webrtc::kRtpExtensionNone) {
+    if (type == webrtc::kRtpExtensionNone) {
       continue;
     }
     if (is_video) {

--- a/erizo/src/erizo/rtp/RtcpAggregator.cpp
+++ b/erizo/src/erizo/rtp/RtcpAggregator.cpp
@@ -87,7 +87,8 @@ int RtcpAggregator::analyzeFeedback(char *buf, int len) {
     uint16_t currentNackPos = 0;
     uint16_t blp = 0;
     uint32_t lostPacketSeq = 0;
-    uint32_t calculatedlsr, delay, calculateLastSr, extendedSeqNo;
+    uint32_t delay = 0;
+    uint32_t calculatedlsr, calculateLastSr, extendedSeqNo;
 
     do {
       movingBuf += rtcpLength;

--- a/erizoAPI/binding.gyp
+++ b/erizoAPI/binding.gyp
@@ -1,10 +1,38 @@
 {
+  'variables' : {
+    'common_sources': [ 'addon.cc', 'IOThreadPool.cc', 'ThreadPool.cc', 'WebRtcConnection.cc', 'OneToManyProcessor.cc', 'ExternalInput.cc', 'ExternalOutput.cc', 'SyntheticInput.cc'],
+    'common_include_dirs' : ["<!(node -e \"require('nan')\")", '$(ERIZO_HOME)/src/erizo', '$(ERIZO_HOME)/../build/libdeps/build/include', '$(ERIZO_HOME)/src/third_party/webrtc/src']
+  },
   'targets': [
   {
     'target_name': 'addon',
-      'sources': [ 'addon.cc', 'IOThreadPool.cc', 'ThreadPool.cc', 'WebRtcConnection.cc', 'OneToManyProcessor.cc', 'ExternalInput.cc', 'ExternalOutput.cc', 'SyntheticInput.cc'],
-      'include_dirs' : ["<!(node -e \"require('nan')\")", '$(ERIZO_HOME)/src/erizo', '$(ERIZO_HOME)/../build/libdeps/build/include', '$(ERIZO_HOME)/src/third_party/webrtc/src'],
-      'libraries': ['-L$(ERIZO_HOME)/build/erizo', '-lerizo'],
+      'sources': ['<@(common_sources)'],
+      'include_dirs' : ['<@(common_include_dirs)'],
+      'libraries': ['-L$(ERIZO_HOME)/build/release/erizo -lerizo -Wl,-rpath,./../../erizo/build/release/erizo'],
+      'conditions': [
+        [ 'OS=="mac"', {
+          'xcode_settings': {
+            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',        # -fno-exceptions
+              'GCC_ENABLE_CPP_RTTI': 'YES',              # -fno-rtti
+              'MACOSX_DEPLOYMENT_TARGET' : '10.11',      #from MAC OS 10.7
+              'OTHER_CFLAGS': [
+              '-g -O3 -stdlib=libc++ -std=c++11',
+            ]
+          },
+        }, { # OS!="mac"
+          'cflags!' : ['-fno-exceptions'],
+          'cflags' : ['-D__STDC_CONSTANT_MACROS'],
+          'cflags_cc' : ['-Wall', '-O3', '-g' , '-std=c++11', '-fexceptions'],
+          'cflags_cc!' : ['-fno-exceptions'],
+          'cflags_cc!' : ['-fno-rtti']
+        }],
+        ]
+  },
+  {
+    'target_name': 'addonDebug',
+      'sources': ['<@(common_sources)'],
+      'include_dirs' : ['<@(common_include_dirs)'],
+      'libraries': ['-L$(ERIZO_HOME)/build/debug/erizo -lerizo -Wl,-rpath,./../../erizo/build/debug/erizo'],
       'conditions': [
         [ 'OS=="mac"', {
           'xcode_settings': {

--- a/erizo_controller/erizoAgent/launch.sh
+++ b/erizo_controller/erizoAgent/launch.sh
@@ -1,5 +1,3 @@
 #!/usr/bin/env bash
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/../../erizo/build/erizo
 ulimit -c unlimited
-
 exec node $ERIZOJS_NODE_OPTIONS $*

--- a/erizo_controller/erizoJS/erizoJS.js
+++ b/erizo_controller/erizoJS/erizoJS.js
@@ -34,6 +34,7 @@ var getopt = new Getopt([
   ['T' , 'turnport=ARG'               , 'TURN server PORT'],
   ['c' , 'turnusername=ARG'           , 'TURN username'],
   ['C' , 'turnpass=ARG'               , 'TURN password'],
+  ['d', 'debug'                   , 'Run Debug erizoAPI addon'],
   ['h' , 'help'                       , 'display this help']
 ]);
 
@@ -62,6 +63,10 @@ for (var prop in opt.options) {
             case 'logging-config-file':
                 GLOBAL.config.logger = GLOBAL.config.logger || {};
                 GLOBAL.config.logger.configFile = value;
+                break;
+            case 'debug':
+                console.log('Loading debug version');
+                addon = require('./../../erizoAPI/build/Release/addonDebug');
                 break;
             default:
                 GLOBAL.config.erizo[prop] = value;

--- a/erizo_controller/initErizo_agent.sh
+++ b/erizo_controller/initErizo_agent.sh
@@ -12,6 +12,6 @@ NVM_CHECK="$LICODE_ROOT"/scripts/checkNvm.sh
 
 cd $ROOT/erizoAgent
 nvm use
-node erizoAgent.js &
+node erizoAgent.js $* &
 
 cd $CURRENT_DIR

--- a/extras/basic_example/basicServer.js
+++ b/extras/basic_example/basicServer.js
@@ -191,7 +191,7 @@ app.use(function(req, res, next) {
 cleanExampleRooms(function() {
     getOrCreateRoom(defaultRoomName, undefined, function (roomId) {
         defaultRoom = roomId;
-        app.listen(3001);
+        app.listen(3002);
         var server = https.createServer(options, app);
         console.log('BasicExample started');
         server.listen(3004);

--- a/extras/basic_example/basicServer.js
+++ b/extras/basic_example/basicServer.js
@@ -191,7 +191,7 @@ app.use(function(req, res, next) {
 cleanExampleRooms(function() {
     getOrCreateRoom(defaultRoomName, undefined, function (roomId) {
         defaultRoom = roomId;
-        app.listen(3002);
+        app.listen(3001);
         var server = https.createServer(options, app);
         console.log('BasicExample started');
         server.listen(3004);

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -80,8 +80,9 @@ window.onload = function () {
     req.setRequestHeader('Content-Type', 'application/json');
     req.send(JSON.stringify(roomData));
   };
-
-  var roomData  = {username: 'user', role: 'presenter', room: roomName, type: roomType};
+  var names = ['pedro', 'juan', 'manolo', 'tito', 'pepe', 'alonso', 'guancho'];
+  var myUserName = names[Math.floor(Math.random()*names.length)];
+  var roomData  = {username: myUserName, role: 'presenter', room: roomName, type: roomType};
 
   createToken(roomData, function (response) {
     var token = response;

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -80,9 +80,8 @@ window.onload = function () {
     req.setRequestHeader('Content-Type', 'application/json');
     req.send(JSON.stringify(roomData));
   };
-  var names = ['pedro', 'juan', 'manolo', 'tito', 'pepe', 'alonso', 'guancho'];
-  var myUserName = names[Math.floor(Math.random()*names.length)];
-  var roomData  = {username: myUserName, role: 'presenter', room: roomName, type: roomType};
+
+  var roomData  = {username: 'user', role: 'presenter', room: roomName, type: roomType};
 
   createToken(roomData, function (response) {
     var token = response;

--- a/extras/docker/initDockerLicode.sh
+++ b/extras/docker/initDockerLicode.sh
@@ -119,7 +119,7 @@ run_erizoController() {
 run_erizoAgent() {
   echo "Starting erizoAgent"
   cd $ROOT/erizo_controller/erizoAgent
-  if [ "$ERIZODEBUG" = "true" ]; then
+  if [ "$ERIZODEBUG" == "true" ]; then
     node erizoAgent.js -d &
   else
     node erizoAgent.js &
@@ -141,11 +141,11 @@ cd $ROOT/scripts
 run_nvm
 nvm use
 
-if [ "$MONGODB" = "true" ]; then
+if [ "$MONGODB" == "true" ]; then
   run_mongo
 fi
 
-if [ "$RABBITMQ" = "true" ]; then
+if [ "$RABBITMQ" == "true" ]; then
   run_rabbitmq
 fi
 
@@ -157,23 +157,23 @@ if [ ! -f "$ROOT"/rtp_media_config.js ]; then
   cp "$SCRIPTS"/rtp_media_config_default.js "$ROOT"/rtp_media_config.js
 fi
 
-if [ "$NUVE" = "true" ]; then
+if [ "$NUVE" == "true" ]; then
   run_nuve
 fi
 
-if [ "$ERIZOCONTROLLER" = "true" ]; then
+if [ "$ERIZOCONTROLLER" == "true" ]; then
   echo "config.erizoController.publicIP = '$PUBLIC_IP';" >> /opt/licode/licode_config.js
   run_erizoController
 fi
 
-if [ "$ERIZOAGENT" = "true" ]; then
+if [ "$ERIZOAGENT" == "true" ]; then
   echo "config.erizoAgent.publicIP = '$PUBLIC_IP';" >> /opt/licode/licode_config.js
   echo "config.erizo.minport = '$MIN_PORT';" >> /opt/licode/licode_config.js
   echo "config.erizo.maxport = '$MAX_PORT';" >> /opt/licode/licode_config.js
   run_erizoAgent
 fi
 
-if [ "$BASICEXAMPLE" = "true" ]; then
+if [ "$BASICEXAMPLE" == "true" ]; then
   run_basicExample
 fi
 

--- a/scripts/initLicode.sh
+++ b/scripts/initLicode.sh
@@ -20,7 +20,6 @@ cd $ROOT/nuve
 
 sleep 5
 
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ROOT/erizo/build/erizo:$ROOT/erizo:$ROOT/build/libdeps/build/lib
 export ERIZO_HOME=$ROOT/erizo/
 
 cd $ROOT/erizo_controller

--- a/scripts/installErizo.sh
+++ b/scripts/installErizo.sh
@@ -32,7 +32,8 @@ OPTIONS:
    -e      Compile Erizo
    -a      Compile Erizo API
    -c      Install Erizo node modules
-   -o      Clean object files
+   -d      Delete Erizo object files
+   -f      Use 4 threads to build
    -s      Install Spine
    -t      Run Tests
 EOF
@@ -54,7 +55,7 @@ install_erizo(){
   cd $ROOT/erizo
   ./generateProject.sh
   ./buildProject.sh $FAST_MAKE
-  if [ $CLEAN_OBJECT_FILES == 'true' ]; then
+  if [ $DELETE_OBJECT_FILES == 'true' ]; then
     ./cleanObjectFiles.sh
   fi
   check_result $?
@@ -104,7 +105,7 @@ then
   install_erizo_controller
   install_spine
 else
-  while getopts “heacstf” OPTION
+  while getopts “heacstfd” OPTION
   do
     case $OPTION in
       h)
@@ -129,8 +130,8 @@ else
       f)
         FAST_MAKE='-j4'
         ;;
-      o)
-        CLEAN_OBJECT_FILES='true'
+      d)
+        DELETE_OBJECT_FILES='true'
         ;;
       ?)
         usage

--- a/scripts/installErizo.sh
+++ b/scripts/installErizo.sh
@@ -32,6 +32,7 @@ OPTIONS:
    -e      Compile Erizo
    -a      Compile Erizo API
    -c      Install Erizo node modules
+   -o      Clean object files
    -s      Install Spine
    -t      Run Tests
 EOF
@@ -53,6 +54,9 @@ install_erizo(){
   cd $ROOT/erizo
   ./generateProject.sh
   ./buildProject.sh $FAST_MAKE
+  if [ $CLEAN_OBJECT_FILES == 'true' ]; then
+    ./cleanObjectFiles.sh
+  fi
   check_result $?
   cd $CURRENT_DIR
 }
@@ -124,6 +128,9 @@ else
         ;;
       f)
         FAST_MAKE='-j4'
+        ;;
+      o)
+        CLEAN_OBJECT_FILES='true'
         ;;
       ?)
         usage

--- a/scripts/installErizo.sh
+++ b/scripts/installErizo.sh
@@ -55,7 +55,7 @@ install_erizo(){
   cd $ROOT/erizo
   ./generateProject.sh
   ./buildProject.sh $FAST_MAKE
-  if [ $DELETE_OBJECT_FILES == 'true' ]; then
+  if [ "$DELETE_OBJECT_FILES" == "true" ]; then
     ./cleanObjectFiles.sh
   fi
   check_result $?


### PR DESCRIPTION
**Description**

This PR adds "Release" and "Debug" configurations for both erizo and erizoAPI. The main difference is that Erizo is now built with `-O3`. Both are built by default, while "Release" is the one that's normally used by ErizoJS.
In order to run the debug version of both erizo and erizoAPI, you can start erizoAgent with `initErizoAgent.sh -d` or, if you are running the docker image, you can add `--erizoDebug`.

Also, we're now using `rpath` when building erizoAPI, meaning that we no longer need `LD_LIBRARY_PATH` for Licode.

**Warning for Spine users**: You do need `LD_LIBRARY_PATH` and note that `liberizo` is now under `erizo/build/release/erizo` or `erizo/build/debug/erizo` .


Finally, in the Docker image we're keeping both builds but removing the object files in `CMakeFiles`to save some space.



[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.