### PR TITLE
Erizo Controller refactoring to add Clients and Channels

### DIFF
--- a/erizo_controller/common/amqper.js
+++ b/erizo_controller/common/amqper.js
@@ -79,16 +79,14 @@ exports.connect = function(callback) {
                             }
                         } catch(err) {
                             log.error('message: error processing message, ' +
-                                      'queueName: ' + clientQueue.name + ', ' +
-                                      logger.objectToLog(err));
+                                      'queueName: ' + clientQueue.name + ', error: ' + err.message);
                         }
                     });
 
                 });
             } catch (err) {
                 log.error('message: exchange error, ' +
-                          'exchangeName: ' + exchange.name + ', ' +
-                          logger.objectToLog(err));
+                          'exchangeName: ' + exchange.name + ', error: ' + err.message);
             }
         });
 
@@ -127,15 +125,13 @@ exports.bind = function(id, callback) {
                     rpcPublic[message.method].apply(rpcPublic, message.args);
                 } catch (error) {
                     log.error('message: error processing call, ' +
-                              'queueName: ' + q.name + ', ' +
-                              logger.objectToLog(error));
+                              'queueName: ' + q.name + ', error: ' + error.message);
                 }
 
             });
         } catch (err) {
             log.error('message: queue error, ' +
-                      'queueName: ' + q.name + ', ' +
-                      logger.objectToLog(err));
+                      'queueName: ' + q.name + ', error: ' + err.message);
         }
 
     });
@@ -161,16 +157,23 @@ exports.bindBroadcast = function(id, callback) {
                 }
                 if (body.message.method && rpcPublic[body.message.method]) {
                     body.message.args.push(answer);
-                    rpcPublic[body.message.method].apply(rpcPublic, body.message.args);
+                    try {
+                      rpcPublic[body.message.method].apply(rpcPublic, body.message.args);
+                    } catch(e) {
+                      log.warn('message: error processing call, error:', e.message);
+                    }
                 } else {
+                  try {
                     callback(body.message, answer);
+                  } catch(e) {
+                    log.warn('message: error processing callback, error:', e.message);
+                  }
                 }
             });
 
         } catch (err) {
             log.error('message: exchange error, ' +
-                      'queueName: ' + q.name + ', ' +
-                      logger.objectToLog(err));
+                      'queueName: ' + q.name + ', error: ' + err.message);
         }
 
     });

--- a/erizo_controller/common/logger.js
+++ b/erizo_controller/common/logger.js
@@ -1,6 +1,8 @@
 'use strict';
 var log4js = require('log4js');
 
+global.config = global.config || {};
+
 global.config.logger = global.config.logger || {};
 
 var logFile = global.config.logger.configFile ||  '../log4js_configuration.json';

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -140,6 +140,16 @@ const Room = (altIo, altConnection, specInput) => {
     connection.createOffer();
   };
 
