### PR TITLE
Add erizoJS debug option in configuration

### DIFF
--- a/erizo_controller/erizoAgent/erizoAgent.js
+++ b/erizo_controller/erizoAgent/erizoAgent.js
@@ -43,9 +43,8 @@ var interfaces = require('os').networkInterfaces(),
     k2,
     address,
     privateIP,
-    publicIP,
-    launchDebugErizoJS;
-
+    publicIP;
+    
 var opt = getopt.parse(process.argv.slice(2));
 
 var metadata;

--- a/erizo_controller/erizoAgent/erizoAgent.js
+++ b/erizo_controller/erizoAgent/erizoAgent.js
@@ -18,6 +18,8 @@ GLOBAL.config.erizoAgent.instanceLogDir = GLOBAL.config.erizoAgent.instanceLogDi
 GLOBAL.config.erizoAgent.useIndividualLogFiles =
     GLOBAL.config.erizoAgent.useIndividualLogFiles|| false;
 
+GLOBAL.config.erizoAgent.launchDebugErizoJS = GLOBAL.config.erizoAgent.launchDebugErizoJS || false;
+
 var BINDED_INTERFACE_NAME = GLOBAL.config.erizoAgent.networkInterface;
 const LAUNCH_SCRIPT = './launch.sh';
 
@@ -84,7 +86,7 @@ for (var prop in opt.options) {
                 metadata = JSON.parse(value);
                 break;
             case 'debug':
-                launchDebugErizoJS = true;
+                GLOBAL.config.erizoAgent.launchDebugErizoJS = true;
                 break;
             default:
                 GLOBAL.config.erizoAgent[prop] = value;
@@ -136,10 +138,10 @@ launchErizoJS = function() {
     var fs = require('fs');
     var erizoProcess, out, err;
     const erizoLaunchOptions = ['./../erizoJS/erizoJS.js', id, privateIP, publicIP];
-    if (launchDebugErizoJS) {
+    if (GLOBAL.config.erizoAgent.launchDebugErizoJS) {
       erizoLaunchOptions.push('-d');
     }
-    
+
     if (GLOBAL.config.erizoAgent.useIndividualLogFiles){
         out = fs.openSync(GLOBAL.config.erizoAgent.instanceLogDir + '/erizo-' + id + '.log', 'a');
         err = fs.openSync(GLOBAL.config.erizoAgent.instanceLogDir + '/erizo-' + id + '.log', 'a');

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -132,6 +132,9 @@ config.erizoAgent.networkinterface = ''; //default value: ''
 //This files will be named erizo-ERIZO_ID_HASH.log
 config.erizoAgent.useIndividualLogFiles = false;
 
+// If true this Agent will launch Debug versions of ErizoJS
+config.erizoAgent.launchDebugErizoJS = false;
+
 // Custom log directory for agent instance log files.
 // If useIndividualLogFiles is enabled, files will go here
 // Default is [licode_path]/erizo_controller/erizoAgent

--- a/test/licode_default.js
+++ b/test/licode_default.js
@@ -132,6 +132,9 @@ config.erizoAgent.networkinterface = ''; //default value: ''
 //This files will be named erizo-ERIZO_ID_HASH.log
 config.erizoAgent.useIndividualLogFiles = false;
 
+// If true this Agent will launch Debug versions of ErizoJS 
+config.erizoAgent.launchDebugErizoJS = false;
+
 // Custom log directory for agent instance log files.
 // If useIndividualLogFiles is enabled, files will go here
 // Default is [licode_path]/erizo_controller/erizoAgent


### PR DESCRIPTION

**Description**
Added the option to load the debug ErizoAPI addon in the ErizoAgent section of `licode_config`

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.