### PR TITLE
Apply coding style to ExternalOutput

### DIFF
--- a/erizo/src/erizo/media/ExternalOutput.cpp
+++ b/erizo/src/erizo/media/ExternalOutput.cpp
@@ -16,12 +16,16 @@ using std::memcpy;
 namespace erizo {
 
 DEFINE_LOGGER(ExternalOutput, "media.ExternalOutput");
-ExternalOutput::ExternalOutput(const std::string& outputUrl)
-  : audioQueue_(5.0, 10.0), videoQueue_(5.0, 10.0), inited_(false),
-    video_stream_(NULL), audio_stream_(NULL), first_video_timestamp_(-1), first_audio_timestamp_(-1),
-    first_data_received_(), video_offset_ms_(-1), audio_offset_ms_(-1), vp8SearchState_(lookingForStart),
-    needToSendFir_(true) {
-  ELOG_DEBUG("Creating output to %s", outputUrl.c_str());
+ExternalOutput::ExternalOutput(const std::string& output_url)
+  : audio_queue_{5.0, 10.0}, video_queue_{5.0, 10.0}, inited_{false}, video_stream_{nullptr},
+    audio_stream_{nullptr}, unpackaged_size_{0}, video_source_ssrc_{0},
+    unpackaged_buffer_part_{unpackaged_buffer_}, first_video_timestamp_{-1}, first_audio_timestamp_{-1},
+    first_data_received_{}, video_offset_ms_{-1}, audio_offset_ms_{-1}, vp8_search_state_{kLookingForStart},
+    need_to_send_fir_{true} {
+  ELOG_DEBUG("Creating output to %s", output_url.c_str());
+
+  fb_sink_ = nullptr;
+  sink_fb_source_ = this;
 
   // TODO(pedro): these should really only be called once per application run
   av_register_all();
@@ -30,15 +34,15 @@ ExternalOutput::ExternalOutput(const std::string& outputUrl)
   fec_receiver_.reset(webrtc::UlpfecReceiver::Create(this));
 
   // our video timebase is easy: always 90 khz.  We'll set audio once we receive a packet and can inspect its header.
-  videoQueue_.setTimebase(90000);
+  video_queue_.setTimebase(90000);
 
   context_ = avformat_alloc_context();
-  if (context_ == NULL) {
+  if (context_ == nullptr) {
     ELOG_ERROR("Error allocating memory for IO context");
   } else {
-    outputUrl.copy(context_->filename, sizeof(context_->filename), 0);
+    output_url.copy(context_->filename, sizeof(context_->filename), 0);
 
-    context_->oformat = av_guess_format(NULL,  context_->filename, NULL);
+    context_->oformat = av_guess_format(nullptr,  context_->filename, nullptr);
     if (!context_->oformat) {
       ELOG_ERROR("Error guessing format %s", context_->filename);
     } else {
@@ -47,12 +51,6 @@ ExternalOutput::ExternalOutput(const std::string& outputUrl)
       // We'll figure this out once we start receiving data; it's either PCM or OPUS
     }
   }
-
-  unpackagedBufferpart_ = unpackagedBuffer_;
-  sink_fb_source_ = this;
-  fb_sink_ = nullptr;
-  unpackagedSize_ = 0;
-  videoSourceSsrc_ = 0;
 }
 
 bool ExternalOutput::init() {
@@ -81,22 +79,22 @@ void ExternalOutput::close() {
   cond_.notify_one();
   thread_.join();
 
-  if (audio_stream_ != NULL && video_stream_ != NULL && context_ != NULL) {
+  if (audio_stream_ != nullptr && video_stream_ != nullptr && context_ != nullptr) {
       av_write_trailer(context_);
   }
 
-  if (video_stream_ && video_stream_->codec != NULL) {
+  if (video_stream_ && video_stream_->codec != nullptr) {
       avcodec_close(video_stream_->codec);
   }
 
-  if (audio_stream_ && audio_stream_->codec != NULL) {
+  if (audio_stream_ && audio_stream_->codec != nullptr) {
       avcodec_close(audio_stream_->codec);
   }
 
-  if (context_ != NULL) {
+  if (context_ != nullptr) {
       avio_close(context_->pb);
       avformat_free_context(context_);
-      context_ = NULL;
+      context_ = nullptr;
   }
 
   ELOG_DEBUG("Closed Successfully");
@@ -107,7 +105,7 @@ void ExternalOutput::receiveRawData(const RawDataPacket& /*packet*/) {
 }
 // This is called by our fec_ object once it recovers a packet.
 bool ExternalOutput::OnRecoveredPacket(const uint8_t* rtp_packet, size_t rtp_packet_length) {
-  videoQueue_.pushPacket((const char*)rtp_packet, rtp_packet_length);
+  video_queue_.pushPacket((const char*)rtp_packet, rtp_packet_length);
   return true;
 }
 
@@ -118,11 +116,11 @@ int32_t ExternalOutput::OnReceivedPayloadData(const uint8_t* payload_data, size_
 }
 
 bool ExternalOutput::bufferCheck(RTPPayloadVP8* payload) {
-  if (payload->dataLength + unpackagedSize_ >= UNPACKAGE_BUFFER_SIZE) {
-    ELOG_ERROR("Not enough buffer. Dropping frame. Please adjust your UNPACKAGE_BUFFER_SIZE in ExternalOutput.h");
-    unpackagedSize_ = 0;
-    unpackagedBufferpart_ = unpackagedBuffer_;
-    vp8SearchState_ = lookingForStart;
+  if (payload->dataLength + unpackaged_size_ >= kUnpackageBufferSize) {
+    ELOG_ERROR("Not enough buffer. Dropping frame. Please adjust your kUnpackageBufferSize in ExternalOutput.h");
+    unpackaged_size_ = 0;
+    unpackaged_buffer_part_ = unpackaged_buffer_;
+    vp8_search_state_ = kLookingForStart;
     return false;
   }
   return true;
@@ -130,14 +128,14 @@ bool ExternalOutput::bufferCheck(RTPPayloadVP8* payload) {
 
 void ExternalOutput::writeAudioData(char* buf, int len) {
   RtpHeader* head = reinterpret_cast<RtpHeader*>(buf);
-  uint16_t currentAudioSequenceNumber = head->getSeqNumber();
-  if (first_audio_timestamp_ != -1 && currentAudioSequenceNumber != lastAudioSequenceNumber_ + 1) {
+  uint16_t current_audio_sequence_number = head->getSeqNumber();
+  if (first_audio_timestamp_ != -1 && current_audio_sequence_number != last_audio_sequence_number_ + 1) {
       // Something screwy.  We should always see sequence numbers incrementing monotonically.
       ELOG_DEBUG("Unexpected audio sequence number; current %d, previous %d",
-                  currentAudioSequenceNumber, lastAudioSequenceNumber_);
+                  current_audio_sequence_number, last_audio_sequence_number_);
   }
 
-  lastAudioSequenceNumber_ = currentAudioSequenceNumber;
+  last_audio_sequence_number_ = current_audio_sequence_number;
   if (first_audio_timestamp_ == -1) {
       first_audio_timestamp_ = head->getTimestamp();
   }
@@ -154,51 +152,51 @@ void ExternalOutput::writeAudioData(char* buf, int len) {
 
   initContext();
 
-  if (audio_stream_ == NULL) {
+  if (audio_stream_ == nullptr) {
       // not yet.
       return;
   }
 
-  long long currentTimestamp = head->getTimestamp();  // NOLINT
-  if (currentTimestamp - first_audio_timestamp_ < 0) {
+  long long current_timestamp = head->getTimestamp();  // NOLINT
+  if (current_timestamp - first_audio_timestamp_ < 0) {
       // we wrapped.  add 2^32 to correct this. We only handle a single wrap around
       // since that's 13 hours of recording, minimum.
-      currentTimestamp += 0xFFFFFFFF;
+      current_timestamp += 0xFFFFFFFF;
   }
 
-  long long timestampToWrite = (currentTimestamp - first_audio_timestamp_) /  // NOLINT
+  long long timestamp_to_write = (current_timestamp - first_audio_timestamp_) /  // NOLINT
                                     (audio_stream_->codec->sample_rate / audio_stream_->time_base.den);
   // generally 48000 / 1000 for the denominator portion, at least for opus
   // Adjust for our start time offset
 
   // in practice, our timebase den is 1000, so this operation is a no-op.
-  timestampToWrite += audio_offset_ms_ / (1000 / audio_stream_->time_base.den);
+  timestamp_to_write += audio_offset_ms_ / (1000 / audio_stream_->time_base.den);
 
-  AVPacket avpkt;
-  av_init_packet(&avpkt);
-  avpkt.data = reinterpret_cast<uint8_t*>(buf) + head->getHeaderLength();
-  avpkt.size = len - head->getHeaderLength();
-  avpkt.pts = timestampToWrite;
-  avpkt.stream_index = 1;
-  av_interleaved_write_frame(context_, &avpkt);   // takes ownership of the packet
+  AVPacket av_packet;
+  av_init_packet(&av_packet);
+  av_packet.data = reinterpret_cast<uint8_t*>(buf) + head->getHeaderLength();
+  av_packet.size = len - head->getHeaderLength();
+  av_packet.pts = timestamp_to_write;
+  av_packet.stream_index = 1;
+  av_interleaved_write_frame(context_, &av_packet);   // takes ownership of the packet
 }
 
 void ExternalOutput::writeVideoData(char* buf, int len) {
     RtpHeader* head = reinterpret_cast<RtpHeader*>(buf);
 
-    uint16_t currentVideoSeqNumber = head->getSeqNumber();
-    if (currentVideoSeqNumber != lastVideoSequenceNumber_ + 1) {
+    uint16_t current_video_sequence_number = head->getSeqNumber();
+    if (current_video_sequence_number != last_video_sequence_number_ + 1) {
         // Something screwy.  We should always see sequence numbers incrementing monotonically.
         ELOG_DEBUG("Unexpected video sequence number; current %d, previous %d",
-                  currentVideoSeqNumber, lastVideoSequenceNumber_);
+                  current_video_sequence_number, last_video_sequence_number_);
         // Set our search state to look for the start of a frame, and discard what we currently have (if anything).
         // it's now worthless.
-        vp8SearchState_ = lookingForStart;
-        unpackagedSize_ = 0;
-        unpackagedBufferpart_ = unpackagedBuffer_;
+        vp8_search_state_ = kLookingForStart;
+        unpackaged_size_ = 0;
+        unpackaged_buffer_part_ = unpackaged_buffer_;
     }
 
-    lastVideoSequenceNumber_ = currentVideoSeqNumber;
+    last_video_sequence_number_ = current_video_sequence_number;
 
     if (first_video_timestamp_ == -1) {
         first_video_timestamp_ = head->getTimestamp();
@@ -210,77 +208,77 @@ void ExternalOutput::writeVideoData(char* buf, int len) {
     erizo::RTPPayloadVP8* payload = parser.parseVP8(reinterpret_cast<unsigned char*>(buf + head->getHeaderLength()),
                                                     len - head->getHeaderLength());
 
-    bool endOfFrame = (head->getMarker() > 0);
-    bool startOfFrame = payload->beginningOfPartition;
+    bool end_of_frame = (head->getMarker() > 0);
+    bool start_of_frame = payload->beginningOfPartition;
 
     bool deliver = false;
-    switch (vp8SearchState_) {
-    case lookingForStart:
-      if (startOfFrame && endOfFrame) {
+    switch (vp8_search_state_) {
+    case kLookingForStart:
+      if (start_of_frame && end_of_frame) {
         // This packet is a standalone frame.  Send it on.  Look for start.
-        unpackagedSize_ = 0;
-        unpackagedBufferpart_ = unpackagedBuffer_;
+        unpackaged_size_ = 0;
+        unpackaged_buffer_part_ = unpackaged_buffer_;
         if (bufferCheck(payload)) {
-          memcpy(unpackagedBufferpart_, payload->data, payload->dataLength);
-          unpackagedSize_ += payload->dataLength;
-          unpackagedBufferpart_ += payload->dataLength;
+          memcpy(unpackaged_buffer_part_, payload->data, payload->dataLength);
+          unpackaged_size_ += payload->dataLength;
+          unpackaged_buffer_part_ += payload->dataLength;
           deliver = true;
         }
-      } else if (!startOfFrame && !endOfFrame) {
+      } else if (!start_of_frame && !end_of_frame) {
         // This is neither the start nor the end of a frame.  Reset our buffers.  Look for start.
-        unpackagedSize_ = 0;
-        unpackagedBufferpart_ = unpackagedBuffer_;
-      } else if (startOfFrame && !endOfFrame) {
+        unpackaged_size_ = 0;
+        unpackaged_buffer_part_ = unpackaged_buffer_;
+      } else if (start_of_frame && !end_of_frame) {
         // Found start frame.  Copy to buffers.  Look for our end.
         if (bufferCheck(payload)) {
-          memcpy(unpackagedBufferpart_, payload->data, payload->dataLength);
-          unpackagedSize_ += payload->dataLength;
-          unpackagedBufferpart_ += payload->dataLength;
-          vp8SearchState_ = lookingForEnd;
+          memcpy(unpackaged_buffer_part_, payload->data, payload->dataLength);
+          unpackaged_size_ += payload->dataLength;
+          unpackaged_buffer_part_ += payload->dataLength;
+          vp8_search_state_ = kLookingForEnd;
         }
-      } else {  // (!startOfFrame && endOfFrame)
+      } else {  // (!start_of_frame && end_of_frame)
         // We got the end of a frame.  Reset our buffers.
-        unpackagedSize_ = 0;
-        unpackagedBufferpart_ = unpackagedBuffer_;
+        unpackaged_size_ = 0;
+        unpackaged_buffer_part_ = unpackaged_buffer_;
       }
       break;
-    case lookingForEnd:
-      if (startOfFrame && endOfFrame) {
+    case kLookingForEnd:
+      if (start_of_frame && end_of_frame) {
         // Unexpected.  We were looking for the end of a frame, and got a whole new frame.
         // Reset our buffers, send this frame on, and go to the looking for start state.
-        vp8SearchState_ = lookingForStart;
-        unpackagedSize_ = 0;
-        unpackagedBufferpart_ = unpackagedBuffer_;
+        vp8_search_state_ = kLookingForStart;
+        unpackaged_size_ = 0;
+        unpackaged_buffer_part_ = unpackaged_buffer_;
         if (bufferCheck(payload)) {
-          memcpy(unpackagedBufferpart_, payload->data, payload->dataLength);
-          unpackagedSize_ += payload->dataLength;
-          unpackagedBufferpart_ += payload->dataLength;
+          memcpy(unpackaged_buffer_part_, payload->data, payload->dataLength);
+          unpackaged_size_ += payload->dataLength;
+          unpackaged_buffer_part_ += payload->dataLength;
           deliver = true;
         }
-      } else if (!startOfFrame && !endOfFrame) {
+      } else if (!start_of_frame && !end_of_frame) {
         // This is neither the start nor the end.  Add it to our unpackage buffer.
         if (bufferCheck(payload)) {
-          memcpy(unpackagedBufferpart_, payload->data, payload->dataLength);
-          unpackagedSize_ += payload->dataLength;
-          unpackagedBufferpart_ += payload->dataLength;
+          memcpy(unpackaged_buffer_part_, payload->data, payload->dataLength);
+          unpackaged_size_ += payload->dataLength;
+          unpackaged_buffer_part_ += payload->dataLength;
         }
-      } else if (startOfFrame && !endOfFrame) {
+      } else if (start_of_frame && !end_of_frame) {
         // Unexpected.  We got the start of a frame.  Clear out our buffer, toss this payload in,
         // and continue looking for the end.
-        unpackagedSize_ = 0;
-        unpackagedBufferpart_ = unpackagedBuffer_;
+        unpackaged_size_ = 0;
+        unpackaged_buffer_part_ = unpackaged_buffer_;
         if (bufferCheck(payload)) {
-          memcpy(unpackagedBufferpart_, payload->data, payload->dataLength);
-          unpackagedSize_ += payload->dataLength;
-          unpackagedBufferpart_ += payload->dataLength;
+          memcpy(unpackaged_buffer_part_, payload->data, payload->dataLength);
+          unpackaged_size_ += payload->dataLength;
+          unpackaged_buffer_part_ += payload->dataLength;
         }
-      } else {  // (!startOfFrame && endOfFrame)
+      } else {  // (!start_of_frame && end_of_frame)
         // Got the end of a frame.  Let's deliver and start looking for the start of a frame.
-        vp8SearchState_ = lookingForStart;
+        vp8_search_state_ = kLookingForStart;
         if (bufferCheck(payload)) {
-          memcpy(unpackagedBufferpart_, payload->data, payload->dataLength);
-          unpackagedSize_ += payload->dataLength;
-          unpackagedBufferpart_ += payload->dataLength;
+          memcpy(unpackaged_buffer_part_, payload->data, payload->dataLength);
+          unpackaged_size_ += payload->dataLength;
+          unpackaged_buffer_part_ += payload->dataLength;
           deliver = true;
         }
       }
@@ -289,46 +287,46 @@ void ExternalOutput::writeVideoData(char* buf, int len) {
 
     delete payload;
 
-    this->initContext();
-    if (video_stream_ == NULL) {
+    initContext();
+    if (video_stream_ == nullptr) {
       // could not init our context yet.
       return;
     }
 
     if (deliver) {
-      unpackagedBufferpart_ -= unpackagedSize_;
+      unpackaged_buffer_part_ -= unpackaged_size_;
 
-      long long currentTimestamp = head->getTimestamp();  // NOLINT
-      if (currentTimestamp - first_video_timestamp_ < 0) {
+      long long current_timestamp = head->getTimestamp();  // NOLINT
+      if (current_timestamp - first_video_timestamp_ < 0) {
         // we wrapped.  add 2^32 to correct this.
         // We only handle a single wrap around since that's ~13 hours of recording, minimum.
-        currentTimestamp += 0xFFFFFFFF;
+        current_timestamp += 0xFFFFFFFF;
       }
 
       // All of our video offerings are using a 90khz clock.
-      long long timestampToWrite = (currentTimestamp - first_video_timestamp_) /  // NOLINT
+      long long timestamp_to_write = (current_timestamp - first_video_timestamp_) /  // NOLINT
                                                 (90000 / video_stream_->time_base.den);
 
       // Adjust for our start time offset
 
       // in practice, our timebase den is 1000, so this operation is a no-op.
-      timestampToWrite += video_offset_ms_ / (1000 / video_stream_->time_base.den);
+      timestamp_to_write += video_offset_ms_ / (1000 / video_stream_->time_base.den);
 
-      AVPacket avpkt;
-      av_init_packet(&avpkt);
-      avpkt.data = unpackagedBufferpart_;
-      avpkt.size = unpackagedSize_;
-      avpkt.pts = timestampToWrite;
-      avpkt.stream_index = 0;
-      av_interleaved_write_frame(context_, &avpkt);   // takes ownership of the packet
-      unpackagedSize_ = 0;
-      unpackagedBufferpart_ = unpackagedBuffer_;
+      AVPacket av_packet;
+      av_init_packet(&av_packet);
+      av_packet.data = unpackaged_buffer_part_;
+      av_packet.size = unpackaged_size_;
+      av_packet.pts = timestamp_to_write;
+      av_packet.stream_index = 0;
+      av_interleaved_write_frame(context_, &av_packet);   // takes ownership of the packet
+      unpackaged_size_ = 0;
+      unpackaged_buffer_part_ = unpackaged_buffer_;
     }
 }
 
 int ExternalOutput::deliverAudioData_(std::shared_ptr<DataPacket> audio_packet) {
   std::shared_ptr<DataPacket> copied_packet = std::make_shared<DataPacket>(*audio_packet);
-  this->queueData(copied_packet->data, copied_packet->length, AUDIO_PACKET);
+  queueData(copied_packet->data, copied_packet->length, AUDIO_PACKET);
   return 0;
 }
 
@@ -338,11 +336,11 @@ int ExternalOutput::deliverVideoData_(std::shared_ptr<DataPacket> video_packet) 
   if (!video_packet->belongsToSpatialLayer(0)) {
     return 0;
   }
-  if (videoSourceSsrc_ == 0) {
+  if (video_source_ssrc_ == 0) {
     RtpHeader* h = reinterpret_cast<RtpHeader*>(copied_packet->data);
-    videoSourceSsrc_ = h->getSSRC();
+    video_source_ssrc_ = h->getSSRC();
   }
-  this->queueData(copied_packet->data, copied_packet->length, VIDEO_PACKET);
+  queueData(copied_packet->data, copied_packet->length, VIDEO_PACKET);
   return 0;
 }
 
@@ -353,10 +351,10 @@ int ExternalOutput::deliverEvent_(MediaEventPtr event) {
 bool ExternalOutput::initContext() {
   if (context_->oformat->video_codec != AV_CODEC_ID_NONE &&
             context_->oformat->audio_codec != AV_CODEC_ID_NONE &&
-            video_stream_ == NULL &&
-            audio_stream_ == NULL) {
+            video_stream_ == nullptr &&
+            audio_stream_ == nullptr) {
     AVCodec* videoCodec = avcodec_find_encoder(context_->oformat->video_codec);
-    if (videoCodec == NULL) {
+    if (videoCodec == nullptr) {
       ELOG_ERROR("Could not find video codec");
       return false;
     }
@@ -374,13 +372,13 @@ bool ExternalOutput::initContext() {
     }
     context_->oformat->flags |= AVFMT_VARIABLE_FPS;
 
-    AVCodec* audioCodec = avcodec_find_encoder(context_->oformat->audio_codec);
-    if (audioCodec == NULL) {
+    AVCodec* audio_codec = avcodec_find_encoder(context_->oformat->audio_codec);
+    if (audio_codec == nullptr) {
       ELOG_ERROR("Could not find audio codec");
       return false;
     }
 
-    audio_stream_ = avformat_new_stream(context_, audioCodec);
+    audio_stream_ = avformat_new_stream(context_, audio_codec);
     audio_stream_->id = 1;
     audio_stream_->codec->codec_id = context_->oformat->audio_codec;
     audio_stream_->codec->sample_rate = context_->oformat->audio_codec == AV_CODEC_ID_PCM_MULAW ? 8000 : 48000;
@@ -399,7 +397,7 @@ bool ExternalOutput::initContext() {
       return false;
     }
 
-    if (avformat_write_header(context_, NULL) < 0) {
+    if (avformat_write_header(context_, nullptr) < 0) {
       ELOG_ERROR("Error writing header");
       return false;
     }
@@ -420,18 +418,18 @@ void ExternalOutput::queueData(char* buffer, int length, packetType type) {
 
   if (first_data_received_ == time_point()) {
     first_data_received_ = clock::now();
-    if (this->getAudioSinkSSRC() == 0) {
+    if (getAudioSinkSSRC() == 0) {
       ELOG_DEBUG("No audio detected");
       context_->oformat->audio_codec = AV_CODEC_ID_PCM_MULAW;
     }
   }
-  if (needToSendFir_ && videoSourceSsrc_) {
-    this->sendFirPacket();
-    needToSendFir_ = false;
+  if (need_to_send_fir_ && video_source_ssrc_) {
+    sendFirPacket();
+    need_to_send_fir_ = false;
   }
 
   if (type == VIDEO_PACKET) {
-    if (this->video_offset_ms_ == -1) {
+    if (video_offset_ms_ == -1) {
       video_offset_ms_ = ClockUtils::durationToMs(clock::now() - first_data_received_);
       ELOG_DEBUG("File %s, video offset msec: %llu", context_->filename, video_offset_ms_);
     }
@@ -446,34 +444,35 @@ void ExternalOutput::queueData(char* buffer, int length, packetType type) {
       // we would have to pull in from the WebRtc project to fully construct
       // a webrtc::RTPHeader object is obscene.  So
       // let's just do this hacky fix.
-      webrtc::RTPHeader hackyHeader;
-      hackyHeader.headerLength = h->getHeaderLength();
-      hackyHeader.sequenceNumber = h->getSeqNumber();
+      webrtc::RTPHeader hacky_header;
+      hacky_header.headerLength = h->getHeaderLength();
+      hacky_header.sequenceNumber = h->getSeqNumber();
 
       // AddReceivedRedPacket returns 0 if there's data to process
-      if (0 == fec_receiver_->AddReceivedRedPacket(hackyHeader, (const uint8_t*)buffer, length, ULP_90000_PT)) {
+      if (0 == fec_receiver_->AddReceivedRedPacket(hacky_header, (const uint8_t*)buffer,
+                                                   length, ULP_90000_PT)) {
         fec_receiver_->ProcessReceivedFec();
       }
     } else {
-      videoQueue_.pushPacket(buffer, length);
+      video_queue_.pushPacket(buffer, length);
     }
   } else {
-    if (this->audio_offset_ms_ == -1) {
+    if (audio_offset_ms_ == -1) {
       audio_offset_ms_ = ClockUtils::durationToMs(clock::now() - first_data_received_);
       ELOG_DEBUG("File %s, audio offset msec: %llu", context_->filename, audio_offset_ms_);
 
       // Let's also take a moment to set our audio queue timebase.
       RtpHeader* h = reinterpret_cast<RtpHeader*>(buffer);
       if (h->getPayloadType() == PCMU_8000_PT) {
-        audioQueue_.setTimebase(8000);
+        audio_queue_.setTimebase(8000);
       } else if (h->getPayloadType() == OPUS_48000_PT) {
-        audioQueue_.setTimebase(48000);
+        audio_queue_.setTimebase(48000);
       }
     }
-    audioQueue_.pushPacket(buffer, length);
+    audio_queue_.pushPacket(buffer, length);
   }
 
-  if (audioQueue_.hasData() || videoQueue_.hasData()) {
+  if (audio_queue_.hasData() || video_queue_.hasData()) {
     // One or both of our queues has enough data to write stuff out.  Notify our writer.
     cond_.notify_one();
   }
@@ -481,14 +480,14 @@ void ExternalOutput::queueData(char* buffer, int length, packetType type) {
 
 int ExternalOutput::sendFirPacket() {
     if (fb_sink_ != nullptr) {
-      RtcpHeader thePLI;
-      thePLI.setPacketType(RTCP_PS_Feedback_PT);
-      thePLI.setBlockCount(1);
-      thePLI.setSSRC(55543);
-      thePLI.setSourceSSRC(videoSourceSsrc_);
-      thePLI.setLength(2);
-      char *buf = reinterpret_cast<char*>(&thePLI);
-      int len = (thePLI.getLength() + 1) * 4;
+      RtcpHeader pli_header;
+      pli_header.setPacketType(RTCP_PS_Feedback_PT);
+      pli_header.setBlockCount(1);
+      pli_header.setSSRC(55543);
+      pli_header.setSourceSSRC(video_source_ssrc_);
+      pli_header.setLength(2);
+      char *buf = reinterpret_cast<char*>(&pli_header);
+      int len = (pli_header.getLength() + 1) * 4;
       std::shared_ptr<DataPacket> pli_packet = std::make_shared<DataPacket>(0, buf, len, VIDEO_PACKET);
       fb_sink_->deliverFeedback(pli_packet);
       return len;
@@ -500,13 +499,13 @@ void ExternalOutput::sendLoop() {
   while (recording_) {
     boost::unique_lock<boost::mutex> lock(mtx_);
     cond_.wait(lock);
-    while (audioQueue_.hasData()) {
-      boost::shared_ptr<DataPacket> audioP = audioQueue_.popPacket();
-      this->writeAudioData(audioP->data, audioP->length);
+    while (audio_queue_.hasData()) {
+      boost::shared_ptr<DataPacket> audio_packet = audio_queue_.popPacket();
+      writeAudioData(audio_packet->data, audio_packet->length);
     }
-    while (videoQueue_.hasData()) {
-      boost::shared_ptr<DataPacket> videoP = videoQueue_.popPacket();
-      this->writeVideoData(videoP->data, videoP->length);
+    while (video_queue_.hasData()) {
+      boost::shared_ptr<DataPacket> video_packet = video_queue_.popPacket();
+      writeVideoData(video_packet->data, video_packet->length);
     }
     if (!inited_ && first_data_received_ != time_point()) {
       inited_ = true;
@@ -514,13 +513,13 @@ void ExternalOutput::sendLoop() {
   }
 
   // Since we're bailing, let's completely drain our queues of all data.
-  while (audioQueue_.getSize() > 0) {
-    boost::shared_ptr<DataPacket> audioP = audioQueue_.popPacket(true);  // ignore our minimum depth check
-    this->writeAudioData(audioP->data, audioP->length);
+  while (audio_queue_.getSize() > 0) {
+    boost::shared_ptr<DataPacket> audio_packet = audio_queue_.popPacket(true);  // ignore our minimum depth check
+    writeAudioData(audio_packet->data, audio_packet->length);
   }
-  while (videoQueue_.getSize() > 0) {
-    boost::shared_ptr<DataPacket> videoP = videoQueue_.popPacket(true);  // ignore our minimum depth check
-    this->writeVideoData(videoP->data, videoP->length);
+  while (video_queue_.getSize() > 0) {
+    boost::shared_ptr<DataPacket> video_packet = video_queue_.popPacket(true);  // ignore our minimum depth check
+    writeVideoData(video_packet->data, video_packet->length);
   }
 }
 }  // namespace erizo

--- a/erizo/src/erizo/media/ExternalOutput.h
+++ b/erizo/src/erizo/media/ExternalOutput.h
@@ -20,14 +20,14 @@ extern "C" {
 
 namespace erizo {
 
-#define UNPACKAGE_BUFFER_SIZE 200000
+constexpr  int kUnpackageBufferSize = 200000;
 
 class WebRtcConnection;
 
 // Our search state for VP8 frames.
 enum vp8SearchState {
-    lookingForStart,
-    lookingForEnd
+    kLookingForStart,
+    kLookingForEnd
 };
 
 class ExternalOutput : public MediaSink, public RawDataReceiver, public FeedbackSource, public webrtc::RtpData {
@@ -49,7 +49,7 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
 
  private:
   std::unique_ptr<webrtc::UlpfecReceiver> fec_receiver_;
-  RtpPacketQueue audioQueue_, videoQueue_;
+  RtpPacketQueue audio_queue_, video_queue_;
   bool recording_, inited_;
   boost::mutex mtx_;  // a mutex we use to signal our writer thread that data is waiting.
   boost::thread thread_;
@@ -57,10 +57,10 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
   AVStream *video_stream_, *audio_stream_;
   AVFormatContext *context_;
 
-  int unpackagedSize_;
-  uint32_t videoSourceSsrc_;
-  unsigned char* unpackagedBufferpart_;
-  unsigned char unpackagedBuffer_[UNPACKAGE_BUFFER_SIZE];
+  int unpackaged_size_;
+  uint32_t video_source_ssrc_;
+  unsigned char* unpackaged_buffer_part_;
+  unsigned char unpackaged_buffer_[kUnpackageBufferSize];
 
   // Timestamping strategy: we use the RTP timestamps so we don't have to restamp and we're not
   // subject to error due to the RTP packet queue depth and playout.
@@ -88,15 +88,15 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
 
 
   // The last sequence numbers we received for audio and video.  Allows us to react to packet loss.
-  uint16_t lastVideoSequenceNumber_;
-  uint16_t lastAudioSequenceNumber_;
+  uint16_t last_video_sequence_number_;
+  uint16_t last_audio_sequence_number_;
 
   // our VP8 frame search state.  We're always looking for either the beginning or the end of a frame.
   // Note: VP8 purportedly has two packetization schemes; per-frame and per-partition.  A frame is
   // composed of one or more partitions.  However, we don't seem to be sent anything but partition 0
   // so the second scheme seems not applicable.  Too bad.
-  vp8SearchState vp8SearchState_;
-  bool needToSendFir_;
+  vp8SearchState vp8_search_state_;
+  bool need_to_send_fir_;
 
   bool initContext();
   int sendFirPacket();


### PR DESCRIPTION
**Description**

Bring ExternalOutput code up to date by applying our coding style:

- CamelCase -> snake_case_
- NULL -> nullptr
- this-> -> 
- CAPITAL_CONSTANT -> kConstant
- Member initializer list with brackets
- member_variable -> member_variable_ 

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.