### PR TITLE
Add an API to limit the max subscribed video resolution and framerate

### DIFF
--- a/doc/client_api.md
+++ b/doc/client_api.md
@@ -294,7 +294,7 @@ It updates the audio and video maximum bandwidth for a publisher or a subscriber
 It can also be used in remote streams to toggle `slideShowMode`
 
 <example>
-You can update the maximun bandwidth of video and audio. These values are defined in the object passed to the function. You can also pass a callback function to get the final result.
+You can update the maximum bandwidth of video and audio. These values are defined in the object passed to the function. You can also pass a callback function to get the final result.
 </example>
 
 ```
@@ -480,6 +480,20 @@ room.subscribe(stream, {audio: true, video: true, slideShowMode:true}, function(
 
 `SlideShowMode` can also be toggled on or off using `stream.updateConfiguration`. Keep in mind this will only work on remote streams (subscriptions).
 
+When we enable Simulcast it is also interesting to specify whether the subscriber should not receive a resolution or frame rate beyond a maximum. We
+can configure it like in the example below:
+
+```
+room.subscribe(stream, {video: {height: {max: 480}, width: {max: 640}, frameRate: {max:20}}}, function(result, error){
+  if (result === undefined){
+    console.log("Error subscribing to stream", error);
+  } else {
+    console.log("Stream subscribed!");
+  }
+});
+```
+
+It would help us not wasting CPU or bandwidth if, for instance, we will not render videos in a <video> element bigger than 640x480.
 
 ## Unsubscribe from a remote stream
 

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -757,6 +757,12 @@ void WebRtcConnection::muteStream(bool mute_video, bool mute_audio) {
   });
 }
 
+void WebRtcConnection::setVideoConstraints(int max_video_width, int max_video_height, int max_video_frame_rate) {
+  asyncTask([max_video_width, max_video_height, max_video_frame_rate] (std::shared_ptr<WebRtcConnection> connection) {
+    connection->quality_manager_->setVideoConstraints(max_video_width, max_video_height, max_video_frame_rate);
+  });
+}
+
 void WebRtcConnection::setFeedbackReports(bool will_send_fb, uint32_t target_bitrate) {
   if (slide_show_mode_) {
     target_bitrate = 0;

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -146,6 +146,7 @@ class WebRtcConnection: public MediaSink, public MediaSource, public FeedbackSin
   void setFeedbackReports(bool will_send_feedback, uint32_t target_bitrate = 0);
   void setSlideShowMode(bool state);
   void muteStream(bool mute_video, bool mute_audio);
+  void setVideoConstraints(int max_video_width, int max_video_height, int max_video_frame_rate);
 
   void setMetadata(std::map<std::string, std::string> metadata);
 

--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -190,6 +190,12 @@ void QualityManager::forceLayers(int spatial_layer, int temporal_layer) {
   temporal_layer_ = temporal_layer;
 }
 
+void QualityManager::setVideoConstraints(int max_video_width, int max_video_height, int max_video_frame_rate) {
+  ELOG_DEBUG("Max: width (%d), height (%d), frameRate (%d)", max_video_width, max_video_height, max_video_frame_rate);
+
+  // TODO(javier): Actually apply constraints to current feed.
+}
+
 void QualityManager::setSpatialLayer(int spatial_layer) {
   if (!forced_layers_) {
     spatial_layer_ = spatial_layer;

--- a/erizo/src/erizo/rtp/QualityManager.h
+++ b/erizo/src/erizo/rtp/QualityManager.h
@@ -29,7 +29,7 @@ class QualityManager: public Service, public std::enable_shared_from_this<Qualit
   void setTemporalLayer(int temporal_layer);
 
   void forceLayers(int spatial_layer, int temporal_layer);
-
+  void setVideoConstraints(int max_video_width, int max_video_height, int max_video_frame_rate);
   void notifyEvent(MediaEventPtr event) override;
   void notifyQualityUpdate();
 

--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -77,6 +77,7 @@ NAN_MODULE_INIT(WebRtcConnection::Init) {
   Nan::SetPrototypeMethod(tpl, "setSlideShowMode", setSlideShowMode);
   Nan::SetPrototypeMethod(tpl, "muteStream", muteStream);
   Nan::SetPrototypeMethod(tpl, "setQualityLayer", setQualityLayer);
+  Nan::SetPrototypeMethod(tpl, "setVideoConstraints", setVideoConstraints);
   Nan::SetPrototypeMethod(tpl, "setMetadata", setMetadata);
   Nan::SetPrototypeMethod(tpl, "enableHandler", enableHandler);
   Nan::SetPrototypeMethod(tpl, "disableHandler", disableHandler);
@@ -269,6 +270,15 @@ NAN_METHOD(WebRtcConnection::muteStream) {
   bool mute_video = info[0]->BooleanValue();
   bool mute_audio = info[1]->BooleanValue();
   me->muteStream(mute_video, mute_audio);
+}
+
+NAN_METHOD(WebRtcConnection::setVideoConstraints) {
+  WebRtcConnection* obj = Nan::ObjectWrap::Unwrap<WebRtcConnection>(info.Holder());
+  std::shared_ptr<erizo::WebRtcConnection> me = obj->me;
+  int max_video_width = info[0]->IntegerValue();
+  int max_video_height = info[1]->IntegerValue();
+  int max_video_frame_rate = info[2]->IntegerValue();
+  me->setVideoConstraints(max_video_width, max_video_height, max_video_frame_rate);
 }
 
 NAN_METHOD(WebRtcConnection::setMetadata) {

--- a/erizoAPI/WebRtcConnection.h
+++ b/erizoAPI/WebRtcConnection.h
@@ -124,6 +124,11 @@ class WebRtcConnection : public MediaSink, public erizo::WebRtcConnectionEventLi
      */
     static NAN_METHOD(muteStream);
     /*
+     * Sets constraints to the subscribing video
+     * Param: Max width, height and framerate.
+     */
+    static NAN_METHOD(setVideoConstraints);
+    /*
      * Gets Stats from this Wrtc
      * Param: None
      * Returns: The Current stats

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -428,6 +428,17 @@ const Room = (altIo, altConnection, specInput) => {
     });
   };
 
+  const getVideoConstraints = (stream, video) => {
+    const hasVideo = video && stream.hasVideo();
+    const width = video && video.width;
+    const height = video && video.height;
+    const frameRate = video && video.frameRate;
+    if (width || height || frameRate) {
+      return { width, height, frameRate };
+    }
+    return hasVideo;
+  };
+
   const subscribeErizo = (streamInput, optionsInput, callback = () => {}) => {
     const stream = streamInput;
     const options = optionsInput;
@@ -441,7 +452,7 @@ const Room = (altIo, altConnection, specInput) => {
     stream.checkOptions(options);
     const constraint = { streamId: stream.getID(),
       audio: options.audio && stream.hasAudio(),
-      video: options.video && stream.hasVideo(),
+      video: getVideoConstraints(stream, options.video),
       data: options.data && stream.hasData(),
       browser: that.Connection.getBrowser(),
       createOffer: options.createOffer,

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -282,9 +282,8 @@ const Stream = (altConnection, specInput) => {
     const config = configInput;
     // TODO: Check for any incompatible options
     if (isUpdate === true) {  // We are updating the stream
-      if (config.video || config.audio || config.screen) {
+      if (config.audio || config.screen) {
         Logger.warning('Cannot update type of subscription');
-        config.video = undefined;
         config.audio = undefined;
         config.screen = undefined;
       }

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -237,10 +237,12 @@ const BaseStack = (specInput) => {
       }
     }
     if (config.minVideoBW || (config.slideShowMode !== undefined) ||
-            (config.muteStream !== undefined) || (config.qualityLayer !== undefined)) {
+            (config.muteStream !== undefined) || (config.qualityLayer !== undefined) ||
+            (config.video !== undefined)) {
       Logger.debug('MinVideo Changed to ', config.minVideoBW);
       Logger.debug('SlideShowMode Changed to ', config.slideShowMode);
       Logger.debug('muteStream changed to ', config.muteStream);
+      Logger.debug('Video Constraints', config.video);
       specBase.callback({ type: 'updatestream', config });
     }
   };

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -268,6 +268,9 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
                         if (msg.config.qualityLayer !== undefined) {
                             that.setQualityLayer (msg.config.qualityLayer, peerId, streamId);
                         }
+                        if (msg.config.video !== undefined) {
+                            that.setVideoConstraints(msg.config.video, peerId, streamId);
+                        }
                     }
                 } else if (msg.type === 'control') {
                   processControlMessage(publisher, peerId, msg.action);
@@ -530,6 +533,13 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
       var publisher = this.publishers[to];
       if (publisher.hasSubscriber(from)) {
         publisher.setQualityLayer(from, qualityLayer.spatialLayer, qualityLayer.temporalLayer);
+      }
+    };
+
+    that.setVideoConstraints = function (video, from, to) {
+      var publisher = this.publishers[to];
+      if (publisher.hasSubscriber(from)) {
+        publisher.setVideoConstraints(from, video.width, video.height, video.frameRate);
       }
     };
 

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -58,8 +58,9 @@ class Source {
     const muteAudio = (options.muteStream && options.muteStream.audio) || false;
     this.muteSubscriberStream(id, muteVideo, muteAudio);
     if (options.video) {
-      this.setVideoConstraints(id, options.video.width, options.video.height, options.video.frameRate);
-    };
+      this.setVideoConstraints(id,
+        options.video.width, options.video.height, options.video.frameRate);
+    }
   }
 
   removeSubscriber(id) {

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -57,6 +57,9 @@ class Source {
     const muteVideo = (options.muteStream && options.muteStream.video) || false;
     const muteAudio = (options.muteStream && options.muteStream.audio) || false;
     this.muteSubscriberStream(id, muteVideo, muteAudio);
+    if (options.video) {
+      this.setVideoConstraints(id, options.video.width, options.video.height, options.video.frameRate);
+    };
   }
 
   removeSubscriber(id) {
@@ -123,6 +126,14 @@ class Source {
                                  ', audio: ', this.muteAudio || muteAudio);
     subscriber.muteStream(this.muteVideo || muteVideo,
                           this.muteAudio || muteAudio);
+  }
+
+  setVideoConstraints(id, width, height, frameRate) {
+    var subscriber = this.getSubscriber(id);
+    var maxWidth = (width && width.max) || -1;
+    var maxHeight = (height && height.max) || -1;
+    var maxFrameRate = (frameRate && frameRate.max) || -1;
+    subscriber.setVideoConstraints(maxWidth, maxHeight, maxFrameRate);
   }
 
   enableHandlers(id, handlers) {


### PR DESCRIPTION
**Description**

It adds a new API to configure the max width/height/frameRate we want to receive in a subscribed video. It could be really useful in Simulcast, when to make sure we won't receive a video larger than the size of the <video> element, or if we want to stop wasting bandwidth/CPU in the client side.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

When we enable Simulcast it is also interesting to specify whether the subscriber should not receive a resolution or frame rate beyond a maximum. We
can configure it like in the example below:

```js
room.subscribe(stream, {video: {height: {max: 480}, width: {max: 640}, frameRate: {max:20}}}, function(result, error){
  if (result === undefined){
    console.log("Error subscribing to stream", error);
  } else {
    console.log("Stream subscribed!");
  }
});
```

It would help us not wasting CPU or bandwidth if, for instance, we will not render videos in a <video> element bigger than 640x480.

- [x] It includes documentation for these changes in `/doc`.