### PR TITLE
Fix usage of liberizo debug version from ErizoJS

### DIFF
--- a/erizo_controller/erizoJS/erizoJS.js
+++ b/erizo_controller/erizoJS/erizoJS.js
@@ -1,7 +1,7 @@
 /*global require*/
 'use strict';
 var Getopt = require('node-getopt');
-var addon = require('./../../erizoAPI/build/Release/addon');
+var addon;
 var config = require('./../../licode_config');
 var mediaConfig = require('./../../rtp_media_config');
 
@@ -73,6 +73,10 @@ for (var prop in opt.options) {
                 break;
         }
     }
+}
+
+if (!addon) {
+  addon = require('./../../erizoAPI/build/Release/addon')
 }
 
 // Load submodules with updated config

--- a/erizo_controller/erizoJS/erizoJS.js
+++ b/erizo_controller/erizoJS/erizoJS.js
@@ -76,7 +76,7 @@ for (var prop in opt.options) {
 }
 
 if (!addon) {
-  addon = require('./../../erizoAPI/build/Release/addon')
+  addon = require('./../../erizoAPI/build/Release/addon');
 }
 
 // Load submodules with updated config


### PR DESCRIPTION
**Description**

We were loading both versions of liberizo (debug and release) in some cases, which caused some unexpected behaviour.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.