### PR TITLE
Add the option to mute audio/video before publishing/subscribing

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -357,6 +357,7 @@ const Room = (altIo, altConnection, specInput) => {
     attributes: stream.getAttributes(),
     metadata: options.metadata,
     createOffer: options.createOffer,
+    muteStream: options.muteStream,
   });
 
   const populateStreamFunctions = (id, streamInput, error, callback = () => {}) => {
@@ -445,6 +446,7 @@ const Room = (altIo, altConnection, specInput) => {
       browser: that.Connection.getBrowser(),
       createOffer: options.createOffer,
       metadata: options.metadata,
+      muteStream: options.muteStream,
       slideShowMode: options.slideShowMode };
     socket.sendSDP('subscribe', constraint, undefined, (result, error) => {
       if (result === null) {
@@ -594,6 +596,11 @@ const Room = (altIo, altConnection, specInput) => {
 
     options.simulcast = options.simulcast || false;
 
+    options.muteStream = {
+      audio: stream.audioMuted,
+      video: stream.videoMuted,
+    };
+
     // 1- If the stream is not local or it is a failed stream we do nothing.
     if (stream && stream.local && !stream.failed && !localStreams.has(stream.getID())) {
       // 2- Publish Media Stream to Erizo-Controller
@@ -702,6 +709,11 @@ const Room = (altIo, altConnection, specInput) => {
         if (!stream.hasAudio()) {
           options.audio = false;
         }
+
+        options.muteStream = {
+          audio: stream.audioMuted,
+          video: stream.videoMuted,
+        };
 
         if (that.p2p) {
           socket.sendSDP('subscribe', { streamId: stream.getID(), metadata: options.metadata });

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -323,7 +323,9 @@ const Stream = (altConnection, specInput) => {
     }
     const config = { muteStream: { audio: that.audioMuted, video: that.videoMuted } };
     that.checkOptions(config, true);
-    that.pc.updateSpec(config, callback);
+    if (that.pc) {
+      that.pc.updateSpec(config, callback);
+    }
   };
 
   that.muteAudio = (isMuted, callback = () => {}) => {

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -196,9 +196,6 @@ class ExternalInput extends Source {
     ei.setAudioReceiver(this.muxer);
     ei.setVideoReceiver(this.muxer);
     this.muxer.setExternalPublisher(ei);
-    const muteVideo = (options.muteStream && options.muteStream.video) || false;
-    const muteAudio = (options.muteStream && options.muteStream.audio) || false;
-    this.muteStream(muteVideo, muteAudio);
   }
 
   init() {

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -54,7 +54,9 @@ class Source {
               'id: ' + wrtcId + ', scheme: ' + this.scheme+
                ', ' + logger.objectToLog(options.metadata));
     wrtc.scheme = this.scheme;
-    this.muteSubscriberStream(id, false, false);
+    const muteVideo = (options.muteStream && options.muteStream.video) || false;
+    const muteAudio = (options.muteStream && options.muteStream.audio) || false;
+    this.muteSubscriberStream(id, muteVideo, muteAudio);
   }
 
   removeSubscriber(id) {
@@ -160,6 +162,9 @@ class Publisher extends Source {
     this.wrtc.setAudioReceiver(this.muxer);
     this.wrtc.setVideoReceiver(this.muxer);
     this.muxer.setPublisher(this.wrtc);
+    const muteVideo = (options.muteStream && options.muteStream.video) || false;
+    const muteAudio = (options.muteStream && options.muteStream.audio) || false;
+    this.muteStream(muteVideo, muteAudio);
   }
 
   resetWrtc() {
@@ -191,6 +196,9 @@ class ExternalInput extends Source {
     ei.setAudioReceiver(this.muxer);
     ei.setVideoReceiver(this.muxer);
     this.muxer.setExternalPublisher(ei);
+    const muteVideo = (options.muteStream && options.muteStream.video) || false;
+    const muteAudio = (options.muteStream && options.muteStream.audio) || false;
+    this.muteStream(muteVideo, muteAudio);
   }
 
   init() {


### PR DESCRIPTION
**Description**

It enables the option to mute audio or video before publishing or subscribing a stream. This could fix race conditions when we want to automatically mute a stream we're receiving.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

No new API, but we now can do something like the example below:

```js
room.addEventListener('stream-added', function (streamEvent) {
  const stream = streamEvent.stream;
  stream.muteAudio(true);
  room.subscribe(stream);
});
```

[] It includes documentation for these changes in `/doc`.