### PR TITLE
adds stream attributes to streamEvent

### DIFF
--- a/erizo_controller/erizoClient/src/Events.js
+++ b/erizo_controller/erizoClient/src/Events.js
@@ -106,6 +106,7 @@ const StreamEvent = (spec) => {
 
   that.msg = spec.msg;
   that.bandwidth = spec.bandwidth;
+  that.attrs = spec.attrs;
 
   return that;
 };


### PR DESCRIPTION
**Description**
Updating stream attributes object of a stream, set its attributes to undefined instead.
This is because when creating the streamEvent Object, it doesn't pull the `attrs` from the spec property passed to it. Thus it gets set to undefined. 
