### PR TITLE
Pass media config to ExternalOutput and make video configuration dynamic

### DIFF
--- a/erizo/src/erizo/media/ExternalOutput.h
+++ b/erizo/src/erizo/media/ExternalOutput.h
@@ -15,6 +15,7 @@ extern "C" {
 #include "webrtc/modules/rtp_rtcp/source/ulpfec_receiver_impl.h"
 #include "media/MediaProcessor.h"
 #include "lib/Clock.h"
+#include "SdpInfo.h"
 
 #include "./logger.h"
 
@@ -34,7 +35,7 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
   DECLARE_LOGGER();
 
  public:
-  explicit ExternalOutput(const std::string& outputUrl);
+  explicit ExternalOutput(const std::string& output_url, const std::vector<RtpMap> rtp_mappings);
   virtual ~ExternalOutput();
   bool init();
   void receiveRawData(const RawDataPacket& packet) override;
@@ -95,8 +96,13 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
   // Note: VP8 purportedly has two packetization schemes; per-frame and per-partition.  A frame is
   // composed of one or more partitions.  However, we don't seem to be sent anything but partition 0
   // so the second scheme seems not applicable.  Too bad.
-  vp8SearchState vp8_search_state_;
+  vp8SearchState video_search_state_;
   bool need_to_send_fir_;
+  std::vector<RtpMap> rtp_mappings_;
+  std::map<uint, RtpMap> video_maps_;
+  std::map<uint, RtpMap> audio_maps_;
+  RtpMap video_map_;
+  RtpMap audio_map_;
 
   bool initContext();
   int sendFirPacket();
@@ -107,6 +113,9 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
   int deliverEvent_(MediaEventPtr event) override;
   void writeAudioData(char* buf, int len);
   void writeVideoData(char* buf, int len);
+  void updateVideoCodec(RtpMap map);
+  void updateAudioCodec(RtpMap map);
+  void writeVP8(char* buf, int len);
   bool bufferCheck(RTPPayloadVP8* payload);
 };
 }  // namespace erizo

--- a/erizoAPI/ExternalOutput.cc
+++ b/erizoAPI/ExternalOutput.cc
@@ -2,14 +2,15 @@
 #define BUILDING_NODE_EXTENSION
 #endif
 #include <node.h>
+#include "lib/json.hpp"
 #include "ExternalOutput.h"
-
 
 using v8::HandleScope;
 using v8::Function;
 using v8::FunctionTemplate;
 using v8::Local;
 using v8::Value;
+using json = nlohmann::json;
 
 Nan::Persistent<Function> ExternalOutput::constructor;
 
@@ -55,9 +56,66 @@ NAN_MODULE_INIT(ExternalOutput::Init) {
 NAN_METHOD(ExternalOutput::New) {
   v8::String::Utf8Value param(Nan::To<v8::String>(info[0]).ToLocalChecked());
   std::string url = std::string(*param);
+  v8::String::Utf8Value json_param(Nan::To<v8::String>(info[1]).ToLocalChecked());
+  std::string media_config_string = std::string(*json_param);
+  json media_config = json::parse(media_config_string);
+  std::vector<erizo::RtpMap> rtp_mappings;
+  if (media_config.find("rtpMappings") != media_config.end()) {
+    json rtp_map_json = media_config["rtpMappings"];
+    for (json::iterator it = rtp_map_json.begin(); it != rtp_map_json.end(); ++it) {
+      erizo::RtpMap rtp_map;
+      if (it.value()["payloadType"].is_number()) {
+        rtp_map.payload_type = it.value()["payloadType"];
+      } else {
+        continue;
+      }
+      if (it.value()["encodingName"].is_string()) {
+        rtp_map.encoding_name = it.value()["encodingName"];
+      } else {
+        continue;
+      }
+      if (it.value()["mediaType"].is_string()) {
+        if (it.value()["mediaType"] == "video") {
+          rtp_map.media_type = erizo::VIDEO_TYPE;
+        } else if (it.value()["mediaType"] == "audio") {
+          rtp_map.media_type = erizo::AUDIO_TYPE;
+        } else {
+          continue;
+        }
+      } else {
+        continue;
+      }
+      if (it.value()["clockRate"].is_number()) {
+        rtp_map.clock_rate = it.value()["clockRate"];
+      }
+      if (rtp_map.media_type == erizo::AUDIO_TYPE) {
+        if (it.value()["channels"].is_number()) {
+          rtp_map.channels = it.value()["channels"];
+        }
+      }
+      if (it.value()["formatParameters"].is_object()) {
+        json format_params_json = it.value()["formatParameters"];
+        for (json::iterator params_it = format_params_json.begin();
+            params_it != format_params_json.end(); ++params_it) {
+          std::string value = params_it.value();
+          std::string key = params_it.key();
+          rtp_map.format_parameters.insert(rtp_map.format_parameters.begin(),
+              std::pair<std::string, std::string> (key, value));
+        }
+      }
+      if (it.value()["feedbackTypes"].is_array()) {
+        json feedback_types_json = it.value()["feedbackTypes"];
+        for (json::iterator feedback_it = feedback_types_json.begin();
+            feedback_it != feedback_types_json.end(); ++feedback_it) {
+            rtp_map.feedback_types.push_back(*feedback_it);
+        }
+      }
+      rtp_mappings.push_back(rtp_map);
+    }
+  }
 
   ExternalOutput* obj = new ExternalOutput();
-  obj->me = std::make_shared<erizo::ExternalOutput>(url);
+  obj->me = std::make_shared<erizo::ExternalOutput>(url, rtp_mappings);
 
   obj->Wrap(info.This());
   info.GetReturnValue().Set(info.This());

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -79,7 +79,7 @@ class Source {
   addExternalOutput(url) {
     var eoId = url + '_' + this.id;
     log.info('message: Adding ExternalOutput, id: ' + eoId);
-    var externalOutput = new addon.ExternalOutput(url);
+    var externalOutput = new addon.ExternalOutput(url, JSON.stringify(global.mediaConfig));
     externalOutput.wrtcId = eoId;
     externalOutput.init();
     this.muxer.addExternalOutput(externalOutput, url);

--- a/spine/nativeClient.js
+++ b/spine/nativeClient.js
@@ -149,7 +149,7 @@ exports.ErizoNativeConnection = (config) => {
 
   that.prepareRecording = (url) => {
     log.info('Preparing Recording', url);
-    externalOutput = new addon.ExternalOutput(url);
+    externalOutput = new addon.ExternalOutput(url, JSON.stringify(global.mediaConfig));
     wrtc.setVideoReceiver(externalOutput);
     wrtc.setAudioReceiver(externalOutput);
   };


### PR DESCRIPTION
**Description**

ExternalOutput will now depend on the values set on `rtp_media_config.js` , so that it will be more dynamic and less prone to errors due to wrong configurations.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.