+  const removeLocalStreamP2PConnection = (streamInput, peerSocket) => {
+    const stream = streamInput;
+    if (stream.pc === undefined || !stream.pc.has(peerSocket)) {
+      return;
+    }
+    const pc = stream.pc.get(peerSocket);
+    pc.close();
+    stream.pc.remove(peerSocket);
+  };
+
   const getErizoConnectionOptions = (stream, options, isRemote) => {
     const connectionOpts = {
       callback(message) {
@@ -239,6 +249,13 @@ const Room = (altIo, altConnection, specInput) => {
     const myStream = localStreams.get(arg.streamId);
 
     createLocalStreamP2PConnection(myStream, arg.peerSocket);
+  };
+
+  const socketOnUnpublishMe = (arg) => {
+    const myStream = localStreams.get(arg.streamId);
+    if (myStream) {
+      removeLocalStreamP2PConnection(myStream, arg.peerSocket);
+    }
   };
 
   const socketOnBandwidthAlert = (arg) => {
@@ -815,6 +832,7 @@ const Room = (altIo, altConnection, specInput) => {
   socket.on('signaling_message_erizo', socketEventToArgs.bind(null, socketOnErizoMessage));
   socket.on('signaling_message_peer', socketEventToArgs.bind(null, socketOnPeerMessage));
   socket.on('publish_me', socketEventToArgs.bind(null, socketOnPublishMe));
+  socket.on('unpublish_me', socketEventToArgs.bind(null, socketOnUnpublishMe));
   socket.on('onBandwidthAlert', socketEventToArgs.bind(null, socketOnBandwidthAlert));
   socket.on('onDataStream', socketEventToArgs.bind(null, socketOnDataStream));
   socket.on('onUpdateAttributeStream', socketEventToArgs.bind(null, socketOnUpdateAttributeStream));

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -33,6 +33,7 @@ const Room = (altIo, altConnection, specInput) => {
   that.Connection = altConnection === undefined ? Connection : altConnection;
 
   let socket = Socket(altIo);
+  that.socket = socket;
   let remoteStreams = that.remoteStreams;
   let localStreams = that.localStreams;
 

--- a/erizo_controller/erizoClient/src/Socket.js
+++ b/erizo_controller/erizoClient/src/Socket.js
@@ -1,4 +1,4 @@
-/* global window */
+/* global */
 
 import io from '../lib/socket.io';
 import Logger from './utils/Logger';
@@ -56,8 +56,8 @@ const Socket = (newIo) => {
       transports: ['websocket'],
       rejectUnauthorized: false,
     };
-    let transport = token.secure ? 'wss://' : 'ws://';
-    let host = token.host;
+    const transport = token.secure ? 'wss://' : 'ws://';
+    const host = token.host;
     socket = that.IO.connect(transport + host, options);
 
     // Hack to know the exact reason of the WS closure (socket.io does not publish it)

--- a/erizo_controller/erizoClient/src/Socket.js
+++ b/erizo_controller/erizoClient/src/Socket.js
@@ -74,6 +74,7 @@ const Socket = (newIo) => {
     socket.on('signaling_message_erizo', emit.bind(that, 'signaling_message_erizo'));
     socket.on('signaling_message_peer', emit.bind(that, 'signaling_message_peer'));
     socket.on('publish_me', emit.bind(that, 'publish_me'));
+    socket.on('unpublish_me', emit.bind(that, 'unpublish_me'));
     socket.on('onBandwidthAlert', emit.bind(that, 'onBandwidthAlert'));
 
     // We receive an event of new data in one of the streams

--- a/erizo_controller/erizoClient/src/Socket.js
+++ b/erizo_controller/erizoClient/src/Socket.js
@@ -68,7 +68,7 @@ const Socket = (newIo) => {
     // The socket has disconnected
     socket.on('disconnect', (reason) => {
       Logger.error('Disconnect!', reason);
-      // emit.bind(that, 'disconnect');
+      emit.bind(that, 'disconnect');
     });
 
     socket.on('connection_failed', () => {

--- a/erizo_controller/erizoClient/src/Socket.js
+++ b/erizo_controller/erizoClient/src/Socket.js
@@ -33,7 +33,7 @@ const Socket = (newIo) => {
 
   that.connect = (token, callback = defaultCallback, error = defaultCallback) => {
     const options = {
-      reconnect: false,
+      reconnection: false,
       reconnectionAttempts: 3,
       secure: token.secure,
       forceNew: true,
@@ -112,7 +112,7 @@ const Socket = (newIo) => {
     // First message with the token
     that.sendMessage('token', token, (response) => {
       that.state = that.CONNECTED;
-      id = response.socketId;
+      id = response.clientId;
       callback(response);
     }, error);
   };

--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -1,10 +1,7 @@
-/*global require, setInterval, clearInterval, Buffer, exports*/
+/*global require, setInterval, clearInterval, exports*/
 'use strict';
-var crypto = require('crypto');
 var rpcPublic = require('./rpc/rpcPublic');
-var ST = require('./Stream');
 var config = require('./../../licode_config');
-var Permission = require('./permission');
 var Getopt = require('node-getopt');
 
 // Configuration default values
@@ -65,8 +62,6 @@ var getopt = new Getopt([
   ['h' , 'help'                    , 'display this help']
 ]);
 
-var PUBLISHER_INITAL = 101, PUBLISHER_READY = 104;
-
 var opt = getopt.parse(process.argv.slice(2));
 
 for (var prop in opt.options) {
@@ -103,8 +98,10 @@ for (var prop in opt.options) {
 // Load submodules with updated config
 var logger = require('./../common/logger').logger;
 var amqper = require('./../common/amqper');
-var controller = require('./roomController');
 var ecch = require('./ecCloudHandler').EcCloudHandler({amqper: amqper});
+var nuve = require('./nuveProxy').NuveProxy({amqper: amqper});
+var Rooms = require('./models/Room').Rooms;
+var Channel = require('./models/Channel').Channel;
 
 // Logger
 var log = logger.getLogger('ErizoController');
@@ -135,8 +132,6 @@ var io = require('socket.io').listen(server, {log:false});
 
 io.set('transports', ['websocket']);
 
-var nuveKey = global.config.nuve.superserviceKey;
-
 var WARNING_N_ROOMS = global.config.erizoController.warning_n_rooms; // jshint ignore:line
 var LIMIT_N_ROOMS = global.config.erizoController.limit_n_rooms; // jshint ignore:line
 
@@ -145,48 +140,9 @@ var INTERVAL_TIME_KEEPALIVE = global.config.erizoController.interval_time_keepAl
 var BINDED_INTERFACE_NAME = global.config.erizoController.networkInterface;
 
 var myId;
-var rooms = {};
+var rooms = new Rooms(amqper, ecch);
+
 var myState;
-
-var calculateSignature = function (token, key) {
-    var toSign = token.tokenId + ',' + token.host,
-        signed = crypto.createHmac('sha1', key).update(toSign).digest('hex');
-    return (new Buffer(signed)).toString('base64');
-};
-
-var checkSignature = function (token, key) {
-    var calculatedSignature = calculateSignature(token, key);
-
-    if (calculatedSignature !== token.signature) {
-        log.info('message: invalid token signature');
-        return false;
-    } else {
-        return true;
-    }
-};
-
-var sendToSocket = function(socketId, type, arg) {
-  if (io.sockets.sockets.hasOwnProperty(socketId)) {
-    io.sockets.sockets[socketId].emit(type, arg);
-  }
-};
-
-/*
- * Sends a message of type 'type' to all sockets in a determined room.
- */
-var sendMsgToRoom = function (room, type, arg) {
-    var sockets = room.sockets,
-        id;
-    for (id in sockets) {
-        if (sockets.hasOwnProperty(id)) {
-            log.debug('message: sendMsgToRoom, ' +
-                      'clientId: ' + sockets[id] + ', ' +
-                      'roomId: ' + room.id + ', ' +
-                      logger.objectToLog(type));
-            sendToSocket(sockets[id], type, arg);
-        }
-    }
-};
 
 var privateRegexp;
 var publicIP;
@@ -225,6 +181,26 @@ var addToCloudHandler = function (callback) {
         publicIP = global.config.erizoController.publicIP;
     }
 
+    var startKeepAlives = (erizoControllerId, publicIP) => {
+      var intervalId = setInterval(function () {
+        nuve.keepAlive(erizoControllerId)
+        .then(() => true)
+        .catch(result => {
+          if (result === 'whoareyou') {
+              // TODO: It should try to register again in Cloud Handler.
+              // But taking into account current rooms, users, ...
+              log.error('message: This ErizoController does not exist in cloudHandler ' +
+                        'to avoid unexpected behavior this ErizoController will die');
+              clearInterval(intervalId);
+              return false;
+          }
+          return true;
+        }).then((result) => {
+          if (!result) return nuve.killMe(publicIP);
+        });
+      }, INTERVAL_TIME_KEEPALIVE);
+    };
+
     var addECToCloudHandler = function(attempt) {
         if (attempt <= 0) {
             log.error('message: addECtoCloudHandler cloudHandler does not respond - fatal');
@@ -238,49 +214,29 @@ var addToCloudHandler = function (callback) {
             port: global.config.erizoController.port,
             ssl: global.config.erizoController.ssl
         };
-        amqper.callRpc('nuve', 'addNewErizoController', controller, {callback: function (msg) {
+        nuve.addNewErizoController(controller).then(msg => {
+          log.info('message: succesfully added to cloudHandler');
 
-            if (msg === 'timeout') {
-                log.warn('message: addECToCloudHandler cloudHandler does not respondr, ' +
-                         'attemptsLeft: ' + attempt );
+          publicIP = msg.publicIP;
+          myId = msg.id;
+          myState = 2;
 
-                // We'll try it more!
-                setTimeout(function() {
-                    attempt = attempt - 1;
-                    addECToCloudHandler(attempt);
-                }, 3000);
-                return;
-            }
-            if (msg === 'error') {
-                log.error('message: cannot contact cloudHandler');
-                return;
-            }
+          startKeepAlives(myId, publicIP);
+          callback('callback');
+        }).catch(reason => {
+          if (reason === 'timeout') {
+            log.warn('message: addECToCloudHandler cloudHandler does not respondr, ' +
+                     'attemptsLeft: ' + attempt );
 
-            log.info('message: succesfully added to cloudHandler');
-
-            publicIP = msg.publicIP;
-            myId = msg.id;
-            myState = 2;
-
-            var intervarId = setInterval(function () {
-
-                amqper.callRpc('nuve', 'keepAlive', myId, {'callback': function (result) {
-                    if (result === 'whoareyou') {
-
-                        // TODO: It should try to register again in Cloud Handler.
-                        // But taking into account current rooms, users, ...
-                        log.error('message: This ErizoController does not exist in cloudHandler ' +
-                                  'to avoid unexpected behavior this ErizoController will die');
-                        clearInterval(intervarId);
-                        amqper.callRpc('nuve', 'killMe', publicIP, {callback: function () {}});
-                    }
-                }});
-
-            }, INTERVAL_TIME_KEEPALIVE);
-
-            callback('callback');
-
-        }});
+            // We'll try it more!
+            setTimeout(function() {
+                attempt = attempt - 1;
+                addECToCloudHandler(attempt);
+            }, 3000);
+          } else {
+            log.error('message: cannot contact cloudHandler');
+          }
+        });
     };
     addECToCloudHandler(5);
 };
@@ -295,13 +251,11 @@ var addToCloudHandler = function (callback) {
 //            2: Available
 //*******************************************************************
 var updateMyState = function () {
-    var nRooms = 0, newState, i, info;
+    var nRooms = 0, newState;
 
-    for (i in rooms) {
-        if (rooms.hasOwnProperty(i)) {
-            nRooms += 1;
-        }
-    }
+    nRooms = rooms.size();
+
+    log.debug('message: Updating my state, id:', myId, ', rooms:', nRooms);
 
     if (nRooms < WARNING_N_ROOMS) {
         newState = 2;
@@ -321,718 +275,73 @@ var updateMyState = function () {
 
     myState = newState;
 
-    info = {id: myId, state: myState};
-    amqper.callRpc('nuve', 'setInfo', info, {callback: function () {}});
+    nuve.setInfo({id: myId, state: myState});
 };
 
 var listen = function () {
     io.sockets.on('connection', function (socket) {
-        log.info('message: erizoClient connected, clientId: ' + socket.id);
+        log.info('message: socket connected, socketId: ' + socket.id);
 
-        // Gets 'token' messages on the socket. Checks the signature and ask nuve if it is valid.
-        // Then registers it in the room and callback to the client.
-        socket.on('token', function (token, callback) {
+        let channel = new Channel(socket, nuve);
 
-            //log.debug("New token", token);
-
-            var tokenDB, user, streamList = [], index;
-            if (checkSignature(token, nuveKey)) {
-
-                amqper.callRpc('nuve', 'deleteToken', token.tokenId, {callback: function (resp) {
-                    if (resp === 'error') {
-                        log.warn('message: Trying to use token that does not exist - ' +
-                                 'disconnecting Client, clientId: ' + socket.id);
-                        callback('error', 'Token does not exist');
-                        socket.disconnect();
-
-                    } else if (resp === 'timeout') {
-                        log.warn('message: Nuve does not respond token check - ' +
-                                 'disconnecting client, clientId: ' + socket.id);
-                        callback('error', 'Nuve does not respond');
-                        socket.disconnect();
-
-                    } else if (token.host === resp.host) {
-                        tokenDB = resp;
-                        if (rooms[tokenDB.room] === undefined) {
-                            var room = {};
-
-                            room.id = tokenDB.room;
-                            room.sockets = [];
-                            room.sockets.push(socket.id);
-                            room.streams = {}; //streamId: Stream
-                            if (tokenDB.p2p) {
-                                log.debug('message: Requested token for p2p room');
-                                room.p2p = true;
-                            } else {
-                                room.controller = controller.RoomController({amqper: amqper,
-                                                                             ecch: ecch});
-                                room.controller.addEventListener(function(type, event) {
-                                    if (type === 'unpublish') {
-                                        // It's supposed to be an integer.
-                                        var streamId = parseInt(event);
-                                        log.warn('message: Triggering removal of stream ' +
-                                                 'because of ErizoJS timeout, ' +
-                                                 'streamId: ' + streamId);
-                                        sendMsgToRoom(room, 'onRemoveStream', {id: streamId});
-                                        /*
-                                        room.controller.removePublisher(streamId);
-
-                                        for (var s in room.sockets) {
-                                            var streams =
-                                                io.sockets.sockets[room.sockets[s]].streams;
-                                            var index = streams.indexOf(streamId);
-                                            if (index !== -1) {
-                                                streams.splice(index, 1);
-                                            }
-                                        }
-
-                                        if (room.streams[streamId]) {
-                                            delete room.streams[streamId];
-                                        }
-                                        */
-                                    }
-
-                                });
-                            }
-                            rooms[tokenDB.room] = room;
-                            updateMyState();
-                        } else {
-                            rooms[tokenDB.room].sockets.push(socket.id);
-                        }
-                        user = {name: tokenDB.userName, role: tokenDB.role};
-                        socket.user = user;
-                        var permissions = global.config.erizoController.roles[tokenDB.role] || [];
-                        socket.user.permissions = {};
-                        for (var right in permissions) {
-                            socket.user.permissions[right] = permissions[right];
-                        }
-                        socket.room = rooms[tokenDB.room];
-                        socket.streams = []; //[list of streamIds]
-                        socket.state = 'sleeping';
-
-                        log.debug('message: Token approved, clientId: ' + socket.id);
-
-                        if (!tokenDB.p2p &&
-                            global.config.erizoController.report.session_events) {  // jshint ignore:line
-                            var timeStamp = new Date();
-                            amqper.broadcast('event', {room: tokenDB.room,
-                                                       user: socket.id,
-                                                       type: 'user_connection',
-                                                       timestamp:timeStamp.getTime()});
-                        }
-
-                        for (index in socket.room.streams) {
-                            if (socket.room.streams.hasOwnProperty(index)) {
-                                if (socket.room.streams[index].status === PUBLISHER_READY){
-                                    streamList.push(socket.room.streams[index].getPublicStream());
-                                }
-                            }
-                        }
-
-                        callback('success', {streams: streamList,
-                                            id: socket.room.id,
-                                            p2p: socket.room.p2p,
-                                            defaultVideoBW:
-                                                global.config.erizoController.defaultVideoBW,
-                                            maxVideoBW: global.config.erizoController.maxVideoBW,
-                                            iceServers: global.config.erizoController.iceServers
-                                            });
-
-                    } else {
-                        log.warn('message: Token has invalid host, clientId: ' + socket.id);
-                        callback('error', 'Invalid host');
-                        socket.disconnect();
-                    }
-                }});
-
-            } else {
-                log.warn('message: Token authentication error, clientId: ' + socket.id);
-                callback('error', 'Authentication error');
-                socket.disconnect();
+        channel.on('connected', (token, callback) => {
+          try {
+            let room = rooms.getOrCreateRoom(token.room, token.p2p);
+            let client = room.createClient(channel, token);
+            log.info('message: client connected, clientId: ' + client.id);
+            if (!room.p2p && global.config.erizoController.report.session_events) {  // jshint ignore:line
+              var timeStamp = new Date();
+              amqper.broadcast('event', {room: room.id,
+                                         user: client.id,
+                                         type: 'user_connection',
+                                         timestamp: timeStamp.getTime()});
             }
+
+            let streamList = [];
+            room.forEachStream((stream) => {
+              streamList.push(stream.getPublicStream());
+            });
+
+            callback('success', {streams: streamList,
+                                 id: room.id,
+                                 p2p: room.p2p,
+                                 defaultVideoBW: global.config.erizoController.defaultVideoBW,
+                                 maxVideoBW: global.config.erizoController.maxVideoBW,
+                                 iceServers: global.config.erizoController.iceServers});
+          } catch(e) {
+            log.warn('message: error creating Room or Client, error:', e);
+          }
         });
 
-        //Gets 'sendDataStream' messages on the socket in order to write a message in a dataStream.
-        socket.on('sendDataStream', function (msg) {
-            if  (socket.room.streams[msg.id] === undefined){
-              log.warn('message: Trying to send Data from a non-initialized stream, ' +
-                       'clientId: ' + socket.id + ', ' +
-                       logger.objectToLog(msg));
-              return;
-            }
-            var sockets = socket.room.streams[msg.id].getDataSubscribers(), id;
-            for (id in sockets) {
-                if (sockets.hasOwnProperty(id)) {
-                    log.debug('message: sending dataStream, ' +
-                    'clientId: ' + sockets[id] + ', dataStream: ' + msg.id);
-                    sendToSocket(sockets[id], 'onDataStream', msg);
-                }
-            }
+        channel.on('reconnected', (clientId, token) => {
+          let room = rooms.getRoom(token.room);
+          if (room === undefined) {
+            channel.disconnect();
+          }
+          let client = room.getClientById(clientId);
+          if (client !== undefined) {
+            client.setNewChannel(channel);
+          }
         });
-
-        var hasPermission = function(user, action) {
-          return user && user.permissions[action] === true;
-        };
-
-        socket.on('signaling_message', function (msg) {
-            if (socket.room === undefined) {
-              log.error('message: singaling_message for user in undefined room ' +
-              msg.streamId + ' user: ' + socket.user);
-              socket.disconnect();
-            }
-            if (socket.room.p2p) {
-                sendToSocket(msg.peerSocket, 'signaling_message_peer',
-                        {streamId: msg.streamId, peerSocket: socket.id, msg: msg.msg});
-            } else {
-                var isControlMessage = msg.msg.type === 'control';
-                if (!isControlMessage ||
-                    (isControlMessage && hasPermission(socket.user, msg.msg.action.name))) {
-                  socket.room.controller.processSignaling(msg.streamId, socket.id, msg.msg);
-                } else {
-                  log.info('message: User unauthorized to execute action on stream, action: ' +
-                    msg.msg.action.name + ', streamId: ' + msg.streamId);
-                }
-            }
-        });
-
-        // Gets 'updateStreamAttributes' messages on the socket
-        // in order to update attributes from the stream.
-        socket.on('updateStreamAttributes', function (msg) {
-            if  (socket.room.streams[msg.id] === undefined){
-              log.warn('message: Update attributes to a uninitialized stream, ' +
-                       logger.objectToLog(msg));
-              return;
-            }
-            var sockets = socket.room.streams[msg.id].getDataSubscribers(), id;
-            socket.room.streams[msg.id].setAttributes(msg.attrs);
-            for (id in sockets) {
-                if (sockets.hasOwnProperty(id)) {
-                    log.debug('message: Sending new attributes, ' +
-                              'clientId: ' + sockets[id] + ', streamId: ' + msg.id);
-                    sendToSocket(sockets[id], 'onUpdateAttributeStream', msg);
-                }
-            }
-        });
-
-        // Gets 'publish' messages on the socket in order to add new stream to the room.
-        // Returns callback(id, error)
-          socket.on('publish', function (options, sdp, callback) {
-            var id, st;
-            if (socket.user === undefined || !socket.user.permissions[Permission.PUBLISH]) {
-                callback(null, 'Unauthorized');
-                return;
-            }
-            if (socket.user.permissions[Permission.PUBLISH] !== true) {
-                var permissions = socket.user.permissions[Permission.PUBLISH];
-                for (var right in permissions) {
-                    if ((options[right] === true) && (permissions[right] === false))
-                        return callback(null, 'Unauthorized');
-                }
-            }
-
-            // generate a 18 digits safe integer
-            id = Math.floor(100000000000000000 + Math.random() * 900000000000000000);
-
-            if (options.state === 'url' || options.state === 'recording') {
-                var url = sdp;
-                if (options.state === 'recording') {
-                    var recordingId = sdp;
-                    if (global.config.erizoController.recording_path) {  // jshint ignore:line
-                        url = global.config.erizoController.recording_path + recordingId + '.mkv'; // jshint ignore:line
-                    } else {
-                        url = '/tmp/' + recordingId + '.mkv';
-                    }
-                }
-                socket.room.controller.addExternalInput(id, url, function (result) {
-                    if (result === 'success') {
-                        st = new ST.Stream({id: id, socket: socket.id,
-                                            audio: options.audio,
-                                            video: options.video,
-                                            data: options.data,
-                                            attributes: options.attributes});
-                        st.status = PUBLISHER_READY;
-                        socket.streams.push(id);
-                        socket.room.streams[id] = st;
-                        callback(id);
-                        sendMsgToRoom(socket.room, 'onAddStream', st.getPublicStream());
-                    } else {
-                        callback(null, 'Error adding External Input:' + result);
-                    }
-                });
-            } else if (options.state === 'erizo') {
-                log.info('message: addPublisher requested, ' +
-                         'streamId: ' + id + ', clientId: ' + socket.id + ', ' +
-                         logger.objectToLog(options) + ', ' +
-                         logger.objectToLog(options.attributes));
-                socket.room.controller.addPublisher(id, options, function (signMess) {
-
-                    if (signMess.type === 'initializing') {
-                        callback(id);
-                        st = new ST.Stream({id: id, socket: socket.id,
-                                            audio: options.audio,
-                                            video: options.video,
-                                            data: options.data,
-                                            screen: options.screen,
-                                            attributes: options.attributes});
-                        socket.streams.push(id);
-                        socket.room.streams[id] = st;
-                        st.status = PUBLISHER_INITAL;
-                        log.info('message: addPublisher, ' +
-                                 'state: PUBLISHER_INITIAL, ' +
-                                 'clientId: ' + socket.id + ', ' +
-                                 'streamId: ' + id);
-
-                        if (global.config.erizoController.report.session_events) {  // jshint ignore:line
-                            var timeStamp = new Date();
-                            amqper.broadcast('event', {room: socket.room.id,
-                                                       user: socket.id,
-                                                       name: socket.user.name,
-                                                       type: 'publish',
-                                                       stream: id,
-                                                       timestamp: timeStamp.getTime(),
-                                                       agent: signMess.agentId,
-                                                       attributes: options.attributes});
-                        }
-                        return;
-                    } else if (signMess.type === 'failed'){
-                        log.warn('message: addPublisher ICE Failed, ' +
-                                 'state: PUBLISHER_FAILED, ' +
-                                 'streamId: ' + id + ', ' +
-                                 'clientId: ' + socket.id);
-                        socket.emit('connection_failed',{type:'publish', streamId: id});
-                        //We're going to let the client disconnect let the client do it
-
-                        /*
-                        if (!socket.room.p2p) {
-                            socket.room.controller.removePublisher(id);
-                            if (global.config.erizoController.report.session_events) {
-                                var timeStamp = new Date();
-                                amqper.broadcast('event', {room: socket.room.id,
-                                                           user: socket.id,
-                                                           type: 'failed',
-                                                           stream: id,
-                                                           sdp: signMess.sdp,
-                                                           timestamp: timeStamp.getTime()});
-                            }
-                        }
-
-                        //We assume it does not have subscribers because, for now
-                        // libnice will ONLY fail on establishment
-                        //TODO: If we upgrade libnice check if this is true and
-                        // also notify subscribers
-
-                        var index = socket.streams.indexOf(id);
-                        if (index !== -1) {
-                            socket.streams.splice(index, 1);
-                        }
-                        */
-                        return;
-                    } else if (signMess.type === 'ready') {
-                        st.status = PUBLISHER_READY;
-                        sendMsgToRoom(socket.room, 'onAddStream', st.getPublicStream());
-                        log.info('message: addPublisher, ' +
-                                 'state: PUBLISHER_READY, ' +
-                                 'streamId: ' + id + ', ' +
-                                 'clientId: ' + socket.id);
-                    } else if (signMess === 'timeout-erizojs') {
-                        log.error('message: addPublisher timeout when contacting ErizoJS, ' +
-                                  'streamId: ' + id + ', clientId: ' + socket.id);
-                        callback(null, 'ErizoJS is not reachable');
-                        return;
-                    } else if (signMess === 'timeout-agent'){
-                        log.error('message: addPublisher timeout when contacting Agent, ' +
-                                  'streamId: ' + id + ', clientId: ' + socket.id);
-                        callback(null, 'ErizoAgent is not reachable');
-                        return;
-                    } else if (signMess === 'timeout'){
-                        log.error('message: addPublisher Undefined RPC Timeout, ' +
-                                  'streamId: ' + id + ', clientId: ' + socket.id);
-                        callback(null, 'ErizoAgent or ErizoJS is not reachable');
-                        return;
-                    }
-
-                    socket.emit('signaling_message_erizo', {mess: signMess, streamId: id});
-                });
-            } else {
-                st = new ST.Stream({id: id,
-                                    socket: socket.id,
-                                    audio: options.audio,
-                                    video: options.video,
-                                    data: options.data,
-                                    screen: options.screen,
-                                    attributes: options.attributes});
-                socket.streams.push(id);
-                socket.room.streams[id] = st;
-                st.status = PUBLISHER_READY;
-                callback(id);
-                sendMsgToRoom(socket.room, 'onAddStream', st.getPublicStream());
-            }
-        });
-
-        //Gets 'subscribe' messages on the socket in order to add new
-        // subscriber to a determined stream (options.streamId).
-        // Returns callback(result, error)
-        socket.on('subscribe', function (options, sdp, callback) {
-            //log.info("Subscribing", options, callback);
-            if (socket.user === undefined || !socket.user.permissions[Permission.SUBSCRIBE]) {
-                callback(null, 'Unauthorized');
-                return;
-            }
-
-            if (socket.user.permissions[Permission.SUBSCRIBE] !== true) {
-                var permissions = socket.user.permissions[Permission.SUBSCRIBE];
-                for (var right in permissions) {
-                    if ((options[right] === true) && (permissions[right] === false))
-                        return callback(null, 'Unauthorized');
-                }
-            }
-
-            var stream = socket.room.streams[options.streamId];
-
-            if (stream === undefined) {
-                return;
-            }
-
-            if (stream.hasData() && options.data !== false) {
-                stream.addDataSubscriber(socket.id);
-            }
-
-            if (stream.hasAudio() || stream.hasVideo() || stream.hasScreen()) {
-
-                if (socket.room.p2p) {
-                    var s = stream.getSocket();
-                    sendToSocket(s, 'publish_me', {streamId: options.streamId,
-                                                             peerSocket: socket.id});
-
-                } else {
-                    log.info('message: addSubscriber requested, ' +
-                             'streamId: ' + options.streamId + ', ' +
-                             'clientId: ' + socket.id);
-                    socket.room.controller.addSubscriber(socket.id, options.streamId, options,
-                                                         function (signMess) {
-                        if (signMess.type === 'initializing') {
-                            log.info('message: addSubscriber, ' +
-                                     'state: SUBSCRIBER_INITIAL, ' +
-                                     'clientId: ' + socket.id + ', ' +
-                                     'streamId: ' + options.streamId);
-                            callback(true);
-
-                            if (global.config.erizoController.report.session_events) {  // jshint ignore:line
-                                var timeStamp = new Date();
-                                amqper.broadcast('event', {room: socket.room.id,
-                                                           user: socket.id,
-                                                           name: socket.user.name,
-                                                           type: 'subscribe',
-                                                           stream: options.streamId,
-                                                           timestamp: timeStamp.getTime()});
-                            }
-                            return;
-                        } else if (signMess.type === 'failed'){
-                            //TODO: Add Stats event
-                            log.warn('message: addSubscriber ICE Failed, ' +
-                                     'state: SUBSCRIBER_FAILED, ' +
-                                     'streamId: ' + options.streamId + ', ' +
-                                     'clientId: ' + socket.id);
-                            socket.emit('connection_failed', {type: 'subscribe',
-                                                              streamId: options.streamId});
-                            return;
-                        } else if (signMess.type === 'ready') {
-                            log.info('message: addSubscriber, ' +
-                                     'state: SUBSCRIBER_READY, ' +
-                                     'streamId: ' + options.streamId + ', ' +
-                                     'clientId: ' + socket.id);
-
-                        } else if (signMess.type === 'bandwidthAlert') {
-                            socket.emit('onBandwidthAlert', {streamID: options.streamId,
-                                                             message: signMess.message,
-                                                             bandwidth: signMess.bandwidth});
-                        } else if (signMess === 'timeout') {
-                            log.error('message: addSubscriber timeout when contacting ErizoJS, ' +
-                                      'streamId: ', options.streamId, ', ' +
-                                      'clientId: ' + socket.id);
-                            callback(null, 'ErizoJS is not reachable');
-                            return;
-                        }
-
-                        socket.emit('signaling_message_erizo', {mess: signMess,
-                                                                peerId: options.streamId});
-                    });
-                }
-            } else {
-                callback(true);
-            }
-
-        });
-
-        // Gets 'startRecorder' messages
-        // Returns callback(id, error)
-        socket.on('startRecorder', function (options, callback) {
-            if (socket.user === undefined || !socket.user.permissions[Permission.RECORD]) {
-                callback(null, 'Unauthorized');
-                return;
-            }
-            var streamId = options.to;
-            var recordingId = Math.random() * 1000000000000000000;
-            var url;
-
-            if (global.config.erizoController.recording_path) {  // jshint ignore:line
-                url = global.config.erizoController.recording_path + recordingId + '.mkv';  // jshint ignore:line
-            } else {
-                url = '/tmp/' + recordingId + '.mkv';
-            }
-
-            log.info('message: startRecorder, ' +
-                     'state: RECORD_REQUESTED, ' +
-                     'streamId: ' + streamId + ', ' +
-                     'url: ' + url);
-
-            if (socket.room.p2p) {
-               callback(null, 'Stream can not be recorded');
-            }
-
-            if (socket.room.streams[streamId].hasAudio() ||
-                socket.room.streams[streamId].hasVideo() ||
-                socket.room.streams[streamId].hasScreen()) {
-
-                socket.room.controller.addExternalOutput(streamId, url, function (result) {
-                    if (result === 'success') {
-                        log.info('message: startRecorder, ' +
-                                 'state: RECORD_STARTED, ' +
-                                 'streamId: ' + streamId + ', ' +
-                                 'url: ' + url);
-                        callback(recordingId);
-                    } else {
-                        log.warn('message: startRecorder stream not found, ' +
-                                 'state: RECORD_FAILED, ' +
-                                 'streamId: ' + streamId + ', ' +
-                                 'url: ' + url);
-                        callback(null, 'Unable to subscribe to stream for recording, ' +
-                                       'publisher not present');
-                    }
-                });
-
-            } else {
-                log.warn('message: startRecorder stream cannot be recorded, ' +
-                         'state: RECORD_FAILED, ' +
-                         'streamId: ' + streamId + ', ' +
-                         'url: ' + url);
-                callback(null, 'Stream can not be recorded');
-            }
-        });
-
-        // Gets 'stopRecorder' messages
-        // Returns callback(result, error)
-        socket.on('stopRecorder', function (options, callback) {
-            if (socket.user === undefined || !socket.user.permissions[Permission.RECORD]) {
-                if (callback) callback(null, 'Unauthorized');
-                return;
-            }
-            var recordingId = options.id;
-            var url;
-
-            if (global.config.erizoController.recording_path) {  // jshint ignore:line
-                url = global.config.erizoController.recording_path + recordingId + '.mkv';  // jshint ignore:line
-            } else {
-                url = '/tmp/' + recordingId + '.mkv';
-            }
-
-            log.info('message: startRecorder, ' +
-                     'state: RECORD_STOPPED, ' +
-                     'streamId: ' + options.id + ', ' +
-                     'url: ' + url);
-            socket.room.controller.removeExternalOutput(url, callback);
-        });
-
-        //Gets 'unpublish' messages on the socket in order to remove a stream from the room.
-        // Returns callback(result, error)
-        socket.on('unpublish', function (streamId, callback) {
-            if (socket.user === undefined || !socket.user.permissions[Permission.PUBLISH]) {
-                if (callback) callback(null, 'Unauthorized');
-                return;
-            }
-
-            // Stream has been already deleted or it does not exist
-            if (socket.room.streams[streamId] === undefined) {
-                return;
-            }
-            var index;
-
-            sendMsgToRoom(socket.room, 'onRemoveStream', {id: streamId});
-
-            if (socket.room.streams[streamId].hasAudio() ||
-                socket.room.streams[streamId].hasVideo() ||
-                socket.room.streams[streamId].hasScreen()) {
-
-                socket.state = 'sleeping';
-                if (!socket.room.p2p) {
-                    socket.room.controller.removePublisher(streamId);
-                    if (global.config.erizoController.report.session_events) {  // jshint ignore:line
-                        var timeStamp = new Date();
-                        amqper.broadcast('event', {room: socket.room.id,
-                                                   user: socket.id,
-                                                   type: 'unpublish',
-                                                   stream: streamId,
-                                                   timestamp: timeStamp.getTime()});
-                    }
-                }
-            }
-
-            index = socket.streams.indexOf(streamId);
-            if (index !== -1) {
-                socket.streams.splice(index, 1);
-            }
-            if (socket.room.streams[streamId]) {
-                delete socket.room.streams[streamId];
-            }
-            callback(true);
-        });
-
-        //Gets 'unsubscribe' messages on the socket in order to
-        // remove a subscriber from a determined stream (to).
-        // Returns callback(result, error)
-        socket.on('unsubscribe', function (to, callback) {
-            if (socket.user === undefined || !socket.user.permissions[Permission.SUBSCRIBE]) {
-                if (callback) callback(null, 'Unauthorized');
-                return;
-            }
-            if (socket.room.streams[to] === undefined) {
-                return;
-            }
-
-            socket.room.streams[to].removeDataSubscriber(socket.id);
-
-            if (socket.room.streams[to].hasAudio() ||
-                socket.room.streams[to].hasVideo() ||
-                socket.room.streams[to].hasScreen()) {
-
-                if (!socket.room.p2p) {
-                    socket.room.controller.removeSubscriber(socket.id, to);
-                    if (global.config.erizoController.report.session_events) {  // jshint ignore:line
-                        var timeStamp = new Date();
-                        amqper.broadcast('event', {room: socket.room.id,
-                                                   user: socket.id,
-                                                   type: 'unsubscribe',
-                                                   stream: to,
-                                                   timestamp: timeStamp.getTime()});
-                    }
-                }
-            }
-            callback(true);
-        });
-
-        //When a client leaves the room erizoController removes its streams from the room if exists.
-        socket.on('disconnect', function () {
-            var i, index, id;
-
-            var timeStamp = new Date();
-
-            log.info('message: Socket disconnect, clientId: ' + socket.id);
-
-            for (i in socket.streams) {
-                if (socket.streams.hasOwnProperty(i)) {
-                    sendMsgToRoom(socket.room, 'onRemoveStream', {id: socket.streams[i]});
-                }
-            }
-
-            if (socket.room !== undefined) {
-
-                for (i in socket.room.streams) {
-                    if (socket.room.streams.hasOwnProperty(i)) {
-                        socket.room.streams[i].removeDataSubscriber(socket.id);
-                    }
-                }
-
-                index = socket.room.sockets.indexOf(socket.id);
-                if (index !== -1) {
-                    socket.room.sockets.splice(index, 1);
-                }
-
-                if (socket.room.controller) {
-                    socket.room.controller.removeSubscriptions(socket.id);
-                }
-
-                for (i in socket.streams) {
-                    if (socket.streams.hasOwnProperty(i)) {
-                        id = socket.streams[i];
-                        if( socket.room.streams[id]) {
-                            if (socket.room.streams[id].hasAudio() ||
-                                socket.room.streams[id].hasVideo() ||
-                                socket.room.streams[id].hasScreen()) {
-
-                                if (!socket.room.p2p) {
-                                    socket.room.controller.removePublisher(id);
-                                    if (global.config.erizoController.report.session_events) {  // jshint ignore:line
-
-                                        amqper.broadcast('event', {room: socket.room.id,
-                                                                   user: socket.id,
-                                                                   type: 'unpublish',
-                                                                   stream: id,
-                                                                   timestamp: timeStamp.getTime()});
-                                    }
-                                }
-                            }
-
-                            delete socket.room.streams[id];
-                        }
-                    }
-                }
-            }
-
-            if (socket.room !== undefined &&
-                !socket.room.p2p &&
-                global.config.erizoController.report.session_events) {  // jshint ignore:line
-                amqper.broadcast('event', {room: socket.room.id,
-                                          user: socket.id,
-                                          type: 'user_disconnection',
-                                          timestamp: timeStamp.getTime()});
-            }
-
-            if (socket.room !== undefined && socket.room.sockets.length === 0) {
-                log.debug('message: deleting empty room, roomId: ' + socket.room.id);
-                delete rooms[socket.room.id];
-                updateMyState();
-            }
-        });
-
-        socket.on('getStreamStats', function (streamId, callback) {
-            log.debug('Getting stats for streamId ' + streamId);
-            if (socket.user === undefined || !socket.user.permissions[Permission.STATS]) {
-                log.info('message: unauthorized getStreamStats request');
-                if (callback) callback(null, 'Unauthorized');
-                return;
-            }
-            if (socket.room.streams[streamId] === undefined) {
-                log.info('message: bad getStreamStats request');
-                return;
-            }
-            if (socket.room !== undefined && !socket.room.p2p) {
-                socket.room.controller.getStreamStats(streamId, function (result) {
-                    callback(result);
-                });
-            }
-        });
+        socket.channel = channel;
     });
-
 };
 
 
 /*
  *Gets a list of users in a given room.
  */
-exports.getUsersInRoom = function (room, callback) {
-    var users = [], sockets, id;
-    if (rooms[room] === undefined) {
+exports.getUsersInRoom = function (roomId, callback) {
+    let users = [];
+    let room = rooms.getRoomById(roomId);
+    if (room === undefined) {
         callback(users);
         return;
     }
 
-    sockets = rooms[room].sockets;
-
-    for (id in sockets) {
-        if (sockets.hasOwnProperty(id)) {
-            users.push(io.sockets.sockets[sockets[id]].user);
-        }
-    }
+    room.forEachClient((client) => {
+      users.push(client.user);
+    });
 
     callback(users);
 };
@@ -1040,89 +349,76 @@ exports.getUsersInRoom = function (room, callback) {
 /*
  *Remove user from a room.
  */
-exports.deleteUser = function (user, room, callback) {
-    var sockets, id;
+exports.deleteUser = function (user, roomId, callback) {
+    let room = rooms.getRoomById(roomId);
 
-    if (rooms[room] === undefined) {
+    if (room === undefined) {
        callback('Success');
        return;
     }
-    sockets = rooms[room].sockets;
-    var socketsToDelete = [];
+    let clientsToDelete = [];
 
-    for (id in sockets) {
-        if (sockets.hasOwnProperty(id)) {
-            if (io.sockets.sockets[sockets[id]].user.name === user){
-                socketsToDelete.push(sockets[id]);
-            }
-        }
+    room.forEachClient((client) => {
+      if (client.user.name === user) {
+        clientsToDelete.push(client);
+      }
+    });
+
+    for (let client of clientsToDelete) {
+        log.info('message: deleteUser, user: ' + client.user.name);
+        client.disconnect();
     }
 
-    for (var s in socketsToDelete) {
-
-        log.info('message: deleteUser, user: ' + io.sockets.sockets[socketsToDelete[s]].user.name);
-        io.sockets.sockets[socketsToDelete[s]].disconnect();
-    }
-
-    if (socketsToDelete.length !== 0) {
+    if (clientsToDelete.length !== 0) {
         callback('Success');
-        return;
-    }
-    else {
+    } else {
         log.error('mesagge: deleteUser user does not exist, user: ' + user );
         callback('User does not exist');
-        return;
     }
-
-
 };
 
 
 /*
  * Delete a room.
  */
-exports.deleteRoom = function (room, callback) {
-    var sockets, streams, id, j;
+exports.deleteRoom = function (roomId, callback) {
+    log.info('message: deleteRoom, roomId: ' + roomId);
 
-    log.info('message: deleteRoom, roomId: ' + room);
+    let room = rooms.getRoomById(roomId);
 
-    if (rooms[room] === undefined) {
-        callback('Success');
-        return;
+    if (room === undefined) {
+       callback('Success');
+       return;
     }
-    sockets = rooms[room].sockets;
 
-    for (id in sockets) {
-        if (sockets.hasOwnProperty(id)) {
-            rooms[room].controller.removeSubscriptions(sockets[id]);
+    room.forEachClient((client) => {
+      room.controller.removeSubscriptions(client.id);
+    });
+
+    if (!room.p2p) {
+      room.forEachStream((stream) => {
+        if (stream.hasAudio() || stream.hasVideo() || stream.hasScreen()) {
+          room.controller.removePublisher(stream.getID());
         }
+      });
     }
 
-    streams = rooms[room].streams;
+    rooms.deleteRoom(roomId);
 
-    for (j in streams) {
-        if (streams[j].hasAudio() || streams[j].hasVideo() || streams[j].hasScreen()) {
-            if (!room.p2p) {
-                rooms[room].controller.removePublisher(j);
-            }
-        }
-    }
-
-    delete rooms[room];
     updateMyState();
     callback('Success');
 };
+
 amqper.connect(function () {
-    try {
-        amqper.setPublicRPC(rpcPublic);
+  try {
+    rooms.on('updated', updateMyState);
+    amqper.setPublicRPC(rpcPublic);
 
-        addToCloudHandler(function () {
-            var rpcID = 'erizoController_' + myId;
-
-            amqper.bind(rpcID, listen);
-
-        });
-    } catch (error) {
-        log.info('message: Error in Erizo Controller, ' + logger.objectToLog(error));
-    }
+    addToCloudHandler(function () {
+      var rpcID = 'erizoController_' + myId;
+      amqper.bind(rpcID, listen);
+    });
+  } catch (error) {
+    log.info('message: Error in Erizo Controller, ' + logger.objectToLog(error));
+  }
 });

--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -317,7 +317,6 @@ var listen = function () {
         channel.on('reconnected', clientId => {
           rooms.forEachRoom(room => {
             const client = room.getClientById(clientId);
-            console.log('Client found');
             if (client !== undefined) {
               client.setNewChannel(channel);
             }

--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -304,6 +304,7 @@ var listen = function () {
 
             callback('success', {streams: streamList,
                                  id: room.id,
+                                 clientId: client.id,
                                  p2p: room.p2p,
                                  defaultVideoBW: global.config.erizoController.defaultVideoBW,
                                  maxVideoBW: global.config.erizoController.maxVideoBW,
@@ -313,16 +314,16 @@ var listen = function () {
           }
         });
 
-        channel.on('reconnected', (clientId, token) => {
-          let room = rooms.getRoom(token.room);
-          if (room === undefined) {
-            channel.disconnect();
-          }
-          let client = room.getClientById(clientId);
-          if (client !== undefined) {
-            client.setNewChannel(channel);
-          }
+        channel.on('reconnected', clientId => {
+          rooms.forEachRoom(room => {
+            const client = room.getClientById(clientId);
+            console.log('Client found');
+            if (client !== undefined) {
+              client.setNewChannel(channel);
+            }
+          });
         });
+
         socket.channel = channel;
     });
 };

--- a/erizo_controller/erizoController/models/Channel.js
+++ b/erizo_controller/erizoController/models/Channel.js
@@ -141,7 +141,8 @@ class Channel extends events.EventEmitter {
     if (this.state !== CONNECTED) {
       return;
     }
-    log.debug('message: sending buffered messages, number:', buffer.length, ', channelId:', this.id);
+    log.debug('message: sending buffered messages, number:', buffer.length,
+              ', channelId:', this.id);
     buffer.forEach((message) => {
       log.debug('message: sending buffered message, message:', message, ', channelId:', this.id);
       this.sendMessage(...message);

--- a/erizo_controller/erizoController/models/Channel.js
+++ b/erizo_controller/erizoController/models/Channel.js
@@ -2,9 +2,12 @@
 const events = require('events');
 const logger = require('./../../common/logger').logger;
 const crypto = require('crypto');
+const uuidv4 = require('uuid/v4');
 const log = logger.getLogger('ErizoController - Channel');
 
 const NUVE_KEY = global.config.nuve.superserviceKey;
+
+const RECONNECTION_TIMEOUT = 10000;
 
 const calculateSignature = (token, key) => {
     var toSign = token.tokenId + ',' + token.host,
@@ -29,11 +32,31 @@ function listenToSocketHandshakeEvents(channel) {
   channel.socket.on('disconnect', channel.onDisconnect.bind(channel));
 }
 
+const CONNECTED = Symbol('connected');
+const RECONNECTING = Symbol('reconnecting');
+const DISCONNECTED = Symbol('disconnected');
+
+const WEBSOCKET_NORMAL_CLOSURE = 1000;
+const WEBSOCKET_GOING_AWAY_CLOSURE = 1001;
+
 class Channel extends events.EventEmitter {
   constructor(socket, nuve) {
     super();
     this.socket = socket;
     this.nuve = nuve;
+    this.state = DISCONNECTED;
+    this.messageBuffer = [];
+    this.id = uuidv4();
+
+    // Hack to know the exact reason of the WS closure (socket.io does not publish it)
+    this.closeCode = WEBSOCKET_NORMAL_CLOSURE;
+    let onCloseFunction = this.socket.conn.transport.socket.internalOnClose;
+    this.socket.conn.transport.socket.internalOnClose = (code, reason) => {
+      this.closeCode = code;
+      if (onCloseFunction) {
+        onCloseFunction(code, reason);
+      }
+    };
     listenToSocketHandshakeEvents(this);
   }
 
@@ -42,6 +65,7 @@ class Channel extends events.EventEmitter {
     if (checkSignature(token, NUVE_KEY)) {
       this.nuve.deleteToken(token.tokenId).then(tokenDB => {
         if (token.host === tokenDB.host) {
+          this.state = CONNECTED;
           this.emit('connected', tokenDB, callback);
         } else {
           log.warn('message: Token has invalid host, clientId: ' + this.id);
@@ -70,9 +94,19 @@ class Channel extends events.EventEmitter {
     }
   }
 
-  onDisconnect(reason) {
-    log.debug('message: socket disconnected, reason:', reason);
+  onDisconnect() {
+    log.debug('message: socket disconnected, code:', this.closeCode);
+    this.state = RECONNECTING;
+    if (this.closeCode !== WEBSOCKET_NORMAL_CLOSURE &&
+        this.closeCode !== WEBSOCKET_GOING_AWAY_CLOSURE) {
+      this.disconnecting = setTimeout(() => {
+        this.emit('disconnect');
+        this.state = DISCONNECTED;
+      }, RECONNECTION_TIMEOUT);
+      return;
+    }
     this.emit('disconnect');
+    this.state = DISCONNECTED;
   }
 
   socketOn(eventName, listener) {
@@ -80,14 +114,43 @@ class Channel extends events.EventEmitter {
   }
 
   onReconnected(clientId) {
+    this.state = CONNECTED;
     this.emit('reconnected',  clientId);
   }
 
   sendMessage(type, arg) {
+    if (this.state === DISCONNECTED) {
+      return;
+    }
+    if (this.state === RECONNECTING) {
+      this.addToBuffer(type, arg);
+      return;
+    }
     this.socket.emit(type, arg);
   }
 
+  addToBuffer(type, arg) {
+    this.messageBuffer.push([type, arg]);
+  }
+
+  getBuffer() {
+    return this.messageBuffer;
+  }
+
+  sendBuffer(buffer) {
+    if (this.state !== CONNECTED) {
+      return;
+    }
+    log.debug('message: sending buffered messages, number:', buffer.length, ', channelId:', this.id);
+    buffer.forEach((message) => {
+      log.debug('message: sending buffered message, message:', message, ', channelId:', this.id);
+      this.sendMessage(...message);
+    });
+  }
+
   disconnect() {
+    this.state = DISCONNECTED;
+    clearTimeout(this.disconnecting);
     this.socket.disconnect();
   }
 

--- a/erizo_controller/erizoController/models/Channel.js
+++ b/erizo_controller/erizoController/models/Channel.js
@@ -96,17 +96,17 @@ class Channel extends events.EventEmitter {
 
   onDisconnect() {
     log.debug('message: socket disconnected, code:', this.closeCode);
-    this.state = RECONNECTING;
     if (this.closeCode !== WEBSOCKET_NORMAL_CLOSURE &&
         this.closeCode !== WEBSOCKET_GOING_AWAY_CLOSURE) {
+      this.state = RECONNECTING;
       this.disconnecting = setTimeout(() => {
         this.emit('disconnect');
         this.state = DISCONNECTED;
       }, RECONNECTION_TIMEOUT);
       return;
     }
-    this.emit('disconnect');
     this.state = DISCONNECTED;
+    this.emit('disconnect');
   }
 
   socketOn(eventName, listener) {
@@ -119,9 +119,6 @@ class Channel extends events.EventEmitter {
   }
 
   sendMessage(type, arg) {
-    if (this.state === DISCONNECTED) {
-      return;
-    }
     if (this.state === RECONNECTING) {
       this.addToBuffer(type, arg);
       return;

--- a/erizo_controller/erizoController/models/Channel.js
+++ b/erizo_controller/erizoController/models/Channel.js
@@ -71,7 +71,7 @@ class Channel extends events.EventEmitter {
   }
 
   onDisconnect(reason) {
-    log.debug('message: channel disconnected, reason:', reason);
+    log.debug('message: socket disconnected, reason:', reason);
     this.emit('disconnect');
   }
 
@@ -79,8 +79,8 @@ class Channel extends events.EventEmitter {
     this.socket.on(eventName, listener);
   }
 
-  onReconnected(clientId, token) {
-    this.emit('reconnected', clientId, token);
+  onReconnected(clientId) {
+    this.emit('reconnected',  clientId);
   }
 
   sendMessage(type, arg) {

--- a/erizo_controller/erizoController/models/Channel.js
+++ b/erizo_controller/erizoController/models/Channel.js
@@ -1,0 +1,96 @@
+'use strict';
+const events = require('events');
+const logger = require('./../../common/logger').logger;
+const crypto = require('crypto');
+const log = logger.getLogger('ErizoController - Channel');
+
+const NUVE_KEY = global.config.nuve.superserviceKey;
+
+const calculateSignature = (token, key) => {
+    var toSign = token.tokenId + ',' + token.host,
+        signed = crypto.createHmac('sha1', key).update(toSign).digest('hex');
+    return (new Buffer(signed)).toString('base64');
+};
+
+const checkSignature = (token, key) => {
+    var calculatedSignature = calculateSignature(token, key);
+
+    if (calculatedSignature !== token.signature) {
+        log.info('message: invalid token signature');
+        return false;
+    } else {
+        return true;
+    }
+};
+
+function listenToSocketHandshakeEvents(channel) {
+  channel.socket.on('token', channel.onToken.bind(channel));
+  channel.socket.on('reconnected', channel.onReconnected.bind(channel));
+  channel.socket.on('disconnect', channel.onDisconnect.bind(channel));
+}
+
+class Channel extends events.EventEmitter {
+  constructor(socket, nuve) {
+    super();
+    this.socket = socket;
+    this.nuve = nuve;
+    listenToSocketHandshakeEvents(this);
+  }
+
+  onToken(token, callback) {
+    log.debug('message: token received');
+    if (checkSignature(token, NUVE_KEY)) {
+      this.nuve.deleteToken(token.tokenId).then(tokenDB => {
+        if (token.host === tokenDB.host) {
+          this.emit('connected', tokenDB, callback);
+        } else {
+          log.warn('message: Token has invalid host, clientId: ' + this.id);
+          callback('error', 'Invalid host');
+          this.disconnect();
+        }
+      }).catch((reason) => {
+        if (reason === 'error') {
+            log.warn('message: Trying to use token that does not exist - ' +
+                     'disconnecting Client, clientId: ' + this.id);
+            callback('error', 'Token does not exist');
+            this.disconnect();
+
+        } else if (reason === 'timeout') {
+            log.warn('message: Nuve does not respond token check - ' +
+                     'disconnecting client, clientId: ' + this.id);
+            callback('error', 'Nuve does not respond');
+            this.disconnect();
+
+        }
+      });
+    } else {
+        log.warn('message: Token authentication error, clientId: ' + this.id);
+        callback('error', 'Authentication error');
+        this.disconnect();
+    }
+  }
+
+  onDisconnect(reason) {
+    log.debug('message: channel disconnected, reason:', reason);
+    this.emit('disconnect');
+  }
+
+  socketOn(eventName, listener) {
+    this.socket.on(eventName, listener);
+  }
+
+  onReconnected(clientId, token) {
+    this.emit('reconnected', clientId, token);
+  }
+
+  sendMessage(type, arg) {
+    this.socket.emit(type, arg);
+  }
+
+  disconnect() {
+    this.socket.disconnect();
+  }
+
+}
+
+exports.Channel = Channel;

--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -44,8 +44,14 @@ class Client extends events.EventEmitter {
   }
 
   setNewChannel(channel) {
+    const oldChannel = this.channel;
+    const buffer = oldChannel.getBuffer();
+    log.info('message: reconnected, oldChannelId:', oldChannel.id, ', channelId:', channel.id);
+    oldChannel.removeAllListeners();
+    oldChannel.disconnect();
     this.channel = channel;
-    this._listenToSocketEvents();
+    listenToSocketEvents(this);
+    this.channel.sendBuffer(buffer);
   }
 
   sendMessage(type, arg) {
@@ -480,7 +486,7 @@ class Client extends events.EventEmitter {
   onDisconnect() {
     let timeStamp = new Date();
 
-    log.info('message: Socket disconnect, clientId: ' + this.id);
+    log.info('message: Channel disconnect, clientId: ' + this.id, ', channelId:', this.channel.id);
 
     for (let streamId of this.streams) {
       this.room.sendMessage('onRemoveStream', {id: streamId});

--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -1,0 +1,552 @@
+'use strict';
+const events = require('events');
+const uuidv4 = require('uuid/v4');
+const Permission = require('../permission');
+const ST = require('./Stream');
+const logger = require('./../../common/logger').logger;
+const log = logger.getLogger('ErizoController - Client');
+
+const PUBLISHER_INITAL = 101, PUBLISHER_READY = 104;
+
+function listenToSocketEvents(client) {
+  client.channel.socketOn('sendDataStream', client.onSendDataStream.bind(client));
+  client.channel.socketOn('signaling_message', client.onSignalingMessage.bind(client));
+  client.channel.socketOn('updateStreamAttributes', client.onUpdateStreamAttributes.bind(client));
+  client.channel.socketOn('publish', client.onPublish.bind(client));
+  client.channel.socketOn('subscribe', client.onSubscribe.bind(client));
+  client.channel.socketOn('startRecorder', client.onStartRecorder.bind(client));
+  client.channel.socketOn('stopRecorder', client.onStopRecorder.bind(client));
+  client.channel.socketOn('unpublish', client.onUnpublish.bind(client));
+  client.channel.socketOn('unsubscribe', client.onUnsubscribe.bind(client));
+  client.channel.socketOn('getStreamStats', client.onGetStreamStats.bind(client));
+  client.channel.on('disconnect', client.onDisconnect.bind(client));
+}
+
+class Client extends events.EventEmitter {
+  constructor(channel, token, room) {
+    super();
+    this.channel = channel;
+    this.room = room;
+    this.token = token;
+    this.id = uuidv4();
+    listenToSocketEvents(this);
+    this.user = {name: token.userName, role: token.role, permissions: {}};
+    const permissions = global.config.erizoController.roles[token.role] || [];
+    for (const right in permissions) {
+        this.user.permissions[right] = permissions[right];
+    }
+    this.streams = []; //[list of streamIds]
+    this.state = 'sleeping'; // ?
+  }
+
+  disconnect() {
+    this.channel.disconnect();
+  }
+
+  setNewChannel(channel) {
+    this.channel = channel;
+    this._listenToSocketEvents();
+  }
+
+  sendMessage(type, arg) {
+    this.channel.sendMessage(type, arg);
+  }
+
+  hasPermission(action) {
+    return this.user && this.user.permissions[action] === true;
+  }
+
+  onSendDataStream(message) {
+    const stream = this.room.getStreamById(message.id);
+    if  (stream === undefined){
+      log.warn('message: Trying to send Data from a non-initialized stream, ' +
+               'clientId: ' + this.id + ', ' +
+               logger.objectToLog(message));
+      return;
+    }
+    const clients = stream.getDataSubscribers();
+
+    for (const index in clients) {
+      const clientId = clients[index];
+      const client = this.room.getClientById(clientId);
+      if (client) {
+        log.debug('message: sending dataStream, ' +
+          'clientId: ' + clientId + ', dataStream: ' + message.id);
+        this.room.getClientById(clientId).sendMessage('onDataStream', message);
+      }
+    }
+  }
+
+  onSignalingMessage(message) {
+    if (this.room === undefined) {
+      log.error('message: singaling_message for user in undefined room ' +
+        message.streamId + ', user: ' + this.user);
+      this.disconnect();
+    }
+    if (this.room.p2p) {
+      const targetClient = this.room.getClientById(message.peerSocket);
+      targetClient.sendMessage('signaling_message_peer',
+                {streamId: message.streamId, peerSocket: targetClient.id, msg: message.msg});
+    } else {
+        const isControlMessage = message.msg.type === 'control';
+        if (!isControlMessage ||
+            (isControlMessage && this.hasPermission(message.msg.action.name))) {
+          this.room.controller.processSignaling(message.streamId, this.id, message.msg);
+        } else {
+          log.info('message: User unauthorized to execute action on stream, action: ' +
+            message.msg.action.name + ', streamId: ' + message.streamId);
+        }
+    }
+  }
+
+  onUpdateStreamAttributes(message) {
+    const stream = this.room.getStreamById(message.id);
+    if  (stream === undefined){
+      log.warn('message: Update attributes to a uninitialized stream, ' +
+               logger.objectToLog(message));
+      return;
+    }
+    const clients = stream.getDataSubscribers();
+    stream.setAttributes(message.attrs);
+
+    for (const index in clients) {
+      const clientId = clients[index];
+      const client = this.room.getClientById(clientId);
+      if (client) {
+            log.debug('message: Sending new attributes, ' +
+                      'clientId: ' + clientId + ', streamId: ' + message.id);
+            client.sendMessage('onUpdateAttributeStream', message);
+        }
+    }
+  }
+
+  onPublish(options, sdp, callback) {
+    if (this.user === undefined || !this.user.permissions[Permission.PUBLISH]) {
+        callback(null, 'Unauthorized');
+        return;
+    }
+    if (this.user.permissions[Permission.PUBLISH] !== true) {
+        const permissions = this.user.permissions[Permission.PUBLISH];
+        for (const right in permissions) {
+            if ((options[right] === true) && (permissions[right] === false)) {
+              callback(null, 'Unauthorized');
+              return;
+            }
+        }
+    }
+
+    // generate a 18 digits safe integer
+    const id = Math.floor(100000000000000000 + Math.random() * 900000000000000000);
+
+    if (options.state === 'url' || options.state === 'recording') {
+        let url = sdp;
+        if (options.state === 'recording') {
+            const recordingId = sdp;
+            if (global.config.erizoController.recording_path) {  // jshint ignore:line
+                url = global.config.erizoController.recording_path + recordingId + '.mkv'; // jshint ignore:line
+            } else {
+                url = '/tmp/' + recordingId + '.mkv';
+            }
+        }
+        this.room.controller.addExternalInput(id, url, (result) => {
+            if (result === 'success') {
+                let st = new ST.Stream({id: id,
+                                    client: this.id,
+                                    audio: options.audio,
+                                    video: options.video,
+                                    data: options.data,
+                                    attributes: options.attributes});
+                st.status = PUBLISHER_READY;
+                this.streams.push(id);
+                this.room.streams.set(id, st);
+                callback(id);
+                this.room.sendMessage('onAddStream', st.getPublicStream());
+            } else {
+                callback(null, 'Error adding External Input:' + result);
+            }
+        });
+    } else if (options.state === 'erizo') {
+        let st;
+        log.info('message: addPublisher requested, ' +
+                 'streamId: ' + id + ', clientId: ' + this.id + ', ' +
+                 logger.objectToLog(options) + ', ' +
+                 logger.objectToLog(options.attributes));
+        this.room.controller.addPublisher(id, options, (signMess) => {
+            if (signMess.type === 'initializing') {
+                callback(id);
+                st = new ST.Stream({id: id,
+                                    client: this.id,
+                                    audio: options.audio,
+                                    video: options.video,
+                                    data: options.data,
+                                    screen: options.screen,
+                                    attributes: options.attributes});
+                this.streams.push(id);
+                this.room.streams.set(id, st);
+                st.status = PUBLISHER_INITAL;
+                log.info('message: addPublisher, ' +
+                         'state: PUBLISHER_INITIAL, ' +
+                         'clientId: ' + this.id + ', ' +
+                         'streamId: ' + id);
+
+                if (global.config.erizoController.report.session_events) {  // jshint ignore:line
+                    var timeStamp = new Date();
+                    this.room.amqper.broadcast('event', {room: this.room.id,
+                                               user: this.id,
+                                               name: this.user.name,
+                                               type: 'publish',
+                                               stream: id,
+                                               timestamp: timeStamp.getTime(),
+                                               agent: signMess.agentId,
+                                               attributes: options.attributes});
+                }
+            } else if (signMess.type === 'failed'){
+                log.warn('message: addPublisher ICE Failed, ' +
+                         'state: PUBLISHER_FAILED, ' +
+                         'streamId: ' + id + ', ' +
+                         'clientId: ' + this.id);
+                this.sendMessage('connection_failed',{type:'publish', streamId: id});
+                //We're going to let the client disconnect
+                return;
+            } else if (signMess.type === 'ready') {
+                st.status = PUBLISHER_READY;
+                this.room.sendMessage('onAddStream', st.getPublicStream());
+                log.info('message: addPublisher, ' +
+                         'state: PUBLISHER_READY, ' +
+                         'streamId: ' + id + ', ' +
+                         'clientId: ' + this.id);
+            } else if (signMess === 'timeout-erizojs') {
+                log.error('message: addPublisher timeout when contacting ErizoJS, ' +
+                          'streamId: ' + id + ', clientId: ' + this.id);
+                callback(null, 'ErizoJS is not reachable');
+                return;
+            } else if (signMess === 'timeout-agent'){
+                log.error('message: addPublisher timeout when contacting Agent, ' +
+                          'streamId: ' + id + ', clientId: ' + this.id);
+                callback(null, 'ErizoAgent is not reachable');
+                return;
+            } else if (signMess === 'timeout'){
+                log.error('message: addPublisher Undefined RPC Timeout, ' +
+                          'streamId: ' + id + ', clientId: ' + this.id);
+                callback(null, 'ErizoAgent or ErizoJS is not reachable');
+                return;
+            }
+            log.debug('Sending message back to the client', signMess);
+            this.sendMessage('signaling_message_erizo', {mess: signMess, streamId: id});
+        });
+    } else {
+        let st = new ST.Stream({id: id,
+                            client: this.id,
+                            audio: options.audio,
+                            video: options.video,
+                            data: options.data,
+                            screen: options.screen,
+                            attributes: options.attributes});
+        this.streams.push(id);
+        this.room.streams.set(id, st);
+        st.status = PUBLISHER_READY;
+        callback(id);
+        this.room.sendMessage('onAddStream', st.getPublicStream());
+    }
+  }
+
+  onSubscribe(options, sdp, callback) {
+    log.info('Subscribing', options, this.user);
+    if (this.user === undefined || !this.user.permissions[Permission.SUBSCRIBE]) {
+        callback(null, 'Unauthorized');
+        return;
+    }
+
+    if (this.user.permissions[Permission.SUBSCRIBE] !== true) {
+        var permissions = this.user.permissions[Permission.SUBSCRIBE];
+        for (var right in permissions) {
+            if ((options[right] === true) && (permissions[right] === false))
+                return callback(null, 'Unauthorized');
+        }
+    }
+
+    var stream = this.room.getStreamById(options.streamId);
+    if (stream === undefined) {
+        return;
+    }
+
+    if (stream.hasData() && options.data !== false) {
+        stream.addDataSubscriber(this.id);
+    }
+
+    if (stream.hasAudio() || stream.hasVideo() || stream.hasScreen()) {
+        if (this.room.p2p) {
+            const clientId = stream.getClient();
+            const client = this.room.getClientById(clientId);
+            client.sendMessage('publish_me', {streamId: options.streamId, peerSocket: this.id});
+        } else {
+            log.info('message: addSubscriber requested, ' +
+                     'streamId: ' + options.streamId + ', ' +
+                     'clientId: ' + this.id);
+            this.room.controller.addSubscriber(this.id, options.streamId, options, (signMess) => {
+                if (signMess.type === 'initializing') {
+                    log.info('message: addSubscriber, ' +
+                             'state: SUBSCRIBER_INITIAL, ' +
+                             'clientId: ' + this.id + ', ' +
+                             'streamId: ' + options.streamId);
+                    callback(true);
+                    if (global.config.erizoController.report.session_events) {  // jshint ignore:line
+                        var timeStamp = new Date();
+                        this.room.amqper.broadcast('event', {room: this.room.id,
+                                                   user: this.id,
+                                                   name: this.user.name,
+                                                   type: 'subscribe',
+                                                   stream: options.streamId,
+                                                   timestamp: timeStamp.getTime()});
+                    }
+                    return;
+                } else if (signMess.type === 'failed'){
+                    //TODO: Add Stats event
+                    log.warn('message: addSubscriber ICE Failed, ' +
+                             'state: SUBSCRIBER_FAILED, ' +
+                             'streamId: ' + options.streamId + ', ' +
+                             'clientId: ' + this.id);
+                    this.sendMessage('connection_failed', {type: 'subscribe',
+                                                      streamId: options.streamId});
+                    return;
+                } else if (signMess.type === 'ready') {
+                    log.info('message: addSubscriber, ' +
+                             'state: SUBSCRIBER_READY, ' +
+                             'streamId: ' + options.streamId + ', ' +
+                             'clientId: ' + this.id);
+
+                } else if (signMess.type === 'bandwidthAlert') {
+                    this.sendMessage('onBandwidthAlert', {streamID: options.streamId,
+                                                   message: signMess.message,
+                                                   bandwidth: signMess.bandwidth});
+                } else if (signMess === 'timeout') {
+                    log.error('message: addSubscriber timeout when contacting ErizoJS, ' +
+                              'streamId: ', options.streamId, ', ' +
+                              'clientId: ' + this.id);
+                    callback(null, 'ErizoJS is not reachable');
+                    return;
+                }
+
+                this.sendMessage('signaling_message_erizo', {mess: signMess,
+                                                             peerId: options.streamId});
+            });
+        }
+    } else {
+        callback(true);
+    }
+  }
+
+  onStartRecorder(options, callback) {
+    if (this.user === undefined || !this.user.permissions[Permission.RECORD]) {
+        callback(null, 'Unauthorized');
+        return;
+    }
+    var streamId = options.to;
+    var recordingId = Math.random() * 1000000000000000000;
+    var url;
+
+    if (global.config.erizoController.recording_path) {  // jshint ignore:line
+        url = global.config.erizoController.recording_path + recordingId + '.mkv';  // jshint ignore:line
+    } else {
+        url = '/tmp/' + recordingId + '.mkv';
+    }
+
+    log.info('message: startRecorder, ' +
+             'state: RECORD_REQUESTED, ' +
+             'streamId: ' + streamId + ', ' +
+             'url: ' + url);
+
+    if (this.room.p2p) {
+       callback(null, 'Stream can not be recorded');
+    }
+
+    let stream = this.room.getStreamById(streamId);
+
+    if (stream.hasAudio() || stream.hasVideo() || stream.hasScreen()) {
+        this.room.controller.addExternalOutput(streamId, url, function (result) {
+            if (result === 'success') {
+                log.info('message: startRecorder, ' +
+                         'state: RECORD_STARTED, ' +
+                         'streamId: ' + streamId + ', ' +
+                         'url: ' + url);
+                callback(recordingId);
+            } else {
+                log.warn('message: startRecorder stream not found, ' +
+                         'state: RECORD_FAILED, ' +
+                         'streamId: ' + streamId + ', ' +
+                         'url: ' + url);
+                callback(null, 'Unable to subscribe to stream for recording, ' +
+                               'publisher not present');
+            }
+        });
+
+    } else {
+        log.warn('message: startRecorder stream cannot be recorded, ' +
+                 'state: RECORD_FAILED, ' +
+                 'streamId: ' + streamId + ', ' +
+                 'url: ' + url);
+        callback(null, 'Stream can not be recorded');
+    }
+  }
+
+  onStopRecorder(options, callback) {
+    if (this.user === undefined || !this.user.permissions[Permission.RECORD]) {
+        if (callback) callback(null, 'Unauthorized');
+        return;
+    }
+    var recordingId = options.id;
+    var url;
+
+    if (global.config.erizoController.recording_path) {  // jshint ignore:line
+        url = global.config.erizoController.recording_path + recordingId + '.mkv';  // jshint ignore:line
+    } else {
+        url = '/tmp/' + recordingId + '.mkv';
+    }
+
+    log.info('message: startRecorder, ' +
+             'state: RECORD_STOPPED, ' +
+             'streamId: ' + options.id + ', ' +
+             'url: ' + url);
+    this.room.controller.removeExternalOutput(url, callback);
+  }
+
+  onUnpublish(streamId, callback) {
+    if (this.user === undefined || !this.user.permissions[Permission.PUBLISH]) {
+        if (callback) callback(null, 'Unauthorized');
+        return;
+    }
+
+    // Stream has been already deleted or it does not exist
+    let stream = this.room.getStreamById(streamId);
+    if (stream === undefined) {
+        return;
+    }
+
+    this.room.sendMessage('onRemoveStream', {id: streamId});
+
+    if (stream.hasAudio() || stream.hasVideo() || stream.hasScreen()) {
+
+        this.state = 'sleeping';
+        if (!this.room.p2p) {
+            this.room.controller.removePublisher(streamId);
+            if (global.config.erizoController.report.session_events) {  // jshint ignore:line
+                var timeStamp = new Date();
+                this.room.amqper.broadcast('event', {room: this.room.id,
+                                           user: this.id,
+                                           type: 'unpublish',
+                                           stream: streamId,
+                                           timestamp: timeStamp.getTime()});
+            }
+        }
+    }
+
+    let index = this.streams.indexOf(streamId);
+    if (index !== -1) {
+        this.streams.splice(index, 1);
+    }
+    this.room.removeStream(streamId);
+    callback(true);
+  }
+
+  onUnsubscribe(to, callback) {
+    if (this.user === undefined || !this.user.permissions[Permission.SUBSCRIBE]) {
+        if (callback) callback(null, 'Unauthorized');
+        return;
+    }
+
+    let stream = this.room.getStreamById(to);
+    if (stream === undefined) {
+        return;
+    }
+
+    stream.removeDataSubscriber(this.id);
+
+    if (stream.hasAudio() || stream.hasVideo() || stream.hasScreen()) {
+        if (!this.room.p2p) {
+            this.room.controller.removeSubscriber(this.id, to);
+            if (global.config.erizoController.report.session_events) {  // jshint ignore:line
+                var timeStamp = new Date();
+                this.room.amqper.broadcast('event', {room: this.room.id,
+                                           user: this.id,
+                                           type: 'unsubscribe',
+                                           stream: to,
+                                           timestamp: timeStamp.getTime()});
+            }
+        }
+    }
+    callback(true);
+  }
+
+  onDisconnect() {
+    let timeStamp = new Date();
+
+    log.info('message: Socket disconnect, clientId: ' + this.id);
+
+    for (let streamId of this.streams) {
+      this.room.sendMessage('onRemoveStream', {id: streamId});
+    }
+
+    if (this.room !== undefined) {
+      this.room.forEachStream((stream) => {
+        stream.removeDataSubscriber(this.id);
+      });
+
+      this.room.removeClient(this.id);
+
+      if (this.room.controller) {
+          this.room.controller.removeSubscriptions(this.id);
+      }
+
+      for (let streamId of this.streams) {
+        let stream = this.room.getStreamById(streamId);
+        if (stream !== undefined) {
+          if (stream.hasAudio() || stream.hasVideo() || stream.hasScreen()) {
+            if (!this.room.p2p) {
+              log.info('message: Unpublishing stream, streamId:', streamId);
+              this.room.controller.removePublisher(streamId);
+              if (global.config.erizoController.report.session_events) {  // jshint ignore:line
+
+                this.room.amqper.broadcast('event', {room: this.room.id,
+                                           user: this.id,
+                                           type: 'unpublish',
+                                           stream: streamId,
+                                           timestamp: timeStamp.getTime()});
+              }
+            }
+          }
+          this.room.removeStream(streamId);
+        }
+      }
+      if (!this.room.p2p &&
+          global.config.erizoController.report.session_events) {  // jshint ignore:line
+          this.room.amqper.broadcast('event', {room: this.room.id,
+                                    user: this.id,
+                                    type: 'user_disconnection',
+                                    timestamp: timeStamp.getTime()});
+      }
+
+      this.emit('disconnect');
+    }
+  }
+
+  onGetStreamStats(streamId, callback) {
+    log.debug('message: getting stats, streamId: ' + streamId);
+    if (this.user === undefined || !this.user.permissions[Permission.STATS]) {
+        log.info('message: unauthorized getStreamStats request');
+        if (callback) callback(null, 'Unauthorized');
+        return;
+    }
+    if (this.room.getStreamById(streamId) === undefined) {
+        log.info('message: bad getStreamStats request');
+        return;
+    }
+    if (this.room !== undefined && !this.room.p2p) {
+        this.room.controller.getStreamStats(streamId, function (result) {
+            callback(result);
+        });
+    }
+  }
+
+}
+
+exports.Client = Client;

--- a/erizo_controller/erizoController/models/Room.js
+++ b/erizo_controller/erizoController/models/Room.js
@@ -113,6 +113,12 @@ class Rooms extends events.EventEmitter {
     return room;
   }
 
+  forEachRoom(doSomething) {
+    for (const room of this.rooms.values()) {
+      doSomething(room);
+    }
+  }
+
   getRoomById(id) {
     return this.rooms.get(id);
   }

--- a/erizo_controller/erizoController/models/Room.js
+++ b/erizo_controller/erizoController/models/Room.js
@@ -1,0 +1,128 @@
+'use strict';
+const events = require('events');
+const controller = require('../roomController');
+const Client = require('./Client').Client;
+const logger = require('./../../common/logger').logger;
+const log = logger.getLogger('ErizoController - Room');
+
+class Room extends events.EventEmitter {
+  constructor(amqper, ecch, id, p2p) {
+    super();
+    this.streams = new Map();
+    this.clients = new Map();
+    this.id = id;
+    this.p2p = p2p;
+    this.amqper = amqper;
+    this.ecch = ecch;
+    if (!p2p) {
+      this.setupRoomController();
+    }
+  }
+
+  getStreamById(id) {
+    return this.streams.get(id);
+  }
+
+  forEachStream(doSomething) {
+    for (let stream of this.streams.values()) {
+      doSomething(stream);
+    }
+  }
+
+  removeStream(id) {
+    return this.streams.delete(id);
+  }
+
+  getClientById(id) {
+    return this.clients.get(id);
+  }
+
+  createClient(channel, token) {
+    let client = new Client(channel, token, this);
+    client.on('disconnect', this.onClientDisconnected.bind(this, client));
+    this.clients.set(client.id, client);
+    return client;
+  }
+
+  forEachClient(doSomething) {
+    for (let client of this.clients.values()) {
+      doSomething(client);
+    }
+  }
+
+  removeClient(id) {
+    return this.clients.delete(id);
+  }
+
+  onClientDisconnected() {
+    if (this.clients.size === 0) {
+      log.debug('message: deleting empty room, roomId: ' + this.id);
+      this.emit('room-empty');
+    }
+  }
+
+  setupRoomController() {
+    this.controller = controller.RoomController({amqper: this.amqper, ecch: this.ecch});
+    this.controller.addEventListener(this.onRoomControllerEvent.bind(this));
+  }
+
+  onRoomControllerEvent(type, evt ) {
+    if (type === 'unpublish') {
+        // It's supposed to be an integer.
+        var streamId = parseInt(evt);
+        log.warn('message: Triggering removal of stream ' +
+                 'because of ErizoJS timeout, ' +
+                 'streamId: ' + streamId);
+        this.sendMessage('onRemoveStream', {id: streamId});
+        // remove clients and streams?
+    }
+  }
+
+  sendMessage(method, args) {
+    var clients = this.clients;
+    for (let client of clients.values()) {
+      log.debug('message: sendMsgToRoom,',
+                'clientId:', client.id, ',',
+                'roomId:', this.id, ', ',
+                logger.objectToLog(method));
+      client.sendMessage(method, args);
+    }
+  }
+}
+
+class Rooms extends events.EventEmitter {
+  constructor(amqper, ecch) {
+    super();
+    this.amqper = amqper;
+    this.ecch = ecch;
+    this.rooms = new Map();
+  }
+
+  size() {
+    return this.rooms.size;
+  }
+
+  getOrCreateRoom(id, p2p) {
+    let room = this.rooms.get(id);
+    if (room === undefined) {
+      room = new Room(this.amqper, this.ecch, id, p2p);
+      this.rooms.set(room.id, room);
+      room.on('room-empty', this.deleteRoom.bind(this, id));
+      this.emit('updated');
+    }
+    return room;
+  }
+
+  getRoomById(id) {
+    return this.rooms.get(id);
+  }
+
+  deleteRoom(id) {
+    if (this.rooms.delete(id)) {
+      this.emit('updated');
+    }
+  }
+}
+
+exports.Room = Room;
+exports.Rooms = Rooms;

--- a/erizo_controller/erizoController/models/Stream.js
+++ b/erizo_controller/erizoController/models/Stream.js
@@ -8,8 +8,8 @@ exports.Stream = function (spec) {
         return spec.id;
     };
 
-    that.getSocket = function () {
-        return spec.socket;
+    that.getClient = function () {
+        return spec.client;
     };
 
     // Indicates if the stream has audio activated

--- a/erizo_controller/erizoController/nuveProxy.js
+++ b/erizo_controller/erizoController/nuveProxy.js
@@ -1,0 +1,33 @@
+/*global require, exports*/
+'use strict';
+var logger = require('./../common/logger').logger;
+
+// Logger
+var log = logger.getLogger('NuveProxy');
+
+exports.NuveProxy = function (spec) {
+  var that = {};
+
+  var callNuve = (method, additionalErrors, args) => new Promise((resolve, reject) => {
+    try {
+      spec.amqper.callRpc('nuve', method, args, {callback: function (response) {
+        const errors = ['timeout', 'error'].concat(additionalErrors);
+        if (errors.indexOf(response) !== -1) {
+          reject(response);
+          return;
+        }
+        resolve(response);
+      }});
+    } catch(err) {
+      log.error('message: Error calling RPC', err);
+    }
+  });
+
+  that.killMe = (publicIP) => callNuve('killMe', [], publicIP);
+  that.keepAlive = (myId) => callNuve('keepAlive', ['whoareyou'], myId);
+  that.addNewErizoController = (controller) => callNuve('addNewErizoController', [], controller);
+  that.setInfo = (info) => callNuve('setInfo', [], info);
+  that.deleteToken = (token) => callNuve('deleteToken', [], token);
+
+  return that;
+};

--- a/erizo_controller/installErizo_controller.sh
+++ b/erizo_controller/installErizo_controller.sh
@@ -13,7 +13,7 @@ NVM_CHECK="$LICODE_ROOT"/scripts/checkNvm.sh
 echo [erizo_controller] Installing node_modules for erizo_controller
 
 nvm use
-npm install --loglevel error amqp socket.io@2.0.3 log4js@1.0.1 node-getopt
+npm install --loglevel error amqp socket.io@2.0.3 log4js@1.0.1 node-getopt uuid@3.1.0
 npm install --loglevel error -g google-closure-compiler-js
 
 echo [erizo_controller] Done, node_modules installed

--- a/erizo_controller/test/erizoController/erizoController.js
+++ b/erizo_controller/test/erizoController/erizoController.js
@@ -60,25 +60,31 @@ describe('Erizo Controller / Erizo Controller', function() {
     expect(amqperMock.setPublicRPC.callCount).to.equal(1);
   });
 
-  it('should bind to AMQP once connected', function() {
+  it('should bind to AMQP once connected', function(done) {
     var callback = amqperMock.callRpc.withArgs('nuve', 'addNewErizoController').args[0][3].callback;
 
     callback({id: arbitraryErizoControllerId});
-
-    expect(amqperMock.bind.callCount).to.equal(1);
+    setTimeout(() => {
+      expect(amqperMock.bind.callCount).to.equal(1);
+      done();
+    }, 0);
   });
 
-  it('should listen to socket connection once bound', function() {
+  it('should listen to socket connection once bound', function(done) {
     var callback = amqperMock.callRpc.withArgs('nuve', 'addNewErizoController').args[0][3].callback;
     amqperMock.bind.withArgs('erizoController_' + arbitraryErizoControllerId).callsArg(1);
 
     callback({id: arbitraryErizoControllerId});
 
-    expect(mocks.socketIoInstance.sockets.on.withArgs('connection').callCount).to.equal(1);
+    setTimeout(() => {
+      expect(mocks.socketIoInstance.sockets.on.withArgs('connection').callCount).to.equal(1);
+      done();
+    }, 0);
   });
 
   describe('Sockets', function() {
     var onToken,
+        onReconnect,
         onSendDataStream,
         onSignalingMessage,
         onUpdateStreamAttributes,
@@ -90,40 +96,24 @@ describe('Erizo Controller / Erizo Controller', function() {
         onUnsubscribe,
         onDisconnect;
 
-    beforeEach(function() {
+    beforeEach(function(done) {
       var callback = amqperMock.callRpc.withArgs('nuve', 'addNewErizoController')
             .args[0][3].callback;
       amqperMock.bind.withArgs('erizoController_' + arbitraryErizoControllerId).callsArg(1);
       mocks.socketIoInstance.sockets.on.withArgs('connection')
-            .callsArgWith(1, mocks.socketInstance);
+                                       .callsArgWith(1, mocks.socketInstance);
       callback({id: arbitraryErizoControllerId});
 
-      onToken = mocks.socketInstance.on.withArgs('token').args[0][1];
-      onSendDataStream = mocks.socketInstance.on.withArgs('sendDataStream').args[0][1];
-      onSignalingMessage = mocks.socketInstance.on.withArgs('signaling_message').args[0][1];
-      onUpdateStreamAttributes = mocks.socketInstance.on
-                                            .withArgs('updateStreamAttributes').args[0][1];
-      onPublish = mocks.socketInstance.on.withArgs('publish').args[0][1];
-      onSubscribe = mocks.socketInstance.on.withArgs('subscribe').args[0][1];
-      onStartRecorder = mocks.socketInstance.on.withArgs('startRecorder').args[0][1];
-      onStopRecorder = mocks.socketInstance.on.withArgs('stopRecorder').args[0][1];
-      onUnpublish = mocks.socketInstance.on.withArgs('unpublish').args[0][1];
-      onUnsubscribe = mocks.socketInstance.on.withArgs('unsubscribe').args[0][1];
-      onDisconnect = mocks.socketInstance.on.withArgs('disconnect').args[0][1];
+      setTimeout(() => {
+        onToken = mocks.socketInstance.on.withArgs('token').args[0][1];
+        onReconnect = mocks.socketInstance.on.withArgs('reconnected').args[0][1];
+        onDisconnect = mocks.socketInstance.on.withArgs('disconnect').args[0][1];
+        done();
+      }, 0);
     });
 
     it('should listen to events', function() {
       expect(mocks.socketInstance.on.withArgs('token').callCount).to.equal(1);
-      expect(mocks.socketInstance.on.withArgs('sendDataStream').callCount).to.equal(1);
-      expect(mocks.socketInstance.on.withArgs('signaling_message').callCount).to.equal(1);
-      expect(mocks.socketInstance.on.withArgs('updateStreamAttributes').callCount).to.equal(1);
-      expect(mocks.socketInstance.on.withArgs('publish').callCount).to.equal(1);
-      expect(mocks.socketInstance.on.withArgs('subscribe').callCount).to.equal(1);
-      expect(mocks.socketInstance.on.withArgs('startRecorder').callCount).to.equal(1);
-      expect(mocks.socketInstance.on.withArgs('stopRecorder').callCount).to.equal(1);
-      expect(mocks.socketInstance.on.withArgs('unpublish').callCount).to.equal(1);
-      expect(mocks.socketInstance.on.withArgs('unsubscribe').callCount).to.equal(1);
-      expect(mocks.socketInstance.on.withArgs('disconnect').callCount).to.equal(1);
     });
 
     describe('on Token', function() {
@@ -174,54 +164,94 @@ describe('Erizo Controller / Erizo Controller', function() {
                                    .args[0][3].callback;
         });
 
-        it('should disconnect socket on Nuve error', function() {
+        it('should disconnect socket on Nuve error', function(done) {
           callback('error');
-
-          expect(mocks.socketInstance.disconnect.callCount).to.equal(1);
-          expect(onTokenCallback.withArgs('error', 'Token does not exist').callCount).to.equal(1);
+          setTimeout(() => {
+            expect(mocks.socketInstance.disconnect.callCount).to.equal(1);
+            expect(onTokenCallback.withArgs('error', 'Token does not exist').callCount).to.equal(1);
+            done();
+          }, 0);
         });
 
-        it('should disconnect socket on Nuve timeout', function() {
+        it('should disconnect socket on Nuve timeout', function(done) {
           callback('timeout');
-
-          expect(mocks.socketInstance.disconnect.callCount).to.equal(1);
-          expect(onTokenCallback.withArgs('error', 'Nuve does not respond').callCount).to.equal(1);
+          setTimeout(() => {
+            expect(mocks.socketInstance.disconnect.callCount).to.equal(1);
+            expect(onTokenCallback.withArgs('error', 'Nuve does not respond').callCount)
+                .to.equal(1);
+            done();
+          }, 0);
         });
 
-        it('should disconnect if Token has an invalid host', function() {
+        it('should disconnect if Token has an invalid host', function(done) {
           callback({host: 'invalidHost', room: 'roomId'});
-
-          expect(onTokenCallback.withArgs('error', 'Invalid host').callCount).to.equal(1);
+          setTimeout(() => {
+            expect(onTokenCallback.withArgs('error', 'Invalid host').callCount).to.equal(1);
+            done();
+          }, 0);
         });
 
-        it('should create Room Controller if it does not exist', function() {
+        it('should create Room Controller if it does not exist', function(done) {
           callback({host: 'host', room: 'roomId'});
-
-          expect(roomControllerMock.RoomController.callCount).to.equal(1);
-          expect(mocks.roomControllerInstance.addEventListener.callCount).to.equal(1);
-
-          expect(onTokenCallback.withArgs('success').callCount).to.equal(1);
+          setTimeout(() => {
+            expect(roomControllerMock.RoomController.callCount).to.equal(1);
+            expect(mocks.roomControllerInstance.addEventListener.callCount).to.equal(1);
+            expect(onTokenCallback.withArgs('success').callCount).to.equal(1);
+            done();
+          }, 0);
         });
 
-        it('should not create Room Controller if it does exist', function() {
+        it('should not create Room Controller if it does exist', function(done) {
           callback({host: 'host', room: 'roomId'});
-
-          expect(roomControllerMock.RoomController.callCount).to.equal(1);
-          expect(mocks.roomControllerInstance.addEventListener.callCount).to.equal(1);
-          expect(onTokenCallback.withArgs('success').callCount).to.equal(1);
-
-          callback({host: 'host', room: 'roomId'});
-          expect(roomControllerMock.RoomController.callCount).to.equal(1);
-          expect(mocks.roomControllerInstance.addEventListener.callCount).to.equal(1);
-          expect(onTokenCallback.withArgs('success').callCount).to.equal(2);
+          setTimeout(() => {
+            expect(roomControllerMock.RoomController.callCount).to.equal(1);
+            expect(mocks.roomControllerInstance.addEventListener.callCount).to.equal(1);
+            expect(onTokenCallback.withArgs('success').callCount).to.equal(1);
+            onToken(arbitraryGoodToken, onTokenCallback);
+            let callback2 = amqperMock.callRpc
+                                     .withArgs('nuve', 'deleteToken', arbitraryGoodToken.tokenId)
+                                     .args[1][3].callback;
+            callback2({host: 'host', room: 'roomId'});
+            setTimeout(() => {
+              expect(roomControllerMock.RoomController.callCount).to.equal(1);
+              expect(mocks.roomControllerInstance.addEventListener.callCount).to.equal(1);
+              expect(onTokenCallback.withArgs('success').callCount).to.equal(2);
+              done();
+            }, 0);
+        }, 0);
         });
 
         describe('Public API', function() {
-          beforeEach(function() {
-            callback({host: 'host', room: 'roomId'});
-            mocks.socketInstance.user = {
-              name: 'user'
-            };
+          beforeEach(function(done) {
+            callback({host: 'host', room: 'roomId', userName: 'user'});
+
+            setTimeout(() => {
+              onSendDataStream = mocks.socketInstance.on.withArgs('sendDataStream').args[0][1];
+              onSignalingMessage = mocks.socketInstance.on.withArgs('signaling_message').args[0][1];
+              onUpdateStreamAttributes = mocks.socketInstance.on
+                                                    .withArgs('updateStreamAttributes').args[0][1];
+              onPublish = mocks.socketInstance.on.withArgs('publish').args[0][1];
+              onSubscribe = mocks.socketInstance.on.withArgs('subscribe').args[0][1];
+              onStartRecorder = mocks.socketInstance.on.withArgs('startRecorder').args[0][1];
+              onStopRecorder = mocks.socketInstance.on.withArgs('stopRecorder').args[0][1];
+              onUnpublish = mocks.socketInstance.on.withArgs('unpublish').args[0][1];
+              onUnsubscribe = mocks.socketInstance.on.withArgs('unsubscribe').args[0][1];
+              done();
+            }, 0);
+          });
+
+          it('should listen to messages', function() {
+            expect(mocks.socketInstance.on.withArgs('sendDataStream').callCount).to.equal(1);
+            expect(mocks.socketInstance.on.withArgs('signaling_message').callCount).to.equal(1);
+            expect(mocks.socketInstance.on.withArgs('updateStreamAttributes').callCount)
+                  .to.equal(1);
+            expect(mocks.socketInstance.on.withArgs('publish').callCount).to.equal(1);
+            expect(mocks.socketInstance.on.withArgs('subscribe').callCount).to.equal(1);
+            expect(mocks.socketInstance.on.withArgs('startRecorder').callCount).to.equal(1);
+            expect(mocks.socketInstance.on.withArgs('stopRecorder').callCount).to.equal(1);
+            expect(mocks.socketInstance.on.withArgs('unpublish').callCount).to.equal(1);
+            expect(mocks.socketInstance.on.withArgs('unsubscribe').callCount).to.equal(1);
+            expect(mocks.socketInstance.on.withArgs('disconnect').callCount).to.equal(1);
           });
 
           it('should return users when calling getUsersInRoom', function() {
@@ -290,819 +320,792 @@ describe('Erizo Controller / Erizo Controller', function() {
             expect(mocks.roomControllerInstance.removeSubscriptions.callCount).to.equal(0);
           });
         });
-      });
-    });
-
-    describe('on Send Data Stream', function() {
-      beforeEach(function() {
-        var sockets = ['streamId1'];
-        mocks.socketInstance.room = {
-          streams: {
-            streamId1: {
-              getDataSubscribers: sinon.stub().returns(sockets)
-            }
-          }
-        };
-      });
-
-      it('should succeed if stream exists', function() {
-        var msg = {id: 'streamId1'};
-
-        onSendDataStream(msg);
-
-        expect(mocks.socketInstance.emit.withArgs('onDataStream', msg).callCount).to.equal(1);
-      });
-
-      it('should fail if stream does not exist', function() {
-        var msg = {id: 'streamId2'};
-
-        onSendDataStream(msg);
-
-        expect(mocks.socketInstance.emit.withArgs('onDataStream', msg).callCount).to.equal(0);
-      });
-    });
-
-    describe('on Signaling Message', function() {
-      var arbitraryMessage = {msg: 'msg', streamId: 'streamId1'};
-
-      it('should send p2p signaling messages', function() {
-        mocks.socketInstance.room = {p2p: true};
-
-        onSignalingMessage(arbitraryMessage);
-
-        expect(mocks.socketInstance.emit.withArgs('signaling_message_peer').callCount).to.equal(1);
-      });
-
-      it('should send other signaling messages', function() {
-        mocks.socketInstance.room = {p2p: false, controller: mocks.roomControllerInstance};
-
-        onSignalingMessage(arbitraryMessage);
-
-        expect(mocks.roomControllerInstance.processSignaling.withArgs(arbitraryMessage.streamId)
-                                                            .callCount).to.equal(1);
-      });
-    });
-
-    describe('on Update Stream Attributes', function() {
-      beforeEach(function() {
-        var sockets = ['streamId1'];
-        mocks.socketInstance.room = {
-          streams: {
-            streamId1: {
-              getDataSubscribers: sinon.stub().returns(sockets),
-              setAttributes: sinon.stub()
-            }
-          }
-        };
-      });
-
-      it('should succeed if stream exists', function() {
-        var msg = {id: 'streamId1'};
-
-        onUpdateStreamAttributes(msg);
-
-        expect(mocks.socketInstance.emit.withArgs('onUpdateAttributeStream', msg).callCount)
-                .to.equal(1);
-      });
-
-      it('should fail if stream does not exist', function() {
-        var msg = {id: 'streamId2'};
-
-        onUpdateStreamAttributes(msg);
 
-        expect(mocks.socketInstance.emit.withArgs('onUpdateAttributeStream', msg).callCount)
-                .to.equal(0);
-      });
-    });
+        describe('Socket API', function() {
+          let room;
+          beforeEach(function(done) {
+            const Rooms = require('../../erizoController/models/Room').Rooms;
+            const Room = require('../../erizoController/models/Room').Room;
+            room = new Room('roomId', false);
+            sinon.stub(Rooms.prototype, 'getOrCreateRoom').returns(room);
+            callback({host: 'host', room: 'roomId', userName: 'user'});
+
+            setTimeout(() => {
+              onSendDataStream = mocks.socketInstance.on.withArgs('sendDataStream').args[0][1];
+              onSignalingMessage = mocks.socketInstance.on.withArgs('signaling_message').args[0][1];
+              onUpdateStreamAttributes = mocks.socketInstance.on
+                                                    .withArgs('updateStreamAttributes').args[0][1];
+              onPublish = mocks.socketInstance.on.withArgs('publish').args[0][1];
+              onSubscribe = mocks.socketInstance.on.withArgs('subscribe').args[0][1];
+              onStartRecorder = mocks.socketInstance.on.withArgs('startRecorder').args[0][1];
+              onStopRecorder = mocks.socketInstance.on.withArgs('stopRecorder').args[0][1];
+              onUnpublish = mocks.socketInstance.on.withArgs('unpublish').args[0][1];
+              onUnsubscribe = mocks.socketInstance.on.withArgs('unsubscribe').args[0][1];
+              done();
+            }, 0);
+          });
+
+          it('should listen to messages', function() {
+            expect(mocks.socketInstance.on.withArgs('sendDataStream').callCount).to.equal(1);
+            expect(mocks.socketInstance.on.withArgs('signaling_message').callCount).to.equal(1);
+            expect(mocks.socketInstance.on.withArgs('updateStreamAttributes').callCount)
+                    .to.equal(1);
+            expect(mocks.socketInstance.on.withArgs('publish').callCount).to.equal(1);
+            expect(mocks.socketInstance.on.withArgs('subscribe').callCount).to.equal(1);
+            expect(mocks.socketInstance.on.withArgs('startRecorder').callCount).to.equal(1);
+            expect(mocks.socketInstance.on.withArgs('stopRecorder').callCount).to.equal(1);
+            expect(mocks.socketInstance.on.withArgs('unpublish').callCount).to.equal(1);
+            expect(mocks.socketInstance.on.withArgs('unsubscribe').callCount).to.equal(1);
+            expect(mocks.socketInstance.on.withArgs('disconnect').callCount).to.equal(1);
+          });
+
+          describe('on Publish', function() {
+            let client;
+            beforeEach(function() {
+              for (let c of room.clients.values()) {
+                client = c;
+              }
+              client.user.permissions[Permission.PUBLISH] = true;
+            });
+
+            it('should fail if user is undefined', function() {
+              var options = {},
+                  sdp = '',
+                  callback = sinon.stub();
+
+              client.user = undefined;
+
+              onPublish(options, sdp, callback);
+
+              expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
+            });
+
+            it('should fail if user is not authorized', function() {
+              var options = {},
+                  sdp = '',
+                  callback = sinon.stub();
+
+              client.user.permissions[Permission.PUBLISH] = false;
+
+              onPublish(options, sdp, callback);
+
+              expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
+            });
+
+            it('should fail if user is not authorized to publish video', function() {
+              var options = {
+                    video: true
+                  },
+                  sdp = '',
+                  callback = sinon.stub();
+
+              client.user.permissions[Permission.PUBLISH] = {video: false};
+
+              onPublish(options, sdp, callback);
+
+              expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
+            });
+
+            it('should start an External Input if url is given', function() {
+              var options = {state: 'url'},
+                  sdp = '',
+                  callback = sinon.stub();
+              mocks.roomControllerInstance.addExternalInput.callsArgWith(2, 'success');
+
+              onPublish(options, sdp, callback);
+
+              expect(mocks.roomControllerInstance.addExternalInput.callCount).to.equal(1);
+              expect(callback.callCount).to.equal(1);
+            });
+
+            it('should add a Stream', function() {
+              var options = {},
+                  sdp = '',
+                  callback = sinon.stub();
 
-    describe('on Publish', function() {
-      beforeEach(function() {
-        var sockets = ['streamId1'];
-        mocks.socketInstance.streams = [];
-        mocks.socketInstance.user = {};
-        mocks.socketInstance.room = {
-          controller: mocks.roomControllerInstance,
-          sockets: sockets,
-          streams: {
-            streamId1: {
-              getDataSubscribers: sinon.stub().returns(sockets),
-              setAttributes: sinon.stub()
-            }
-          }
-        };
-        mocks.socketInstance.user.permissions = {};
-        mocks.socketInstance.user.permissions[Permission.PUBLISH] = true;
-      });
+              onPublish(options, sdp, callback);
 
-      it('should fail if user is undefined', function() {
-        var options = {},
-            sdp = '',
-            callback = sinon.stub();
+              expect(mocks.socketInstance.emit.withArgs('onAddStream').callCount).to.equal(1);
+            });
 
-        mocks.socketInstance.user = undefined;
+            describe('addPublisher with Erizo', function() {
+              var options = {state: 'erizo'},
+                  sdp = '',
+                  callback = sinon.stub();
 
-        onPublish(options, sdp, callback);
+              it('should call addPublisher', function() {
+                onPublish(options, sdp, callback);
 
-        expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
-      });
+                expect(mocks.roomControllerInstance.addPublisher.callCount).to.equal(1);
+              });
 
-      it('should fail if user is not authorized', function() {
-        var options = {},
-            sdp = '',
-            callback = sinon.stub();
+              it('should send if when receiving initializing state', function() {
+                var signMes = {type: 'initializing'};
+                mocks.roomControllerInstance.addPublisher.callsArgWith(2, signMes);
 
-        mocks.socketInstance.user.permissions[Permission.PUBLISH] = false;
+                onPublish(options, sdp, callback);
 
-        onPublish(options, sdp, callback);
+                expect(callback.callCount).to.equal(1);
+              });
 
-        expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
-      });
+              it('should emit connection_failed when receiving initializing state', function() {
+                var signMes = {type: 'failed'};
+                mocks.roomControllerInstance.addPublisher.callsArgWith(2, signMes);
 
-      it('should fail if user is not authorized to publish video', function() {
-        var options = {
-              video: true
-            },
-            sdp = '',
-            callback = sinon.stub();
+                onPublish(options, sdp, callback);
 
-        mocks.socketInstance.user.permissions[Permission.PUBLISH] = {video: false};
-
-        onPublish(options, sdp, callback);
-
-        expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
-      });
-
-      it('should start an External Input if url is given', function() {
-        var options = {state: 'url'},
-            sdp = '',
-            callback = sinon.stub();
-        mocks.roomControllerInstance.addExternalInput.callsArgWith(2, 'success');
-
-        onPublish(options, sdp, callback);
-
-        expect(mocks.roomControllerInstance.addExternalInput.callCount).to.equal(1);
-        expect(callback.callCount).to.equal(1);
-      });
-
-      it('should add a Stream', function() {
-        var options = {},
-            sdp = '',
-            callback = sinon.stub();
-
-        onPublish(options, sdp, callback);
-
-        expect(mocks.socketInstance.emit.withArgs('onAddStream').callCount).to.equal(1);
-      });
-
-      describe('addPublisher with Erizo', function() {
-        var options = {state: 'erizo'},
-            sdp = '',
-            callback = sinon.stub();
-
-        it('should call addPublisher', function() {
-          onPublish(options, sdp, callback);
-
-          expect(mocks.roomControllerInstance.addPublisher.callCount).to.equal(1);
-        });
-
-        it('should send if when receiving initializing state', function() {
-          var signMes = {type: 'initializing'};
-          mocks.roomControllerInstance.addPublisher.callsArgWith(2, signMes);
-
-          onPublish(options, sdp, callback);
-
-          expect(callback.callCount).to.equal(1);
-        });
-
-        it('should emit connection_failed when receiving initializing state', function() {
-          var signMes = {type: 'failed'};
-          mocks.roomControllerInstance.addPublisher.callsArgWith(2, signMes);
-
-          onPublish(options, sdp, callback);
-
-          expect(mocks.socketInstance.emit.withArgs('connection_failed').callCount).to.equal(1);
-        });
-
-        it('should send onAddStream event to Room when receiving ready stat', function() {
-          var signMes = {type: 'initializing'};
-          mocks.roomControllerInstance.addPublisher.callsArgWith(2, signMes);
-
-          onPublish(options, sdp, callback);
-
-          var onEvent = mocks.roomControllerInstance.addPublisher.args[0][2];
-
-          onEvent({type: 'ready'});
-
-          expect(mocks.socketInstance.emit.withArgs('onAddStream').callCount).to.equal(1);
-        });
-
-        it('should emit ErizoJS unreachable', function() {
-          var signMes = 'timeout-erizojs';
-          mocks.roomControllerInstance.addPublisher.callsArgWith(2, signMes);
-
-          onPublish(options, sdp, callback);
-
-          expect(callback.withArgs(null, 'ErizoJS is not reachable').callCount).to.equal(1);
-        });
-
-        it('should emit ErizoAgent unreachable', function() {
-          var signMes = 'timeout-agent';
-          mocks.roomControllerInstance.addPublisher.callsArgWith(2, signMes);
-
-          onPublish(options, sdp, callback);
-
-          expect(callback.withArgs(null, 'ErizoAgent is not reachable').callCount).to.equal(1);
-        });
-
-        it('should emit ErizoJS or ErizoAgent unreachable', function() {
-          var signMes = 'timeout';
-          mocks.roomControllerInstance.addPublisher.callsArgWith(2, signMes);
-
-          onPublish(options, sdp, callback);
-
-          expect(callback.withArgs(null, 'ErizoAgent or ErizoJS is not reachable').callCount)
-                            .to.equal(1);
-        });
-      });
-    });
-
-    describe('on Subscribe', function() {
-      var subscriberOptions, subscriberSdp, streamId;
-      beforeEach(function() {
-        var sockets = ['streamId1'];
-        mocks.socketInstance.streams = [];
-        mocks.socketInstance.user = {};
-        mocks.socketInstance.room = {
-          controller: mocks.roomControllerInstance,
-          sockets: sockets,
-          streams: {
-            streamId1: {
-              getDataSubscribers: sinon.stub().returns(sockets),
-              setAttributes: sinon.stub()
-            }
-          }
-        };
-        mocks.socketInstance.user.permissions = {};
-        mocks.socketInstance.user.permissions[Permission.SUBSCRIBE] = true;
-        mocks.socketInstance.user.permissions[Permission.PUBLISH] = true;
-
-        var options = {audio: true, video: true, data: true},
-            sdp = '',
-            callback = sinon.stub();
-
-        onPublish(options, sdp, callback);
-
-        streamId = callback.args[0][0];
-
-        subscriberOptions= {
-             streamId: streamId
-           };
-        subscriberSdp = '';
-      });
-
-      it('should fail if user is undefined', function() {
-        var callback = sinon.stub();
-
-        mocks.socketInstance.user = undefined;
-
-        onSubscribe(subscriberOptions, subscriberSdp, callback);
-
-        expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
-      });
-
-      it('should fail if user is not authorized', function() {
-        var callback = sinon.stub();
-
-        mocks.socketInstance.user.permissions[Permission.SUBSCRIBE] = false;
-
-        onSubscribe(subscriberOptions, subscriberSdp, callback);
-
-        expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
-      });
-
-      it('should fail if user is not authorized to subscribe video', function() {
-        var callback = sinon.stub();
-
-        subscriberOptions.video = true;
-
-        mocks.socketInstance.user.permissions[Permission.SUBSCRIBE] = {video: false};
-
-        onSubscribe(subscriberOptions, subscriberSdp, callback);
-
-        expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
-      });
-
-      it('should emit a publish_me event if the room is p2p', function() {
-        var callback = sinon.stub();
-        mocks.socketInstance.room.p2p = true;
-
-        onSubscribe(subscriberOptions, subscriberSdp, callback);
-
-        expect(mocks.socketInstance.emit.withArgs('publish_me').callCount).to.equal(1);
-      });
-
-      it('should return true if the stream has no media', function() {
-        var callback = sinon.stub();
-        var returnFalse = sinon.stub().returns(false);
-        mocks.socketInstance.room.streams[streamId].hasVideo = returnFalse;
-        mocks.socketInstance.room.streams[streamId].hasAudio = returnFalse;
-        mocks.socketInstance.room.streams[streamId].hasScreen = returnFalse;
-
-        onSubscribe(subscriberOptions, subscriberSdp, callback);
-
-        expect(mocks.roomControllerInstance.addSubscriber.callCount).to.equal(0);
-        expect(callback.withArgs(true).callCount).to.equal(1);
-      });
-
-      describe('when receiving events from RoomController', function() {
-        var callback = sinon.stub();
-
-        it('should call addSubscriber', function() {
-          onSubscribe(subscriberOptions, subscriberSdp, callback);
-
-          expect(mocks.roomControllerInstance.addSubscriber.callCount).to.equal(1);
-        });
-
-        it('should send if when receiving initializing state', function() {
-          var signMes = {type: 'initializing'};
-          mocks.roomControllerInstance.addSubscriber.callsArgWith(3, signMes);
-
-          onSubscribe(subscriberOptions, subscriberSdp, callback);
-
-          expect(callback.withArgs(true).callCount).to.equal(1);
-        });
-
-        it('should emit connection_failed when receiving initializing state', function() {
-          var signMes = {type: 'failed'};
-          mocks.roomControllerInstance.addSubscriber.callsArgWith(3, signMes);
-
-          onSubscribe(subscriberOptions, subscriberSdp, callback);
-
-          expect(mocks.socketInstance.emit.withArgs('connection_failed').callCount).to.equal(1);
-        });
-
-        it('should send signaling event to the socket when receiving ready stat', function() {
-          var signMes = {type: 'ready'};
-          mocks.roomControllerInstance.addSubscriber.callsArgWith(3, signMes);
-
-          onSubscribe(subscriberOptions, subscriberSdp, callback);
-
-          expect(mocks.socketInstance.emit.withArgs('signaling_message_erizo').callCount)
+                expect(mocks.socketInstance.emit.withArgs('connection_failed').callCount)
                         .to.equal(1);
-        });
+              });
 
-        it('should send signaling event to the socket when receiving bandwidth alerts', function() {
-          var signMes = {type: 'bandwidthAlert'};
-          mocks.roomControllerInstance.addSubscriber.callsArgWith(3, signMes);
+              it('should send onAddStream event to Room when receiving ready stat', function() {
+                var signMes = {type: 'initializing'};
+                mocks.roomControllerInstance.addPublisher.callsArgWith(2, signMes);
 
-          onSubscribe(subscriberOptions, subscriberSdp, callback);
+                onPublish(options, sdp, callback);
 
-          expect(mocks.socketInstance.emit.withArgs('signaling_message_erizo').callCount)
-                        .to.equal(1);
-        });
+                var onEvent = mocks.roomControllerInstance.addPublisher.args[0][2];
+
+                onEvent({type: 'ready'});
+
+                expect(mocks.socketInstance.emit.withArgs('onAddStream').callCount).to.equal(1);
+              });
+
+              it('should emit ErizoJS unreachable', function() {
+                var signMes = 'timeout-erizojs';
+                mocks.roomControllerInstance.addPublisher.callsArgWith(2, signMes);
+
+                onPublish(options, sdp, callback);
+
+                expect(callback.withArgs(null, 'ErizoJS is not reachable').callCount).to.equal(1);
+              });
+
+              it('should emit ErizoAgent unreachable', function() {
+                var signMes = 'timeout-agent';
+                mocks.roomControllerInstance.addPublisher.callsArgWith(2, signMes);
+
+                onPublish(options, sdp, callback);
+
+                expect(callback.withArgs(null, 'ErizoAgent is not reachable').callCount)
+                      .to.equal(1);
+              });
+
+              it('should emit ErizoJS or ErizoAgent unreachable', function() {
+                var signMes = 'timeout';
+                mocks.roomControllerInstance.addPublisher.callsArgWith(2, signMes);
+
+                onPublish(options, sdp, callback);
+
+                expect(callback.withArgs(null, 'ErizoAgent or ErizoJS is not reachable').callCount)
+                                  .to.equal(1);
+              });
+
+              describe('on Subscribe', function() {
+                var subscriberOptions, subscriberSdp, streamId;
+                beforeEach(function() {
+                  client.user.permissions = {};
+                  client.user.permissions[Permission.SUBSCRIBE] = true;
+                  client.user.permissions[Permission.PUBLISH] = true;
+
+                  var options = {audio: true, video: true, screen:true, data: true},
+                      sdp = '',
+                      callback = sinon.stub();
+
+                  onPublish(options, sdp, callback);
+
+                  streamId = callback.args[0][0];
+
+                  subscriberOptions= {
+                       streamId: streamId
+                     };
+                  subscriberSdp = '';
+                });
+
+                it('should fail if user is undefined', function() {
+                  var callback = sinon.stub();
+
+                  client.user = undefined;
+
+                  onSubscribe(subscriberOptions, subscriberSdp, callback);
+
+                  expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
+                });
+
+                it('should fail if user is not authorized', function() {
+                  var callback = sinon.stub();
+
+                  client.user.permissions[Permission.SUBSCRIBE] = false;
+
+                  onSubscribe(subscriberOptions, subscriberSdp, callback);
+
+                  expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
+                });
+
+                it('should fail if user is not authorized to subscribe video', function() {
+                  var callback = sinon.stub();
+
+                  subscriberOptions.video = true;
+
+                  client.user.permissions[Permission.SUBSCRIBE] = {video: false};
+
+                  onSubscribe(subscriberOptions, subscriberSdp, callback);
+
+                  expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
+                });
+
+                it('should emit a publish_me event if the room is p2p', function() {
+                  var callback = sinon.stub();
+                  room.p2p = true;
+
+                  onSubscribe(subscriberOptions, subscriberSdp, callback);
+
+                  expect(mocks.socketInstance.emit.withArgs('publish_me').callCount).to.equal(1);
+                });
+
+                it('should return true if the stream has no media', function() {
+                  var callback = sinon.stub();
+                  var returnFalse = sinon.stub().returns(false);
+                  client.room.getStreamById(streamId).hasVideo = returnFalse;
+                  client.room.getStreamById(streamId).hasAudio = returnFalse;
+                  client.room.getStreamById(streamId).hasScreen = returnFalse;
+
+                  onSubscribe(subscriberOptions, subscriberSdp, callback);
+
+                  expect(mocks.roomControllerInstance.addSubscriber.callCount).to.equal(0);
+                  expect(callback.withArgs(true).callCount).to.equal(1);
+                });
+
+                describe('when receiving events from RoomController', function() {
+                  var callback = sinon.stub();
+
+                  it('should call addSubscriber', function() {
+                    onSubscribe(subscriberOptions, subscriberSdp, callback);
+
+                    expect(mocks.roomControllerInstance.addSubscriber.callCount).to.equal(1);
+                  });
+
+                  it('should send if when receiving initializing state', function() {
+                    var signMes = {type: 'initializing'};
+                    mocks.roomControllerInstance.addSubscriber.callsArgWith(3, signMes);
+
+                    onSubscribe(subscriberOptions, subscriberSdp, callback);
+
+                    expect(callback.withArgs(true).callCount).to.equal(1);
+                  });
+
+                  it('should emit connection_failed when receiving initializing state', function() {
+                    var signMes = {type: 'failed'};
+                    mocks.roomControllerInstance.addSubscriber.callsArgWith(3, signMes);
+
+                    onSubscribe(subscriberOptions, subscriberSdp, callback);
+
+                    expect(mocks.socketInstance.emit.withArgs('connection_failed').callCount)
+                          .to.equal(1);
+                  });
+
+                  it('should send signaling event to the socket when receiving ready stat',
+                      function() {
+                    var signMes = {type: 'ready'};
+                    mocks.roomControllerInstance.addSubscriber.callsArgWith(3, signMes);
+
+                    onSubscribe(subscriberOptions, subscriberSdp, callback);
+
+                    expect(mocks.socketInstance.emit.withArgs('signaling_message_erizo').callCount)
+                                  .to.equal(1);
+                  });
+
+                  it('should send signaling event to the socket when receiving bandwidth alerts',
+                      function() {
+                    var signMes = {type: 'bandwidthAlert'};
+                    mocks.roomControllerInstance.addSubscriber.callsArgWith(3, signMes);
+
+                    onSubscribe(subscriberOptions, subscriberSdp, callback);
+
+                    expect(mocks.socketInstance.emit.withArgs('signaling_message_erizo')
+                          .callCount).to.equal(1);
+                  });
 
 
-        it('should emit ErizoJS unreachable', function() {
-          var signMes = 'timeout';
-          mocks.roomControllerInstance.addSubscriber.callsArgWith(3, signMes);
+                  it('should emit ErizoJS unreachable', function() {
+                    var signMes = 'timeout';
+                    mocks.roomControllerInstance.addSubscriber.callsArgWith(3, signMes);
 
-          onSubscribe(subscriberOptions, subscriberSdp, callback);
+                    onSubscribe(subscriberOptions, subscriberSdp, callback);
 
-          expect(callback.withArgs(null, 'ErizoJS is not reachable').callCount).to.equal(1);
-        });
-      });
-    });
+                    expect(callback.withArgs(null, 'ErizoJS is not reachable').callCount)
+                          .to.equal(1);
+                  });
+                });
 
-    describe('on Start Recorder', function() {
-      var subscriberOptions, streamId;
-      beforeEach(function() {
-        var sockets = ['streamId1'];
-        mocks.socketInstance.streams = [];
-        mocks.socketInstance.user = {};
-        mocks.socketInstance.room = {
-          controller: mocks.roomControllerInstance,
-          sockets: sockets,
-          streams: {
-            streamId1: {
-              getDataSubscribers: sinon.stub().returns(sockets),
-              setAttributes: sinon.stub()
-            }
-          }
-        };
-        mocks.socketInstance.user.permissions = {};
-        mocks.socketInstance.user.permissions[Permission.RECORD] = true;
-        mocks.socketInstance.user.permissions[Permission.PUBLISH] = true;
+                describe('on Send Data Stream', function() {
+                  let stream, streamId;
+                  beforeEach(function() {
+                    for (let st of room.streams.values()) {
+                        stream = st;
+                        streamId = stream.getID();
+                    }
+                    stream.getDataSubscribers = sinon.stub().returns([client.id]);
+                  });
 
-        var options = {audio: true, video: true, data: true},
-            sdp = '',
-            callback = sinon.stub();
+                  it('should succeed if stream exists', function() {
+                    var msg = {id: streamId};
 
-        onPublish(options, sdp, callback);
+                    onSendDataStream(msg);
 
-        streamId = callback.args[0][0];
+                    expect(mocks.socketInstance.emit.withArgs('onDataStream', msg).callCount)
+                          .to.equal(1);
+                  });
 
-        subscriberOptions= {
-             to: streamId
-           };
-      });
+                  it('should fail if stream does not exist', function() {
+                    var msg = {id: 'streamId2'};
 
-      it('should fail if user is undefined', function() {
-        var callback = sinon.stub();
-        mocks.socketInstance.user = undefined;
+                    onSendDataStream(msg);
 
-        onStartRecorder(subscriberOptions, callback);
+                    expect(mocks.socketInstance.emit.withArgs('onDataStream', msg).callCount)
+                          .to.equal(0);
+                  });
+                });
 
-        expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
-      });
+                describe('on Signaling Message', function() {
+                  var arbitraryMessage = {msg: 'msg'};
 
-      it('should fail if user is not authorized', function() {
-        var callback = sinon.stub();
-        mocks.socketInstance.user.permissions[Permission.RECORD] = false;
+                  let stream, streamId;
+                  beforeEach(function() {
+                    for (let st of room.streams.values()) {
+                        stream = st;
+                        streamId = stream.getID();
+                    }
+                    arbitraryMessage.streamId = streamId;
+                    stream.getDataSubscribers = sinon.stub().returns([client.id]);
+                  });
 
-        onStartRecorder(subscriberOptions, callback);
+                  it('should send p2p signaling messages', function() {
+                    room.p2p = true;
+                    arbitraryMessage.peerSocket = client.id;
 
-        expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
-      });
+                    onSignalingMessage(arbitraryMessage);
 
-      it('should return an error if the room is p2p', function() {
-        var callback = sinon.stub();
-        mocks.socketInstance.room.p2p = true;
+                    expect(mocks.socketInstance.emit.withArgs('signaling_message_peer')
+                          .callCount).to.equal(1);
+                  });
 
-        onStartRecorder(subscriberOptions, callback);
+                  it('should send other signaling messages', function() {
+                    room.p2p = false;
+                    room.controller = mocks.roomControllerInstance;
 
-        expect(callback.withArgs(null, 'Stream can not be recorded').callCount).to.equal(1);
-      });
+                    onSignalingMessage(arbitraryMessage);
 
-      it('should return an error if the stream has no media', function() {
-        var callback = sinon.stub();
-        var returnFalse = sinon.stub().returns(false);
-        mocks.socketInstance.room.streams[streamId].hasVideo = returnFalse;
-        mocks.socketInstance.room.streams[streamId].hasAudio = returnFalse;
-        mocks.socketInstance.room.streams[streamId].hasScreen = returnFalse;
+                    expect(mocks.roomControllerInstance.processSignaling
+                            .withArgs(arbitraryMessage.streamId).callCount).to.equal(1);
+                  });
+                });
 
-        onStartRecorder(subscriberOptions, callback);
+                describe('on Update Stream Attributes', function() {
+                  let stream, streamId;
+                  beforeEach(function() {
+                    for (let st of room.streams.values()) {
+                        stream = st;
+                        streamId = stream.getID();
+                    }
+                    stream.getDataSubscribers = sinon.stub().returns([client.id]);
+                    stream.setAttributes = sinon.stub();
+                  });
 
-        expect(callback.withArgs(null, 'Stream can not be recorded').callCount).to.equal(1);
-      });
+                  it('should succeed if stream exists', function() {
+                    var msg = {id: streamId};
 
-      describe('when receiving events from RoomController', function() {
-        var callback = sinon.stub();
+                    onUpdateStreamAttributes(msg);
 
-        it('should call addExternalOutput', function() {
-          onStartRecorder(subscriberOptions, callback);
+                    expect(mocks.socketInstance.emit.withArgs('onUpdateAttributeStream', msg)
+                          .callCount).to.equal(1);
+                  });
 
-          expect(mocks.roomControllerInstance.addExternalOutput.callCount).to.equal(1);
-        });
+                  it('should fail if stream does not exist', function() {
+                    var msg = {id: 'streamId2'};
 
-        it('should return ok if when receiving success state', function() {
-          var signMes = 'success';
-          mocks.roomControllerInstance.addExternalOutput.callsArgWith(2, signMes);
+                    onUpdateStreamAttributes(msg);
 
-          onStartRecorder(subscriberOptions, callback);
+                    expect(mocks.socketInstance.emit.withArgs('onUpdateAttributeStream', msg)
+                          .callCount).to.equal(0);
+                  });
+                });
 
-          expect(callback.callCount).to.equal(1);
-        });
+                describe('on Unsubscribe', function() {
+                  let stream, streamId;
+                  beforeEach(function() {
+                    for (const st of room.streams.values()) {
+                        stream = st;
+                        streamId = stream.getID();
+                    }
+                    stream.getDataSubscribers = sinon.stub().returns([client.id]);
+                    room.controller = mocks.roomControllerInstance;
+                    client.user.permissions = {};
+                    client.user.permissions[Permission.PUBLISH] = true;
+                    client.user.permissions[Permission.SUBSCRIBE] = true;
+                  });
 
-        it('should return an error if when receiving a failed state', function() {
-          var signMes = 'failed';
-          mocks.roomControllerInstance.addExternalOutput.callsArgWith(2, signMes);
+                  it('should fail if user is undefined', function() {
+                    var callback = sinon.stub();
 
-          onStartRecorder(subscriberOptions, callback);
+                    client.user = undefined;
 
-          expect(callback.withArgs(null, 'Unable to subscribe to stream for recording, ' +
-                         'publisher not present').callCount).to.equal(1);
-        });
-      });
-    });
+                    onUnsubscribe(streamId, callback);
 
-    describe('on Stop Recorder', function() {
-      var subscriberOptions = {};
+                    expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
+                  });
 
-      beforeEach(function() {
-        var sockets = ['streamId1'];
-        mocks.socketInstance.streams = [];
-        mocks.socketInstance.user = {};
-        mocks.socketInstance.room = {
-          controller: mocks.roomControllerInstance,
-          sockets: sockets,
-          streams: {
-            streamId1: {
-              getDataSubscribers: sinon.stub().returns(sockets),
-              setAttributes: sinon.stub()
-            }
-          }
-        };
-        mocks.socketInstance.user.permissions = {};
-        mocks.socketInstance.user.permissions[Permission.RECORD] = true;
-        mocks.socketInstance.user.permissions[Permission.PUBLISH] = true;
-      });
+                  it('should fail if user is not authorized', function() {
+                    var callback = sinon.stub();
 
-      it('should fail if user is undefined', function() {
-        var callback = sinon.stub();
-        mocks.socketInstance.user = undefined;
+                    client.user.permissions[Permission.SUBSCRIBE] = false;
 
-        onStopRecorder(subscriberOptions, callback);
+                    onUnsubscribe(streamId, callback);
 
-        expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
-      });
+                    expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
+                  });
 
-      it('should fail if user is not authorized', function() {
-        var callback = sinon.stub();
-        mocks.socketInstance.user.permissions[Permission.RECORD] = false;
+                  it('should do nothing if stream does not exist', function() {
+                    var callback = sinon.stub();
+                    streamId = 'unknownStreamId';
 
-        onStopRecorder(subscriberOptions, callback);
+                    onUnsubscribe(streamId, callback);
 
-        expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
-      });
+                    expect(callback.callCount).to.equal(0);
+                  });
 
-      it('should succeed if authorized', function() {
-        var callback = sinon.stub();
+                  it('should call removeSubscriber when succeded', function() {
+                    var callback = sinon.stub();
 
-        onStopRecorder(subscriberOptions, callback);
+                    onUnsubscribe(streamId, callback);
 
-        expect(mocks.roomControllerInstance.removeExternalOutput.callCount).to.equal(1);
-      });
-    });
+                    expect(mocks.roomControllerInstance.removeSubscriber.callCount).to.equal(1);
+                    expect(callback.withArgs(true).callCount).to.equal(1);
+                  });
 
-    describe('on Unpublish', function() {
-      var streamId;
-      beforeEach(function() {
-        var sockets = ['streamId1'];
-        mocks.socketInstance.streams = [];
-        mocks.socketInstance.user = {};
-        mocks.socketInstance.room = {
-          controller: mocks.roomControllerInstance,
-          sockets: sockets,
-          streams: {
-            streamId1: {
-              getDataSubscribers: sinon.stub().returns(sockets),
-              setAttributes: sinon.stub()
-            }
-          }
-        };
-        mocks.socketInstance.user.permissions = {};
-        mocks.socketInstance.user.permissions[Permission.PUBLISH] = true;
+                  it('should call removeSubscriber when succeded (audio only streams) ',
+                      function() {
+                    var callback = sinon.stub();
+                    var returnFalse = sinon.stub().returns(false);
+                    client.room.getStreamById(streamId).hasVideo = returnFalse;
+                    client.room.getStreamById(streamId).hasScreen = returnFalse;
 
-        var options = {audio: true, video: true, screen: true, data: true},
-            sdp = '',
-            callback = sinon.stub();
+                    onUnsubscribe(streamId, callback);
 
-        onPublish(options, sdp, callback);
+                    expect(mocks.roomControllerInstance.removeSubscriber.callCount).to.equal(1);
+                    expect(callback.withArgs(true).callCount).to.equal(1);
+                  });
 
-        streamId = callback.args[0][0];
-      });
+                  it('should call removeSubscriber when succeded (video only streams) ',
+                      function() {
+                    var callback = sinon.stub();
+                    var returnFalse = sinon.stub().returns(false);
+                    client.room.getStreamById(streamId).hasAudio = returnFalse;
+                    client.room.getStreamById(streamId).hasScreen = returnFalse;
 
-      it('should fail if user is undefined', function() {
-        var callback = sinon.stub();
+                    onUnsubscribe(streamId, callback);
 
-        mocks.socketInstance.user = undefined;
+                    expect(mocks.roomControllerInstance.removeSubscriber.callCount).to.equal(1);
+                    expect(callback.withArgs(true).callCount).to.equal(1);
+                  });
 
-        onUnpublish(streamId, callback);
+                  it('should call removeSubscriber when succeded (screen only streams) ',
+                      function() {
+                    var callback = sinon.stub();
+                    var returnFalse = sinon.stub().returns(false);
+                    client.room.getStreamById(streamId).hasAudio = returnFalse;
+                    client.room.getStreamById(streamId).hasVideo = returnFalse;
 
-        expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
-      });
+                    onUnsubscribe(streamId, callback);
 
-      it('should fail if user is not authorized', function() {
-        var callback = sinon.stub();
+                    expect(mocks.roomControllerInstance.removeSubscriber.callCount).to.equal(1);
+                    expect(callback.withArgs(true).callCount).to.equal(1);
+                  });
 
-        mocks.socketInstance.user.permissions[Permission.PUBLISH] = false;
+                  it('should not call removePublisher in p2p rooms', function() {
+                    var callback = sinon.stub();
 
-        onUnpublish(streamId, callback);
+                    room.p2p = true;
 
-        expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
-      });
+                    onUnsubscribe(streamId, callback);
 
-      it('should do nothing if stream does not exist', function() {
-        var callback = sinon.stub();
-        streamId = 'unknownStreamId';
+                    expect(mocks.roomControllerInstance.removeSubscriber.callCount).to.equal(0);
+                    expect(callback.withArgs(true).callCount).to.equal(1);
+                  });
+                });
 
-        onUnpublish(streamId, callback);
+                describe('on Unpublish', function() {
+                  let stream, streamId;
+                  beforeEach(function() {
+                    for (const st of room.streams.values()) {
+                        stream = st;
+                        streamId = stream.getID();
+                    }
+                    stream.getDataSubscribers = sinon.stub().returns([client.id]);
+                    room.controller = mocks.roomControllerInstance;
+                    client.user.permissions = {};
+                    client.user.permissions[Permission.PUBLISH] = true;
+                    client.user.permissions[Permission.SUBSCRIBE] = true;
+                  });
 
-        expect(callback.callCount).to.equal(0);
-      });
+                  it('should fail if user is undefined', function() {
+                    var callback = sinon.stub();
 
-      it('should send a onRemoveStream event when succeded', function() {
-        var callback = sinon.stub();
+                    client.user = undefined;
 
-        onUnpublish(streamId, callback);
+                    onUnpublish(streamId, callback);
 
-        expect(mocks.roomControllerInstance.removePublisher.withArgs(streamId).callCount)
+                    expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
+                  });
+
+                  it('should fail if user is not authorized', function() {
+                    var callback = sinon.stub();
+
+                    client.user.permissions[Permission.PUBLISH] = false;
+
+                    onUnpublish(streamId, callback);
+
+                    expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
+                  });
+
+                  it('should do nothing if stream does not exist', function() {
+                    var callback = sinon.stub();
+                    streamId = 'unknownStreamId';
+
+                    onUnpublish(streamId, callback);
+
+                    expect(callback.callCount).to.equal(0);
+                  });
+
+                  it('should send a onRemoveStream event when succeded', function() {
+                    var callback = sinon.stub();
+
+                    onUnpublish(streamId, callback);
+
+                    expect(mocks.roomControllerInstance.removePublisher.withArgs(streamId)
+                            .callCount).to.equal(1);
+                    expect(mocks.socketInstance.emit.withArgs('onRemoveStream').callCount)
+                          .to.equal(1);
+                    expect(callback.withArgs(true).callCount).to.equal(1);
+                  });
+
+                  it('should send a onRemoveStream event when succeded (audio only streams) ',
+                      function() {
+                    var callback = sinon.stub();
+                    var returnFalse = sinon.stub().returns(false);
+                    client.room.getStreamById(streamId).hasVideo = returnFalse;
+                    client.room.getStreamById(streamId).hasScreen = returnFalse;
+
+                    onUnpublish(streamId, callback);
+
+                    expect(mocks.roomControllerInstance.removePublisher.withArgs(streamId)
+                          .callCount).to.equal(1);
+                    expect(mocks.socketInstance.emit.withArgs('onRemoveStream').callCount)
+                          .to.equal(1);
+                    expect(callback.withArgs(true).callCount).to.equal(1);
+                  });
+
+                  it('should send a onRemoveStream event when succeded (video only streams) ',
+                      function() {
+                    var callback = sinon.stub();
+                    var returnFalse = sinon.stub().returns(false);
+                    client.room.getStreamById(streamId).hasAudio = returnFalse;
+                    client.room.getStreamById(streamId).hasScreen = returnFalse;
+
+                    onUnpublish(streamId, callback);
+
+                    expect(mocks.roomControllerInstance.removePublisher.withArgs(streamId)
+                          .callCount).to.equal(1);
+                    expect(mocks.socketInstance.emit.withArgs('onRemoveStream').callCount)
                             .to.equal(1);
-        expect(mocks.socketInstance.emit.withArgs('onRemoveStream').callCount).to.equal(1);
-        expect(callback.withArgs(true).callCount).to.equal(1);
-      });
+                    expect(callback.withArgs(true).callCount).to.equal(1);
+                  });
 
-      it('should send a onRemoveStream event when succeded (audio only streams) ', function() {
-        var callback = sinon.stub();
-        var returnFalse = sinon.stub().returns(false);
-        mocks.socketInstance.room.streams[streamId].hasVideo = returnFalse;
-        mocks.socketInstance.room.streams[streamId].hasScreen = returnFalse;
+                  it('should send a onRemoveStream event when succeded (screen only streams) ',
+                      function() {
+                    var callback = sinon.stub();
+                    var returnFalse = sinon.stub().returns(false);
+                    client.room.getStreamById(streamId).hasAudio = returnFalse;
+                    client.room.getStreamById(streamId).hasVideo = returnFalse;
 
-        onUnpublish(streamId, callback);
+                    onUnpublish(streamId, callback);
 
-        expect(mocks.roomControllerInstance.removePublisher.withArgs(streamId).callCount)
+                    expect(mocks.roomControllerInstance.removePublisher.withArgs(streamId)
+                          .callCount).to.equal(1);
+                    expect(mocks.socketInstance.emit.withArgs('onRemoveStream').callCount)
                             .to.equal(1);
-        expect(mocks.socketInstance.emit.withArgs('onRemoveStream').callCount).to.equal(1);
-        expect(callback.withArgs(true).callCount).to.equal(1);
-      });
+                    expect(callback.withArgs(true).callCount).to.equal(1);
+                  });
 
-      it('should send a onRemoveStream event when succeded (video only streams) ', function() {
-        var callback = sinon.stub();
-        var returnFalse = sinon.stub().returns(false);
-        mocks.socketInstance.room.streams[streamId].hasAudio = returnFalse;
-        mocks.socketInstance.room.streams[streamId].hasScreen = returnFalse;
+                  it('should not call removePublisher in p2p rooms', function() {
+                    var callback = sinon.stub();
 
-        onUnpublish(streamId, callback);
+                    room.p2p = true;
 
-        expect(mocks.roomControllerInstance.removePublisher.withArgs(streamId).callCount)
-                            .to.equal(1);
-        expect(mocks.socketInstance.emit.withArgs('onRemoveStream').callCount).to.equal(1);
-        expect(callback.withArgs(true).callCount).to.equal(1);
-      });
+                    onUnpublish(streamId, callback);
 
-      it('should send a onRemoveStream event when succeded (screen only streams) ', function() {
-        var callback = sinon.stub();
-        var returnFalse = sinon.stub().returns(false);
-        mocks.socketInstance.room.streams[streamId].hasAudio = returnFalse;
-        mocks.socketInstance.room.streams[streamId].hasVideo = returnFalse;
+                    expect(mocks.roomControllerInstance.removePublisher
+                            .withArgs(streamId).callCount).to.equal(0);
+                    expect(mocks.socketInstance.emit.withArgs('onRemoveStream').callCount)
+                          .to.equal(1);
+                    expect(callback.withArgs(true).callCount).to.equal(1);
+                  });
+                });
 
-        onUnpublish(streamId, callback);
+                describe('on Disconnect', function() {
+                  beforeEach(function() {
+                  });
 
-        expect(mocks.roomControllerInstance.removePublisher.withArgs(streamId).callCount)
-                            .to.equal(1);
-        expect(mocks.socketInstance.emit.withArgs('onRemoveStream').callCount).to.equal(1);
-        expect(callback.withArgs(true).callCount).to.equal(1);
-      });
+                  it('should send a onRemoveStream event', function() {
+                    onDisconnect();
 
-      it('should not call removePublisher in p2p rooms', function() {
-        var callback = sinon.stub();
+                    expect(mocks.socketInstance.emit.withArgs('onRemoveStream').callCount)
+                          .to.equal(1);
+                  });
 
-        mocks.socketInstance.room.p2p = true;
+                  it('should call removePublisher', function() {
+                    onDisconnect();
 
-        onUnpublish(streamId, callback);
+                    expect(mocks.roomControllerInstance.removePublisher.callCount).to.equal(1);
+                  });
 
-        expect(mocks.roomControllerInstance.removePublisher.withArgs(streamId).callCount)
-                              .to.equal(0);
-        expect(mocks.socketInstance.emit.withArgs('onRemoveStream').callCount).to.equal(1);
-        expect(callback.withArgs(true).callCount).to.equal(1);
-      });
-    });
+                  it('should not call removePublisher if room is p2p', function() {
+                    room.p2p = true;
 
-    describe('on Unsubscribe', function() {
-      var streamId;
-      beforeEach(function() {
-        var sockets = ['streamId1'];
-        mocks.socketInstance.streams = [];
-        mocks.socketInstance.user = {};
-        mocks.socketInstance.room = {
-          controller: mocks.roomControllerInstance,
-          sockets: sockets,
-          streams: {
-            streamId1: {
-              getDataSubscribers: sinon.stub().returns(sockets),
-              setAttributes: sinon.stub()
-            }
-          }
-        };
-        mocks.socketInstance.user.permissions = {};
-        mocks.socketInstance.user.permissions[Permission.PUBLISH] = true;
-        mocks.socketInstance.user.permissions[Permission.SUBSCRIBE] = true;
+                    onDisconnect();
 
-        var options = {audio: true, video: true, screen: true, data: true},
-            sdp = '',
-            callback = sinon.stub();
+                    expect(mocks.roomControllerInstance.removePublisher.callCount).to.equal(0);
+                  });
+                });
+              });
+            });
+          });
 
-        onPublish(options, sdp, callback);
+          describe('on Start Recorder', function() {
+            let subscriberOptions, streamId, client;
 
-        streamId = callback.args[0][0];
-      });
+            beforeEach(function() {
+              for (let c of room.clients.values()) {
+                client = c;
+              }
+              client.user.permissions[Permission.PUBLISH] = true;
+              client.user.permissions[Permission.RECORD] = true;
 
-      it('should fail if user is undefined', function() {
-        var callback = sinon.stub();
+              var options = {audio: true, video: true, data: true},
+                  sdp = '',
+                  callback = sinon.stub();
 
-        mocks.socketInstance.user = undefined;
+              onPublish(options, sdp, callback);
 
-        onUnsubscribe(streamId, callback);
+              streamId = callback.args[0][0];
 
-        expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
-      });
+              subscriberOptions= {
+                   to: streamId
+                 };
+            });
 
-      it('should fail if user is not authorized', function() {
-        var callback = sinon.stub();
+            it('should fail if user is undefined', function() {
+              var callback = sinon.stub();
+              client.user = undefined;
 
-        mocks.socketInstance.user.permissions[Permission.SUBSCRIBE] = false;
+              onStartRecorder(subscriberOptions, callback);
 
-        onUnsubscribe(streamId, callback);
+              expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
+            });
 
-        expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
-      });
+            it('should fail if user is not authorized', function() {
+              var callback = sinon.stub();
+              client.user.permissions[Permission.RECORD] = false;
 
-      it('should do nothing if stream does not exist', function() {
-        var callback = sinon.stub();
-        streamId = 'unknownStreamId';
+              onStartRecorder(subscriberOptions, callback);
 
-        onUnsubscribe(streamId, callback);
+              expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
+            });
 
-        expect(callback.callCount).to.equal(0);
-      });
+            it('should return an error if the room is p2p', function() {
+              var callback = sinon.stub();
+              room.p2p = true;
 
-      it('should call removeSubscriber when succeded', function() {
-        var callback = sinon.stub();
+              onStartRecorder(subscriberOptions, callback);
 
-        onUnsubscribe(streamId, callback);
+              expect(callback.withArgs(null, 'Stream can not be recorded').callCount).to.equal(1);
+            });
 
-        expect(mocks.roomControllerInstance.removeSubscriber.callCount).to.equal(1);
-        expect(callback.withArgs(true).callCount).to.equal(1);
-      });
+            it('should return an error if the stream has no media', function() {
+              var callback = sinon.stub();
+              var returnFalse = sinon.stub().returns(false);
+              client.room.getStreamById(streamId).hasVideo = returnFalse;
+              client.room.getStreamById(streamId).hasAudio = returnFalse;
+              client.room.getStreamById(streamId).hasScreen = returnFalse;
 
-      it('should call removeSubscriber when succeded (audio only streams) ', function() {
-        var callback = sinon.stub();
-        var returnFalse = sinon.stub().returns(false);
-        mocks.socketInstance.room.streams[streamId].hasVideo = returnFalse;
-        mocks.socketInstance.room.streams[streamId].hasScreen = returnFalse;
+              onStartRecorder(subscriberOptions, callback);
 
-        onUnsubscribe(streamId, callback);
+              expect(callback.withArgs(null, 'Stream can not be recorded').callCount).to.equal(1);
+            });
 
-        expect(mocks.roomControllerInstance.removeSubscriber.callCount).to.equal(1);
-        expect(callback.withArgs(true).callCount).to.equal(1);
-      });
+            describe('when receiving events from RoomController', function() {
+              var callback = sinon.stub();
 
-      it('should call removeSubscriber when succeded (video only streams) ', function() {
-        var callback = sinon.stub();
-        var returnFalse = sinon.stub().returns(false);
-        mocks.socketInstance.room.streams[streamId].hasAudio = returnFalse;
-        mocks.socketInstance.room.streams[streamId].hasScreen = returnFalse;
+              it('should call addExternalOutput', function() {
+                onStartRecorder(subscriberOptions, callback);
 
-        onUnsubscribe(streamId, callback);
+                expect(mocks.roomControllerInstance.addExternalOutput.callCount).to.equal(1);
+              });
 
-        expect(mocks.roomControllerInstance.removeSubscriber.callCount).to.equal(1);
-        expect(callback.withArgs(true).callCount).to.equal(1);
-      });
+              it('should return ok if when receiving success state', function() {
+                var signMes = 'success';
+                mocks.roomControllerInstance.addExternalOutput.callsArgWith(2, signMes);
 
-      it('should call removeSubscriber when succeded (screen only streams) ', function() {
-        var callback = sinon.stub();
-        var returnFalse = sinon.stub().returns(false);
-        mocks.socketInstance.room.streams[streamId].hasAudio = returnFalse;
-        mocks.socketInstance.room.streams[streamId].hasVideo = returnFalse;
+                onStartRecorder(subscriberOptions, callback);
 
-        onUnsubscribe(streamId, callback);
+                expect(callback.callCount).to.equal(1);
+              });
 
-        expect(mocks.roomControllerInstance.removeSubscriber.callCount).to.equal(1);
-        expect(callback.withArgs(true).callCount).to.equal(1);
-      });
+              it('should return an error if when receiving a failed state', function() {
+                var signMes = 'failed';
+                mocks.roomControllerInstance.addExternalOutput.callsArgWith(2, signMes);
 
-      it('should not call removePublisher in p2p rooms', function() {
-        var callback = sinon.stub();
+                onStartRecorder(subscriberOptions, callback);
 
-        mocks.socketInstance.room.p2p = true;
+                expect(callback.withArgs(null, 'Unable to subscribe to stream for recording, ' +
+                               'publisher not present').callCount).to.equal(1);
+              });
+            });
 
-        onUnsubscribe(streamId, callback);
+            describe('on Stop Recorder', function() {
+              var subscriberOptions = {};
 
-        expect(mocks.roomControllerInstance.removeSubscriber.callCount).to.equal(0);
-        expect(callback.withArgs(true).callCount).to.equal(1);
-      });
-    });
+              beforeEach(function() {
+                room.controller = mocks.roomControllerInstance;
+              });
 
-    describe('on Disconnect', function() {
-      beforeEach(function() {
-        var sockets = ['streamId1'];
-        var streams = sockets;
-        mocks.socketInstance.streams = streams;
-        mocks.socketInstance.user = {};
-        mocks.socketInstance.room = {
-          controller: mocks.roomControllerInstance,
-          sockets: sockets,
-          streams: {
-            streamId1: {
-              hasAudio: sinon.stub().returns(true),
-              hasVideo: sinon.stub().returns(true),
-              hasScreen: sinon.stub().returns(true),
-              getDataSubscribers: sinon.stub().returns(sockets),
-              removeDataSubscriber: sinon.stub(),
-              setAttributes: sinon.stub()
-            }
-          }
-        };
-      });
+              it('should fail if user is undefined', function() {
+                var callback = sinon.stub();
+                client.user = undefined;
 
-      it('should send a onRemoveStream event', function() {
-        onDisconnect();
+                onStopRecorder(subscriberOptions, callback);
 
-        expect(mocks.socketInstance.emit.withArgs('onRemoveStream').callCount).to.equal(1);
-      });
+                expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
+              });
 
-      it('should call removePublisher', function() {
-        onDisconnect();
+              it('should fail if user is not authorized', function() {
+                var callback = sinon.stub();
+                client.user.permissions[Permission.RECORD] = false;
 
-        expect(mocks.roomControllerInstance.removePublisher.callCount).to.equal(1);
-      });
+                onStopRecorder(subscriberOptions, callback);
 
-      it('should not call removePublisher if room is p2p', function() {
-        mocks.socketInstance.room.p2p = true;
+                expect(callback.withArgs(null, 'Unauthorized').callCount).to.equal(1);
+              });
 
-        onDisconnect();
+              it('should succeed if authorized', function() {
+                var callback = sinon.stub();
 
-        expect(mocks.roomControllerInstance.removePublisher.callCount).to.equal(0);
+                onStopRecorder(subscriberOptions, callback);
+
+                expect(mocks.roomControllerInstance.removeExternalOutput.callCount).to.equal(1);
+              });
+            });
+          });
+        });
       });
     });
   });

--- a/erizo_controller/test/utils.js
+++ b/erizo_controller/test/utils.js
@@ -88,6 +88,7 @@ var reset = module.exports.reset = function() {
   });
 
   module.exports.socketInstance = {
+    conn: {transport: {socket: {internalOnClose: undefined}}},
     disconnect: sinon.stub(),
     emit: sinon.stub(),
     on: sinon.stub()

--- a/erizo_controller/test/utils.js
+++ b/erizo_controller/test/utils.js
@@ -78,7 +78,8 @@ var reset = module.exports.reset = function() {
   };
 
   module.exports.crypto = createMock('crypto', {
-    createHmac: sinon.stub().returns(module.exports.signature)
+    createHmac: sinon.stub().returns(module.exports.signature),
+    randomBytes: sinon.stub().returns(new Buffer(16))
   });
 
   module.exports.http = createMock('http', {


### PR DESCRIPTION
**Description**

Some code refactoring in Erizo Controller. Now we use the next models to improve code readability: 
* Stream: this one is not new, represents a published stream. 
* Channel: a basic transport channel that checks received tokens.
* Client: represents an end client connection. Stores its room, streams, etc. Handles events received from the client side.
* Room: represents a room, with clients and streams.

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed. All changes are in the backend.

[] It includes documentation for these changes in `/doc`.