### PR TITLE
Send async events from pub to subs

### DIFF
--- a/erizo/src/erizo/MediaDefinitions.h
+++ b/erizo/src/erizo/MediaDefinitions.h
@@ -77,6 +77,7 @@ class Monitor {
 class MediaEvent {
  public:
   MediaEvent() = default;
+  virtual ~MediaEvent() {}
   virtual std::string getType() const {
     return "event";
   }

--- a/erizo/src/erizo/MediaDefinitions.h
+++ b/erizo/src/erizo/MediaDefinitions.h
@@ -74,6 +74,16 @@ class Monitor {
     boost::mutex monitor_mutex_;
 };
 
+class MediaEvent {
+ public:
+  MediaEvent() = default;
+  virtual std::string getType() const {
+    return "event";
+  }
+};
+
+using MediaEventPtr = std::shared_ptr<MediaEvent>;
+
 class FeedbackSink {
  public:
     virtual ~FeedbackSink() {}
@@ -83,7 +93,6 @@ class FeedbackSink {
  private:
     virtual int deliverFeedback_(std::shared_ptr<DataPacket> data_packet) = 0;
 };
-
 
 class FeedbackSource {
  protected:
@@ -140,6 +149,9 @@ class MediaSink: public virtual Monitor {
         boost::mutex::scoped_lock lock(monitor_mutex_);
         return sink_fb_source_;
     }
+    int deliverEvent(MediaEventPtr event) {
+      return this->deliverEvent_(event);
+    }
     MediaSink() : audio_sink_ssrc_{0}, video_sink_ssrc_{0}, sink_fb_source_{nullptr} {}
     virtual ~MediaSink() {}
 
@@ -148,6 +160,7 @@ class MediaSink: public virtual Monitor {
  private:
     virtual int deliverAudioData_(std::shared_ptr<DataPacket> data_packet) = 0;
     virtual int deliverVideoData_(std::shared_ptr<DataPacket> data_packet) = 0;
+    virtual int deliverEvent_(MediaEventPtr event) = 0;
 };
 
 /**
@@ -160,6 +173,7 @@ class MediaSource: public virtual Monitor {
     std::vector<uint32_t> video_source_ssrc_list_;
     MediaSink* video_sink_;
     MediaSink* audio_sink_;
+    MediaSink* event_sink_;
     // can it accept feedback
     FeedbackSink* source_fb_sink_;
 
@@ -171,6 +185,10 @@ class MediaSource: public virtual Monitor {
     void setVideoSink(MediaSink* video_sink) {
         boost::mutex::scoped_lock lock(monitor_mutex_);
         this->video_sink_ = video_sink;
+    }
+    void setEventSink(MediaSink* event_sink) {
+      boost::mutex::scoped_lock lock(monitor_mutex_);
+      this->event_sink_ = event_sink;
     }
 
     FeedbackSink* getFeedbackSink() {
@@ -216,7 +234,7 @@ class MediaSource: public virtual Monitor {
     }
 
     MediaSource() : audio_source_ssrc_{0}, video_source_ssrc_list_{std::vector<uint32_t>(1, 0)},
-      video_sink_{nullptr}, audio_sink_{nullptr}, source_fb_sink_{nullptr} {}
+      video_sink_{nullptr}, audio_sink_{nullptr}, event_sink_{nullptr}, source_fb_sink_{nullptr} {}
     virtual ~MediaSource() {}
 
     virtual void close() = 0;

--- a/erizo/src/erizo/OneToManyProcessor.cpp
+++ b/erizo/src/erizo/OneToManyProcessor.cpp
@@ -74,6 +74,19 @@ namespace erizo {
     return 0;
   }
 
+  int OneToManyProcessor::deliverEvent_(MediaEventPtr event) {
+    boost::unique_lock<boost::mutex> lock(monitor_mutex_);
+    if (subscribers.empty())
+      return 0;
+    std::map<std::string, std::shared_ptr<MediaSink>>::iterator it;
+    for (it = subscribers.begin(); it != subscribers.end(); ++it) {
+      if ((*it).second != nullptr) {
+        (*it).second->deliverEvent(event);
+      }
+    }
+    return 0;
+  }
+
   void OneToManyProcessor::addSubscriber(std::shared_ptr<MediaSink> webRtcConn,
       const std::string& peerId) {
     ELOG_DEBUG("Adding subscriber");

--- a/erizo/src/erizo/OneToManyProcessor.h
+++ b/erizo/src/erizo/OneToManyProcessor.h
@@ -56,6 +56,7 @@ class OneToManyProcessor : public MediaSink, public FeedbackSink {
   int deliverAudioData_(std::shared_ptr<DataPacket> audio_packet) override;
   int deliverVideoData_(std::shared_ptr<DataPacket> video_packet) override;
   int deliverFeedback_(std::shared_ptr<DataPacket> fb_packet) override;
+  int deliverEvent_(MediaEventPtr event) override;
   std::future<void> deleteAsync(std::shared_ptr<WebRtcConnection> connection);
   void closeAll();
 };

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -441,6 +441,17 @@ int WebRtcConnection::deliverFeedback_(std::shared_ptr<DataPacket> fb_packet) {
   return fb_packet->length;
 }
 
+int WebRtcConnection::deliverEvent_(MediaEventPtr event) {
+  if (!sending_ || getCurrentState() != CONN_READY) {
+    return 0;
+  }
+  auto conn_ptr = shared_from_this();
+  worker_->task([conn_ptr, event]{
+    conn_ptr->pipeline_->notifyEvent(event);
+  });
+  return 1;
+}
+
 void WebRtcConnection::onTransportData(std::shared_ptr<DataPacket> packet, Transport *transport) {
   if ((audio_sink_ == nullptr && video_sink_ == nullptr && fb_sink_ == nullptr) ||
       getCurrentState() != CONN_READY) {
@@ -527,6 +538,10 @@ void WebRtcConnection::read(std::shared_ptr<DataPacket> packet) {
       }
     }  // if not bundle
   }  // if not Feedback
+}
+
+void WebRtcConnection::notifyToEventSink(MediaEventPtr event) {
+  event_sink_->deliverEvent(event);
 }
 
 int WebRtcConnection::sendPLI() {

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -442,11 +442,11 @@ int WebRtcConnection::deliverFeedback_(std::shared_ptr<DataPacket> fb_packet) {
 }
 
 int WebRtcConnection::deliverEvent_(MediaEventPtr event) {
-  if (!sending_ || getCurrentState() != CONN_READY) {
-    return 0;
-  }
   auto conn_ptr = shared_from_this();
   worker_->task([conn_ptr, event]{
+    if (!conn_ptr->pipeline_initialized_) {
+      return;
+    }
     conn_ptr->pipeline_->notifyEvent(event);
   });
   return 1;

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -156,6 +156,8 @@ class WebRtcConnection: public MediaSink, public MediaSource, public FeedbackSin
   void disableHandler(const std::string &name);
   void notifyUpdateToHandlers();
 
+  void notifyToEventSink(MediaEventPtr event);
+
   void asyncTask(std::function<void(std::shared_ptr<WebRtcConnection>)> f);
 
   bool isAudioMuted() { return audio_muted_; }
@@ -181,6 +183,7 @@ class WebRtcConnection: public MediaSink, public MediaSource, public FeedbackSin
   int deliverAudioData_(std::shared_ptr<DataPacket> audio_packet) override;
   int deliverVideoData_(std::shared_ptr<DataPacket> video_packet) override;
   int deliverFeedback_(std::shared_ptr<DataPacket> fb_packet) override;
+  int deliverEvent_(MediaEventPtr event) override;
   void initializePipeline();
 
   // Utils

--- a/erizo/src/erizo/media/ExternalOutput.cpp
+++ b/erizo/src/erizo/media/ExternalOutput.cpp
@@ -346,6 +346,9 @@ int ExternalOutput::deliverVideoData_(std::shared_ptr<DataPacket> video_packet) 
   return 0;
 }
 
+int ExternalOutput::deliverEvent_(MediaEventPtr event) {
+  return 0;
+}
 
 bool ExternalOutput::initContext() {
   if (context_->oformat->video_codec != AV_CODEC_ID_NONE &&

--- a/erizo/src/erizo/media/ExternalOutput.h
+++ b/erizo/src/erizo/media/ExternalOutput.h
@@ -104,6 +104,7 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
   void sendLoop();
   int deliverAudioData_(std::shared_ptr<DataPacket> audio_packet) override;
   int deliverVideoData_(std::shared_ptr<DataPacket> video_packet) override;
+  int deliverEvent_(MediaEventPtr event) override;
   void writeAudioData(char* buf, int len);
   void writeVideoData(char* buf, int len);
   bool bufferCheck(RTPPayloadVP8* payload);

--- a/erizo/src/erizo/media/MediaProcessor.cpp
+++ b/erizo/src/erizo/media/MediaProcessor.cpp
@@ -126,6 +126,10 @@ int InputProcessor::deliverVideoData_(std::shared_ptr<DataPacket> video_packet) 
   return 0;
 }
 
+int InputProcessor::deliverEvent_(MediaEventPtr event) {
+  return 0;
+}
+
 bool InputProcessor::initAudioDecoder() {
   aDecoder = avcodec_find_decoder(static_cast<AVCodecID>(mediaInfo.audioCodec.codec));
   if (!aDecoder) {

--- a/erizo/src/erizo/media/MediaProcessor.h
+++ b/erizo/src/erizo/media/MediaProcessor.h
@@ -128,6 +128,7 @@ class InputProcessor: public MediaSink {
   bool initVideoUnpackager();
   int deliverAudioData_(std::shared_ptr<DataPacket> audio_packet) override;
   int deliverVideoData_(std::shared_ptr<DataPacket> video_packet) override;
+  int deliverEvent_(MediaEventPtr event) override;
 
   int decodeAudio(unsigned char* inBuff, int inBuffLen, unsigned char* outBuff);
 };

--- a/erizo/src/erizo/media/OneToManyTranscoder.cpp
+++ b/erizo/src/erizo/media/OneToManyTranscoder.cpp
@@ -81,6 +81,10 @@ int OneToManyTranscoder::deliverVideoData_(std::shared_ptr<DataPacket> video_pac
   return 0;
 }
 
+int OneToManyTranscoder::deliverEvent_(MediaEventPtr event) {
+  return 0;
+}
+
 void OneToManyTranscoder::receiveRawData(const RawDataPacket& pkt) {
   // ELOG_DEBUG("Received %d", pkt.length);
   op_->receiveRawData(pkt);

--- a/erizo/src/erizo/media/OneToManyTranscoder.h
+++ b/erizo/src/erizo/media/OneToManyTranscoder.h
@@ -64,6 +64,7 @@ class OneToManyTranscoder : public MediaSink, public RawDataReceiver, public RTP
   unsigned int sentPackets_;
   int deliverAudioData_(std::shared_ptr<DataPacket> audio_packet) override;
   int deliverVideoData_(std::shared_ptr<DataPacket> video_packet) override;
+  int deliverEvent_(MediaEventPtr event) override;
   /**
   * Closes all the subscribers and the publisher, the object is useless after this
   */

--- a/erizo/src/erizo/pipeline/Handler.h
+++ b/erizo/src/erizo/pipeline/Handler.h
@@ -68,6 +68,8 @@ class Handler : public HandlerBase<HandlerContext> {
   }
 
   virtual void notifyUpdate() = 0;
+  virtual void notifyEvent(MediaEventPtr event) {
+  }
 };
 
 class InboundHandler : public HandlerBase<InboundHandlerContext> {
@@ -94,6 +96,7 @@ class InboundHandler : public HandlerBase<InboundHandlerContext> {
   }
 
   virtual void notifyUpdate() = 0;
+  virtual void notifyEvent(MediaEventPtr event) {}
 };
 
 class OutboundHandler : public HandlerBase<OutboundHandlerContext> {
@@ -114,6 +117,7 @@ class OutboundHandler : public HandlerBase<OutboundHandlerContext> {
   }
 
   virtual void notifyUpdate() = 0;
+  virtual void notifyEvent(MediaEventPtr event) {}
 };
 
 class HandlerAdapter : public Handler {
@@ -139,6 +143,9 @@ class HandlerAdapter : public Handler {
   }
 
   void notifyUpdate() override {
+  }
+
+  void notifyEvent(MediaEventPtr event) override {
   }
 };
 }  // namespace erizo

--- a/erizo/src/erizo/pipeline/HandlerContext-inl.h
+++ b/erizo/src/erizo/pipeline/HandlerContext-inl.h
@@ -22,6 +22,7 @@ class PipelineContext {
   virtual void detachPipeline() = 0;
 
   virtual void notifyUpdate() = 0;
+  virtual void notifyEvent(MediaEventPtr event) = 0;
   virtual std::string getName() = 0;
   virtual void enable() = 0;
   virtual void disable() = 0;
@@ -76,6 +77,10 @@ class ContextImplBase : public PipelineContext {
 
   void notifyUpdate() override {
     handler_->notifyUpdate();
+  }
+
+  void notifyEvent(MediaEventPtr event) override {
+    handler_->notifyEvent(event);
   }
 
   std::string getName() override {

--- a/erizo/src/erizo/pipeline/Pipeline.cpp
+++ b/erizo/src/erizo/pipeline/Pipeline.cpp
@@ -140,6 +140,15 @@ void Pipeline::notifyUpdate() {
   }
 }
 
+void Pipeline::notifyEvent(MediaEventPtr event) {
+  for (auto it = ctxs_.rbegin(); it != ctxs_.rend(); it++) {
+    (*it)->notifyEvent(event);
+  }
+  for (auto it = service_ctxs_.rbegin(); it != service_ctxs_.rend(); it++) {
+    (*it)->notifyEvent(event);
+  }
+}
+
 void Pipeline::enable(std::string name) {
   for (auto it = ctxs_.rbegin(); it != ctxs_.rend(); it++) {
     if ((*it)->getName() == name) {

--- a/erizo/src/erizo/pipeline/Pipeline.h
+++ b/erizo/src/erizo/pipeline/Pipeline.h
@@ -176,6 +176,7 @@ class Pipeline : public PipelineBase {
   void finalize() override;
 
   void notifyUpdate();
+  void notifyEvent(MediaEventPtr event);
   void enable(std::string name);
   void disable(std::string name);
 

--- a/erizo/src/erizo/pipeline/Service.h
+++ b/erizo/src/erizo/pipeline/Service.h
@@ -14,6 +14,8 @@ class ServiceBase {
 
   virtual void attachPipeline(Context* /*ctx*/) {}
   virtual void detachPipeline(Context* /*ctx*/) {}
+  virtual void notifyEvent(MediaEventPtr event) {}
+
 
   Context* getContext() {
     if (attach_count_ != 1) {

--- a/erizo/src/erizo/pipeline/ServiceContext-inl.h
+++ b/erizo/src/erizo/pipeline/ServiceContext-inl.h
@@ -9,6 +9,7 @@ class PipelineServiceContext {
 
   virtual void attachPipeline() = 0;
   virtual void detachPipeline() = 0;
+  virtual void notifyEvent(MediaEventPtr event) = 0;
 
   template <class S, class Context>
   void attachContext(S* service, Context* ctx) {
@@ -57,6 +58,14 @@ class ServiceContextImplBase : public PipelineServiceContext {
     }
     service_ptr->detachPipeline(impl_);
     attached_ = false;
+  }
+
+  void notifyEvent(MediaEventPtr event) override {
+    auto service_ptr = service_.lock();
+    if (!service_ptr) {
+      return;
+    }
+    service_ptr->notifyEvent(event);
   }
 
  protected:

--- a/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
+++ b/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
@@ -53,13 +53,18 @@ void LayerDetectorHandler::notifyLayerInfoChangedEvent() {
     ELOG_DEBUG(" SPATIAL LAYER (%u): %u %u",
               spatial_layer, video_frame_width_list_[spatial_layer], video_frame_height_list_[spatial_layer]);
   }
+  std::vector<uint64_t> video_frame_rate_list;
   for (uint32_t temporal_layer = 0; temporal_layer < video_frame_rate_list_.size(); temporal_layer++) {
+    video_frame_rate_list.push_back(video_frame_rate_list_[temporal_layer].value());
     ELOG_DEBUG(" TEMPORAL LAYER (%u): %lu",
               temporal_layer, video_frame_rate_list_[temporal_layer].value());
   }
 
-  // TODO(javier): send an event to subscribers with the new info
-
+  if (connection_) {
+    connection_->notifyToEventSink(
+      std::make_shared<LayerInfoChangedEvent>(video_frame_width_list_,
+        video_frame_height_list_, video_frame_rate_list));
+  }
   last_event_sent_ = clock_->now();
 }
 

--- a/erizo/src/erizo/rtp/LayerDetectorHandler.h
+++ b/erizo/src/erizo/rtp/LayerDetectorHandler.h
@@ -16,6 +16,22 @@
 
 namespace erizo {
 
+class LayerInfoChangedEvent : public MediaEvent {
+ public:
+  LayerInfoChangedEvent(std::vector<uint32_t> video_frame_width_list_, std::vector<uint32_t> video_frame_height_list_,
+                        std::vector<uint64_t> video_frame_rate_list_)
+    : video_frame_width_list{video_frame_width_list_},
+      video_frame_height_list{video_frame_height_list_},
+      video_frame_rate_list{video_frame_rate_list_} {}
+
+  std::string getType() const override {
+    return "LayerInfoChangedEvent";
+  }
+  std::vector<uint32_t> video_frame_width_list;
+  std::vector<uint32_t> video_frame_height_list;
+  std::vector<uint64_t> video_frame_rate_list;
+};
+
 class WebRtcConnection;
 
 class LayerDetectorHandler: public InboundHandler, public std::enable_shared_from_this<LayerDetectorHandler> {

--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -1,5 +1,8 @@
 #include "rtp/QualityManager.h"
+#include <memory>
+
 #include "WebRtcConnection.h"
+#include "rtp/LayerDetectorHandler.h"
 
 namespace erizo {
 
@@ -27,6 +30,15 @@ void QualityManager::disable() {
   ELOG_DEBUG("message: Disabling QualityManager");
   enabled_ = false;
   setPadding(false);
+}
+
+void QualityManager::notifyEvent(MediaEventPtr event) {
+  if (event->getType() == "LayerInfoChangedEvent") {
+    auto layer_event = std::static_pointer_cast<LayerInfoChangedEvent>(event);
+    video_frame_width_list_ = layer_event->video_frame_width_list;
+    video_frame_height_list_ = layer_event->video_frame_height_list;
+    video_frame_rate_list_ = layer_event->video_frame_rate_list;
+  }
 }
 
 void QualityManager::notifyQualityUpdate() {

--- a/erizo/src/erizo/rtp/QualityManager.h
+++ b/erizo/src/erizo/rtp/QualityManager.h
@@ -30,6 +30,7 @@ class QualityManager: public Service, public std::enable_shared_from_this<Qualit
 
   void forceLayers(int spatial_layer, int temporal_layer);
 
+  void notifyEvent(MediaEventPtr event) override;
   void notifyQualityUpdate();
 
   virtual bool isPaddingEnabled() const { return padding_enabled_; }
@@ -59,6 +60,9 @@ class QualityManager: public Service, public std::enable_shared_from_this<Qualit
   time_point last_activity_check_;
   std::shared_ptr<Stats> stats_;
   std::shared_ptr<Clock> clock_;
+  std::vector<uint32_t> video_frame_width_list_;
+  std::vector<uint32_t> video_frame_height_list_;
+  std::vector<uint64_t> video_frame_rate_list_;
 };
 }  // namespace erizo
 

--- a/erizo/src/test/OneToManyProcessorTest.cpp
+++ b/erizo/src/test/OneToManyProcessorTest.cpp
@@ -10,6 +10,7 @@ using testing::_;
 using testing::Return;
 using testing::Eq;
 using erizo::DataPacket;
+using erizo::MediaEventPtr;
 
 static const char kArbitraryPeerId[] = "111";
 
@@ -43,9 +44,13 @@ class MockSubscriber: public erizo::MediaSink, public erizo::FeedbackSource {
   int deliverVideoData_(std::shared_ptr<DataPacket> packet) override {
     return internalDeliverVideoData_(packet);
   }
+  int deliverEvent_(MediaEventPtr event) override {
+    return internalDeliverEvent_(event);
+  }
 
   MOCK_METHOD1(internalDeliverAudioData_, int(std::shared_ptr<DataPacket>));
   MOCK_METHOD1(internalDeliverVideoData_, int(std::shared_ptr<DataPacket>));
+  MOCK_METHOD1(internalDeliverEvent_, int(MediaEventPtr));
 };
 
 class OneToManyProcessorTest : public ::testing::Test {

--- a/erizo/src/test/utils/Mocks.h
+++ b/erizo/src/test/utils/Mocks.h
@@ -43,6 +43,7 @@ class MockMediaSink : public MediaSink {
   MOCK_METHOD0(internal_close, void());
   MOCK_METHOD2(deliverAudioDataInternal, void(char*, int));
   MOCK_METHOD2(deliverVideoDataInternal, void(char*, int));
+  MOCK_METHOD1(deliverEventInternal, void(MediaEventPtr));
 
  private:
   int deliverAudioData_(std::shared_ptr<DataPacket> audio_packet) override {
@@ -51,6 +52,10 @@ class MockMediaSink : public MediaSink {
   }
   int deliverVideoData_(std::shared_ptr<DataPacket> video_packet) override {
     deliverVideoDataInternal(video_packet->data, video_packet->length);
+    return 0;
+  }
+  int deliverEvent_(MediaEventPtr event) override {
+    deliverEventInternal(event);
     return 0;
   }
 };

--- a/erizoAPI/ExternalInput.cc
+++ b/erizoAPI/ExternalInput.cc
@@ -99,6 +99,7 @@ NAN_METHOD(ExternalInput::setAudioReceiver) {
   erizo::MediaSink *mr = param->msink;
 
   me->setAudioSink(mr);
+  me->setEventSink(mr);
 }
 
 NAN_METHOD(ExternalInput::setVideoReceiver) {
@@ -109,4 +110,5 @@ NAN_METHOD(ExternalInput::setVideoReceiver) {
   erizo::MediaSink *mr = param->msink;
 
   me->setVideoSink(mr);
+  me->setEventSink(mr);
 }

--- a/erizoAPI/SyntheticInput.cc
+++ b/erizoAPI/SyntheticInput.cc
@@ -109,6 +109,7 @@ NAN_METHOD(SyntheticInput::setAudioReceiver) {
   erizo::MediaSink *mr = param->msink;
 
   me->setAudioSink(mr);
+  me->setEventSink(mr);
 }
 
 NAN_METHOD(SyntheticInput::setVideoReceiver) {
@@ -119,6 +120,7 @@ NAN_METHOD(SyntheticInput::setVideoReceiver) {
   erizo::MediaSink *mr = param->msink;
 
   me->setVideoSink(mr);
+  me->setEventSink(mr);
 }
 
 NAN_METHOD(SyntheticInput::setFeedbackSource) {

--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -342,6 +342,7 @@ NAN_METHOD(WebRtcConnection::setAudioReceiver) {
   erizo::MediaSink *mr = param->msink;
 
   me->setAudioSink(mr);
+  me->setEventSink(mr);
 }
 
 NAN_METHOD(WebRtcConnection::setVideoReceiver) {
@@ -352,6 +353,7 @@ NAN_METHOD(WebRtcConnection::setVideoReceiver) {
   erizo::MediaSink *mr = param->msink;
 
   me->setVideoSink(mr);
+  me->setEventSink(mr);
 }
 
 NAN_METHOD(WebRtcConnection::getCurrentState) {


### PR DESCRIPTION
**Description**

Adds a way to send async events from pub to subs. That way we can safely notify about different events and they will be synced with the media data.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.