### PR TITLE
Accept zero as a value in video constraints.

### DIFF
--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -131,9 +131,9 @@ class Source {
 
   setVideoConstraints(id, width, height, frameRate) {
     var subscriber = this.getSubscriber(id);
-    var maxWidth = (width && width.max) || -1;
-    var maxHeight = (height && height.max) || -1;
-    var maxFrameRate = (frameRate && frameRate.max) || -1;
+    var maxWidth = (width && width.max !== undefined) ? width.max : -1;
+    var maxHeight = (height && height.max !== undefined) ? height.max : -1;
+    var maxFrameRate = (frameRate && frameRate.max !== undefined) ? frameRate.max : -1;
     subscriber.setVideoConstraints(maxWidth, maxHeight, maxFrameRate);
   }
 


### PR DESCRIPTION
**Description**

Fixes a bug that was converting 0 values to -1 on constraints received in erizoJS.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.