### PR TITLE
Add an option to force the client to use only TURN candidates

### DIFF
--- a/doc/client_api.md
+++ b/doc/client_api.md
@@ -389,6 +389,12 @@ room.addEventListener("stream-added", function(event) {
 room.publish(localStream, {maxVideoBW:300});
 ```
 
+We can also force the client to use a TURN server when publishing by setting the next parameter:
+
+```
+room.publish(localStream, {forceTurn: true});
+```
+
 In `room.publish` you can include a callback with two parameters, `id` and `error`. If the stream has been published, `id` contains the id of that stream. On the other hand, if there has been any kind of error, `id` is `undefined` and the error is described in `error`.
 
 <example>
@@ -448,6 +454,12 @@ room.addEventListener("stream-subscribed", function(streamEvt) {
   console.log("Stream subscribed");
 });
 room.subscribe(stream, {audio: true, video: false});
+```
+
+We can also force the client to use a TURN server when subscribing by setting the next parameter:
+
+```
+room.publish(localStream, {forceTurn: true});
 ```
 
 In `room.subscribe` you can include a callback with two parameters, `result` and `error`. If the stream has been subscribed, `result` is true. On the other hand, if there has been any kind of error, `result` is `undefined` and the error is described in `error`.

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -104,6 +104,7 @@ const Room = (altIo, altConnection, specInput) => {
       maxVideoBW: stream.maxVideoBW,
       limitMaxAudioBW: spec.maxAudioBW,
       limitMaxVideoBW: spec.maxVideoBW,
+      forceTurn: stream.forceTurn,
     };
     return options;
   };
@@ -166,7 +167,8 @@ const Room = (altIo, altConnection, specInput) => {
       maxVideoBW: options.maxVideoBW,
       limitMaxAudioBW: spec.maxAudioBW,
       limitMaxVideoBW: spec.maxVideoBW,
-      iceServers: that.iceServers };
+      iceServers: that.iceServers,
+      forceTurn: stream.forceTurn };
     if (!isRemote) {
       connectionOpts.simulcast = options.simulcast;
     }
@@ -298,11 +300,12 @@ const Room = (altIo, altConnection, specInput) => {
       return;
     }
     stream = remoteStreams.get(arg.id);
-
-    remoteStreams.remove(arg.id);
-    removeStream(stream);
-    const evt = StreamEvent({ type: 'stream-removed', stream });
-    that.dispatchEvent(evt);
+    if (stream) {
+      remoteStreams.remove(arg.id);
+      removeStream(stream);
+      const evt = StreamEvent({ type: 'stream-removed', stream });
+      that.dispatchEvent(evt);
+    }
   };
 
   // The socket has disconnected
@@ -623,6 +626,8 @@ const Room = (altIo, altConnection, specInput) => {
       options.minVideoBW = spec.defaultVideoBW;
     }
 
+    stream.forceTurn = options.forceTurn;
+
     options.simulcast = options.simulcast || false;
 
     options.muteStream = {
@@ -743,6 +748,8 @@ const Room = (altIo, altConnection, specInput) => {
           audio: stream.audioMuted,
           video: stream.videoMuted,
         };
+
+        stream.forceTurn = options.forceTurn;
 
         if (that.p2p) {
           socket.sendSDP('subscribe', { streamId: stream.getID(), metadata: options.metadata });

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -19,6 +19,9 @@ const BaseStack = (specInput) => {
   if (specBase.iceServers !== undefined) {
     that.pcConfig.iceServers = specBase.iceServers;
   }
+  if (specBase.forceTurn === true) {
+    that.pcConfig.iceTransportPolicy = 'relay';
+  }
   if (specBase.audio === undefined) {
     specBase.audio = true;
   }


### PR DESCRIPTION
**Description**

Add an option to force the client to use only TURN candidates

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

We can now force the client to use a TURN server when publishing/subscribing by setting the next parameter:
```js
room.publish(localStream, {forceTurn: true});
```
- [x] It includes documentation for these changes in `/doc`.