### PR TITLE
Add support to configure codecs per room

### DIFF
--- a/doc/server_api.md
+++ b/doc/server_api.md
@@ -32,6 +32,7 @@ A Room object has the following properties:
 - `Room.name`: the name of the room.
 - `Room._id`: a unique identifier for the room.
 - `Room.p2p` (optional): boolean that indicates if the room is a peer - to - peer room. In p2p rooms server side is only used for signalling.
+- `Room.mediaConfiguration` (optional): a string with the media configuration used for this room.
 - `Room.data` (optional): additional metadata for the room.
 
 In your service you can create a room, get a list of rooms that you have created, get the info about a determined room or delete a room when you don't need it.
@@ -44,7 +45,7 @@ To create a room you need to specify a name and a callback function. When the ro
 
 ```
 var roomName = 'myFirstRoom';
- 
+
 N.API.createRoom(roomName, function(room) {
   console.log('Room created with id: ', room._id);
 }, errorCallback);
@@ -54,7 +55,7 @@ You can create peer - to - peer rooms in which users will communicate directly b
 
 ```
 var roomName = 'myP2PRoom';
- 
+
 N.API.createRoom(roomName, function(room) {
   console.log('P2P room created with id: ', room._id);
 }, errorCallback, {p2p: true});
@@ -64,10 +65,18 @@ You can include metadata when creating the room. This metadata will be stored in
 
 ```
 var roomName = 'myRoomWithMetadata';
- 
+
 N.API.createRoom(roomName, function(room) {
-  console.log('P2P room created with id: ', room._id);
+  console.log('Room created with id: ', room._id);
 }, errorCallback, {data: {room_color: 'red', room_description: 'Room for testing metadata'}});
+```
+
+You can also specify which media configuration you want to use in the Room.
+
+```
+N.API.createRoom(roomName, function(room) {
+  console.log('Room created with id: ', room._id);
+}, errorCallback, {mediaConfiguration: 'VP8_AND_OPUS'});
 ```
 
 ## Get Rooms
@@ -89,7 +98,7 @@ Also you can get the info about a determined room with its roomId:
 
 ```
 var roomId = '30121g51113e74fff3115502';
- 
+
 N.API.getRoom(roomId, function(resp) {
   var room= JSON.parse(resp);
   console.log('Room name: ', room.name);
@@ -102,7 +111,7 @@ And finally, to delete a determined room:
 
 ```
 var roomId = '30121g51113e74fff3115502';
- 
+
 N.API.deleteRoom(roomId, function(result) {
   console.log('Result: ', result);
 }, errorCallback);
@@ -123,7 +132,7 @@ When you want to add a new participant to a room, you need to create a new token
 var roomId = '30121g51113e74fff3115502';
 var name = 'userName';
 var role = '';
- 
+
 N.API.createToken(roomId, name, role, function(token) {
   console.log('Token created: ', token);
 }, errorCallback);
@@ -145,11 +154,11 @@ You can ask Nuve for a list of the users connected to a determined room.
 
 ```
 var roomId = '30121g51113e74fff3115502';
- 
+
 N.API.getUsers(roomId, function(users) {
   var usersList = JSON.parse(users);
   console.log('This room has ', usersList.length, 'users');
- 
+
   for(var i in usersList) {
     console.log('User ', i, ':', usersList[i].name, 'with role: ', usersList[i].role);
   }
@@ -174,7 +183,7 @@ We also include express support for our server. We prepare it to publish static 
 ```
 var express = require('express');
 var app = express.createServer();
- 
+
 app.use(express.bodyParser());
 app.configure(function () {
     app.use(express.logger());
@@ -186,7 +195,7 @@ Requests to `/createRoom/` URL will create a new Room in Licode.
 
 ```
 app.post('/createRoom/', function(req, res){
- 
+
     N.API.createRoom('myRoom', function(roomID) {
         res.send(roomID);
     }, function (e) {
@@ -199,7 +208,7 @@ Requests to `/getRooms/` URL will retrieve a list of our Rooms in Licode.
 
 ```
 app.get('/getRooms/', function(req, res){
- 
+
     N.API.getRooms(function(rooms) {
         res.send(rooms);
     }, function (e) {
@@ -212,7 +221,7 @@ Requests to `/getUsers/roomID` URL will retrieve a list of users that are connec
 
 ```
 app.get('/getUsers/:room', function(req, res){
- 
+
     var room = req.params.room;
     N.API.getUsers(room, function(users) {
         res.send(users);
@@ -226,7 +235,7 @@ Requests to `/createToken/roomID` URL will create an access token for including 
 
 ```
 app.post('/createToken/:room', function(req, res){
- 
+
     var room = req.params.room;
     var username = req.body.username;
     var role = req.body.role;
@@ -243,4 +252,3 @@ Finally, we will start our service, that will listen to port 80 (line 19).
 ```
 app.listen (80);
 ```
-

--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -173,6 +173,7 @@ class Client extends events.EventEmitter {
         });
     } else if (options.state === 'erizo') {
         let st;
+        options.mediaConfiguration = this.token.mediaConfiguration;
         log.info('message: addPublisher requested, ' +
                  'streamId: ' + id + ', clientId: ' + this.id + ', ' +
                  logger.objectToLog(options) + ', ' +
@@ -289,6 +290,7 @@ class Client extends events.EventEmitter {
             log.info('message: addSubscriber requested, ' +
                      'streamId: ' + options.streamId + ', ' +
                      'clientId: ' + this.id);
+            options.mediaConfiguration = this.token.mediaConfiguration;
             this.room.controller.addSubscriber(this.id, options.streamId, options, (signMess) => {
                 if (signMess.type === 'initializing') {
                     log.info('message: addSubscriber, ' +
@@ -369,7 +371,8 @@ class Client extends events.EventEmitter {
     let stream = this.room.getStreamById(streamId);
 
     if (stream.hasAudio() || stream.hasVideo() || stream.hasScreen()) {
-        this.room.controller.addExternalOutput(streamId, url, function (result) {
+        var mediaOptions = {mediaConfiguration: this.token.mediaConfiguration};
+        this.room.controller.addExternalOutput(streamId, url, mediaOptions, function (result) {
             if (result === 'success') {
                 log.info('message: startRecorder, ' +
                          'state: RECORD_STARTED, ' +

--- a/erizo_controller/erizoController/roomController.js
+++ b/erizo_controller/erizoController/roomController.js
@@ -113,11 +113,11 @@ exports.RoomController = function (spec) {
         }
     };
 
-    that.addExternalOutput = function (publisherId, url, callback) {
+    that.addExternalOutput = function (publisherId, url, options, callback) {
         if (publishers[publisherId] !== undefined) {
             log.info('message: addExternalOuput, streamId: ' + publisherId + ', url:' + url);
 
-            var args = [publisherId, url];
+            var args = [publisherId, url, options];
 
             amqper.callRpc(getErizoQueue(publisherId), 'addExternalOutput', args, undefined);
 

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -209,8 +209,8 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
         }
     };
 
-    that.addExternalOutput = function (to, url) {
-        if (publishers[to]) publishers[to].addExternalOutput(url);
+    that.addExternalOutput = function (to, url, options) {
+        if (publishers[to]) publishers[to].addExternalOutput(url, options);
     };
 
     that.removeExternalOutput = function (to, url) {

--- a/erizo_controller/test/erizoController/erizoController.js
+++ b/erizo_controller/test/erizoController/erizoController.js
@@ -1053,7 +1053,7 @@ describe('Erizo Controller / Erizo Controller', function() {
 
               it('should return ok if when receiving success state', function() {
                 var signMes = 'success';
-                mocks.roomControllerInstance.addExternalOutput.callsArgWith(2, signMes);
+                mocks.roomControllerInstance.addExternalOutput.callsArgWith(3, signMes);
 
                 onStartRecorder(subscriberOptions, callback);
 
@@ -1062,7 +1062,7 @@ describe('Erizo Controller / Erizo Controller', function() {
 
               it('should return an error if when receiving a failed state', function() {
                 var signMes = 'failed';
-                mocks.roomControllerInstance.addExternalOutput.callsArgWith(2, signMes);
+                mocks.roomControllerInstance.addExternalOutput.callsArgWith(3, signMes);
 
                 onStartRecorder(subscriberOptions, callback);
 

--- a/erizo_controller/test/erizoController/roomController.js
+++ b/erizo_controller/test/erizoController/roomController.js
@@ -73,6 +73,7 @@ describe('Erizo Controller / Room Controller', function() {
   describe('External Output', function() {
     var kArbitraryId = 'id1',
         kArbitraryUrl = 'url1',
+        kArbitraryOptions = {},
         kArbitraryUnknownId = 'unknownId',
         kArbitraryOutputUrl = 'url2';
 
@@ -85,7 +86,7 @@ describe('Erizo Controller / Room Controller', function() {
 
     it('should call Erizo\'s addExternalOutput', function() {
       var callback = sinon.stub();
-      controller.addExternalOutput(kArbitraryId, kArbitraryUrl, callback);
+      controller.addExternalOutput(kArbitraryId, kArbitraryUrl, kArbitraryOptions, callback);
 
       expect(amqperMock.callRpc.callCount).to.equal(2);
       expect(amqperMock.callRpc.args[1][1]).to.equal('addExternalOutput');
@@ -97,7 +98,8 @@ describe('Erizo Controller / Room Controller', function() {
       var callback = sinon.stub();
       ecchInstanceMock.getErizoJS.callsArgWith(0, 'erizoId');
 
-      controller.addExternalOutput(kArbitraryUnknownId, kArbitraryOutputUrl, callback);
+      controller.addExternalOutput(kArbitraryUnknownId, kArbitraryOutputUrl,
+        kArbitraryOptions, callback);
 
       expect(amqperMock.callRpc.callCount).to.equal(1);
       expect(callback.withArgs('error').callCount).to.equal(1);
@@ -106,7 +108,7 @@ describe('Erizo Controller / Room Controller', function() {
     describe('Remove', function() {
       beforeEach(function() {
         var callback = sinon.stub();
-        controller.addExternalOutput(kArbitraryId, kArbitraryUrl, callback);
+        controller.addExternalOutput(kArbitraryId, kArbitraryUrl, kArbitraryOptions, callback);
       });
 
       it('should call Erizo\'s removeExternalOutput', function() {

--- a/erizo_controller/test/erizoJS/erizoJSController.js
+++ b/erizo_controller/test/erizoJS/erizoJSController.js
@@ -94,6 +94,7 @@ describe('Erizo JS Controller', function() {
 
   describe('Add External Output', function() {
     var kArbitraryEoUrl = 'eo_url1';
+    var kArbitraryEoOptions = {};
     var kArbitraryEiId = 'ei_id1';
     var kArbitraryEiUrl = 'ei_url1';
 
@@ -103,7 +104,7 @@ describe('Erizo JS Controller', function() {
     });
 
     it('should succeed creating ExternalOutput', function() {
-      controller.addExternalOutput(kArbitraryEiId, kArbitraryEoUrl);
+      controller.addExternalOutput(kArbitraryEiId, kArbitraryEoUrl, kArbitraryEoOptions);
       expect(erizoApiMock.ExternalOutput.args[0][0]).to.equal(kArbitraryEoUrl);
       expect(erizoApiMock.ExternalOutput.callCount).to.equal(1);
       expect(mocks.ExternalOutput.wrtcId).to.equal(kArbitraryEoUrl + '_' + kArbitraryEiId);
@@ -112,7 +113,7 @@ describe('Erizo JS Controller', function() {
     });
 
     it('should fail if Publisher does not exist', function() {
-      controller.addExternalOutput(kArbitraryEiId + 'a', kArbitraryEiUrl);
+      controller.addExternalOutput(kArbitraryEiId + 'a', kArbitraryEiUrl, kArbitraryEoOptions);
 
       expect(erizoApiMock.ExternalOutput.callCount).to.equal(0);
     });
@@ -120,7 +121,7 @@ describe('Erizo JS Controller', function() {
     describe('Remove External Output', function() {
 
       beforeEach(function() {
-        controller.addExternalOutput(kArbitraryEiId, kArbitraryEoUrl);
+        controller.addExternalOutput(kArbitraryEiId, kArbitraryEoUrl, kArbitraryEoOptions);
       });
 
       it('should succeed removing ExternalOutput', function() {

--- a/extras/basic_example/basicServer.js
+++ b/extras/basic_example/basicServer.js
@@ -51,7 +51,8 @@ N.API.init(config.nuve.superserviceID, config.nuve.superserviceKey, 'http://loca
 var defaultRoom;
 const defaultRoomName = 'basicExampleRoom';
 
-var getOrCreateRoom = function (name, type = 'erizo', callback = function(){}) {
+var getOrCreateRoom = function (name, type = 'erizo', mediaConfiguration = 'default',
+                                callback = function() {}) {
 
     if (name === defaultRoomName && defaultRoom) {
         callback(defaultRoom);
@@ -71,8 +72,7 @@ var getOrCreateRoom = function (name, type = 'erizo', callback = function(){}) {
                 return;
             }
         }
-
-        let extra = {data: {basicExampleRoom: true}};
+        let extra = {data: {basicExampleRoom: true}, mediaConfiguration: mediaConfiguration};
         if (type === 'p2p') extra.p2p = true;
 
         N.API.createRoom(name, function (roomID) {
@@ -152,11 +152,12 @@ app.post('/createToken/', function(req, res) {
     let username = req.body.username;
     let role = req.body.role;
 
-    let room = defaultRoomName, type, roomId;
+    let room = defaultRoomName, type, roomId, mediaConfiguration;
 
     if (req.body.room && !isNaN(req.body.room)) room = req.body.room;
     if (req.body.type) type = req.body.type;
     if (req.body.roomId) roomId = req.body.roomId;
+    if (req.body.mediaConfiguration) mediaConfiguration = req.body.mediaConfiguration;
 
     let createToken = function (roomId) {
       N.API.createToken(roomId, username, role, function(token) {
@@ -171,7 +172,7 @@ app.post('/createToken/', function(req, res) {
     if (roomId) {
       createToken(roomId);
     } else {
-      getOrCreateRoom(room, type, createToken);
+      getOrCreateRoom(room, type, mediaConfiguration, createToken);
     }
 
 });
@@ -189,7 +190,7 @@ app.use(function(req, res, next) {
 });
 
 cleanExampleRooms(function() {
-    getOrCreateRoom(defaultRoomName, undefined, function (roomId) {
+    getOrCreateRoom(defaultRoomName, undefined, undefined, function (roomId) {
         defaultRoom = roomId;
         app.listen(3001);
         var server = https.createServer(options, app);

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -50,6 +50,7 @@ window.onload = function () {
   var screen = getParameterByName('screen');
   var roomName = getParameterByName('room') || 'basicExampleRoom';
   var roomType = getParameterByName('type') || 'erizo';
+  var mediaConfiguration = getParameterByName('mediaConfiguration') || 'default';
   var onlySubscribe = getParameterByName('onlySubscribe');
   console.log('Selected Room', roomName, 'of type', roomType);
   var config = {audio: true,
@@ -81,7 +82,11 @@ window.onload = function () {
     req.send(JSON.stringify(roomData));
   };
 
-  var roomData  = {username: 'user', role: 'presenter', room: roomName, type: roomType};
+  var roomData  = {username: 'user',
+                   role: 'presenter',
+                   room: roomName,
+                   type: roomType,
+                   mediaConfiguration: mediaConfiguration};
 
   createToken(roomData, function (response) {
     var token = response;

--- a/nuve/nuveAPI/resource/roomResource.js
+++ b/nuve/nuveAPI/resource/roomResource.js
@@ -68,6 +68,9 @@ exports.updateRoom = function (req, res) {
             if (options.data) {
                 room.data = options.data;
             }
+            if (typeof options.mediaConfiguration === 'string') {
+                room.mediaConfiguration = options.mediaConfiguration;
+            }
 
             roomRegistry.updateRoom(id, room);
 

--- a/nuve/nuveAPI/resource/roomsResource.js
+++ b/nuve/nuveAPI/resource/roomsResource.js
@@ -51,6 +51,9 @@ exports.createRoom = function (req, res) {
         if (req.body.options.data) {
             room.data = req.body.options.data;
         }
+        if (typeof req.body.options.mediaConfiguration === 'string') {
+            room.mediaConfiguration = req.body.options.mediaConfiguration;
+        }
         roomRegistry.addRoom(room, function (result) {
             currentService.rooms.push(result);
             serviceRegistry.updateService(currentService);

--- a/nuve/nuveAPI/resource/tokensResource.js
+++ b/nuve/nuveAPI/resource/tokensResource.js
@@ -64,6 +64,9 @@ var generateToken = function (req, callback) {
     token.role = role;
     token.service = currentService._id;
     token.creationDate = new Date();
+    if (typeof currentRoom.mediaConfiguration === 'string') {
+      token.mediaConfiguration = currentRoom.mediaConfiguration;
+    }
 
     // Values to be filled from the erizoController
     token.secure = false;

--- a/scripts/rtp_media_config_default.js
+++ b/scripts/rtp_media_config_default.js
@@ -1,138 +1,177 @@
-var mediaConfig = {};
+const mediaConfig = {};
 
-mediaConfig.extMappings = [
-  "urn:ietf:params:rtp-hdrext:ssrc-audio-level",
-  "http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time",
-  "urn:ietf:params:rtp-hdrext:toffset",
-  "urn:3gpp:video-orientation",
-  // "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01",
-  "http://www.webrtc.org/experiments/rtp-hdrext/playout-delay",
-  "urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id"
+const extMappings = [
+  'urn:ietf:params:rtp-hdrext:ssrc-audio-level',
+  'http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time',
+  'urn:ietf:params:rtp-hdrext:toffset',
+  'urn:3gpp:video-orientation',
+  // 'http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01',
+  'http://www.webrtc.org/experiments/rtp-hdrext/playout-delay',
+  'urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id',
 ];
 
-mediaConfig.rtpMappings = {};
-
-mediaConfig.rtpMappings.vp8 = {
-    payloadType: 100,
-    encodingName: 'VP8',
-    clockRate: 90000,
-    channels: 1,
-    mediaType: 'video',
-    feedbackTypes: [
-        'ccm fir',
-        'nack',
-        'nack pli',
-        'goog-remb',
-//        'transport-cc',
-    ],
-};
-/*
-mediaConfig.rtpMappings.red = {
-    payloadType: 116,
-    encodingName: 'red',
-    clockRate: 90000,
-    channels: 1,
-    mediaType: 'video',
+const vp8 = {
+  payloadType: 100,
+  encodingName: 'VP8',
+  clockRate: 90000,
+  channels: 1,
+  mediaType: 'video',
+  feedbackTypes: [
+    'ccm fir',
+    'nack',
+    'nack pli',
+    'goog-remb',
+    // 'transport-cc',
+  ],
 };
 
-mediaConfig.rtpMappings.rtx = {
-    payloadType: 96,
-    encodingName: 'rtx',
-    clockRate: 90000,
-    channels: 1,
-    mediaType: 'video',
-    formatParameters: {
-        apt: '100'
-    },
+const vp9 = {
+  payloadType: 100,
+  encodingName: 'VP9',
+  clockRate: 90000,
+  channels: 1,
+  mediaType: 'video',
+  feedbackTypes: [
+    'ccm fir',
+    'nack',
+    'nack pli',
+    'goog-remb',
+    // 'transport-cc',
+  ],
 };
 
-mediaConfig.rtpMappings.ulpfec = {
-    payloadType: 117,
-    encodingName: 'ulpfec',
-    clockRate: 90000,
-    channels: 1,
-    mediaType: 'video',
+const h264 = {
+  payloadType: 101,
+  encodingName: 'H264',
+  clockRate: 90000,
+  channels: 1,
+  mediaType: 'video',
+  formatParameters: {
+    'profile-level-id': '42e01f',
+    'level-asymmetry-allowed': '1',
+    'packetization-mode': '1',
+  },
+  feedbackTypes: [
+    'ccm fir',
+    'nack',
+    'nack pli',
+    'goog-remb',
+    // 'transport-cc',
+  ],
 };
 
-mediaConfig.rtpMappings.opus = {
-    payloadType: 111,
-    encodingName: 'opus',
-    clockRate: 48000,
-    channels: 2,
-    mediaType: 'audio',
+const red = {
+  payloadType: 116,
+  encodingName: 'red',
+  clockRate: 90000,
+  channels: 1,
+  mediaType: 'video',
 };
 
-mediaConfig.rtpMappings.isac16 = {
-    payloadType: 103,
-    encodingName: 'ISAC',
-    clockRate: 16000,
-    channels: 1,
-    mediaType: 'audio',
+const rtx = {
+  payloadType: 96,
+  encodingName: 'rtx',
+  clockRate: 90000,
+  channels: 1,
+  mediaType: 'video',
+  formatParameters: {
+    apt: '100',
+  },
 };
 
-mediaConfig.rtpMappings.isac32 = {
-    payloadType: 104,
-    encodingName: 'ISAC',
-    clockRate: 32000,
-    channels: 1,
-    mediaType: 'audio',
+const ulpfec = {
+  payloadType: 117,
+  encodingName: 'ulpfec',
+  clockRate: 90000,
+  channels: 1,
+  mediaType: 'video',
 };
 
-*/
-mediaConfig.rtpMappings.pcmu = {
-    payloadType: 0,
-    encodingName: 'PCMU',
-    clockRate: 8000,
-    channels: 1,
-    mediaType: 'audio',
-};
-/*
-mediaConfig.rtpMappings.pcma = {
-    payloadType: 8,
-    encodingName: 'PCMA',
-    clockRate: 8000,
-    channels: 1,
-    mediaType: 'audio',
+const opus = {
+  payloadType: 111,
+  encodingName: 'opus',
+  clockRate: 48000,
+  channels: 2,
+  mediaType: 'audio',
 };
 
-mediaConfig.rtpMappings.cn8 = {
-    payloadType: 13,
-    encodingName: 'CN',
-    clockRate: 8000,
-    channels: 1,
-    mediaType: 'audio',
+const isac16 = {
+  payloadType: 103,
+  encodingName: 'ISAC',
+  clockRate: 16000,
+  channels: 1,
+  mediaType: 'audio',
 };
 
-mediaConfig.rtpMappings.cn16 = {
-    payloadType: 105,
-    encodingName: 'CN',
-    clockRate: 16000,
-    channels: 1,
-    mediaType: 'audio',
+const isac32 = {
+  payloadType: 104,
+  encodingName: 'ISAC',
+  clockRate: 32000,
+  channels: 1,
+  mediaType: 'audio',
 };
 
-mediaConfig.rtpMappings.cn32 = {
-    payloadType: 106,
-    encodingName: 'CN',
-    clockRate: 32000,
-    channels: 1,
-    mediaType: 'audio',
+const pcmu = {
+  payloadType: 0,
+  encodingName: 'PCMU',
+  clockRate: 8000,
+  channels: 1,
+  mediaType: 'audio',
 };
 
-mediaConfig.rtpMappings.cn48 = {
-    payloadType: 107,
-    encodingName: 'CN',
-    clockRate: 48000,
-    channels: 1,
-    mediaType: 'audio',
+const pcma = {
+  payloadType: 8,
+  encodingName: 'PCMA',
+  clockRate: 8000,
+  channels: 1,
+  mediaType: 'audio',
 };
-*/
-mediaConfig.rtpMappings.telephoneevent = {
-    payloadType: 126,
-    encodingName: 'telephone-event',
-    clockRate: 8000,
-    channels: 1,
-    mediaType: 'audio',
+
+const cn8 = {
+  payloadType: 13,
+  encodingName: 'CN',
+  clockRate: 8000,
+  channels: 1,
+  mediaType: 'audio',
+};
+
+const cn16 = {
+  payloadType: 105,
+  encodingName: 'CN',
+  clockRate: 16000,
+  channels: 1,
+  mediaType: 'audio',
+};
+
+const cn32 = {
+  payloadType: 106,
+  encodingName: 'CN',
+  clockRate: 32000,
+  channels: 1,
+  mediaType: 'audio',
+};
+
+const cn48 = {
+  payloadType: 107,
+  encodingName: 'CN',
+  clockRate: 48000,
+  channels: 1,
+  mediaType: 'audio',
+};
+
+const telephoneevent = {
+  payloadType: 126,
+  encodingName: 'telephone-event',
+  clockRate: 8000,
+  channels: 1,
+  mediaType: 'audio',
+};
+
+mediaConfig.codecConfigurations = {
+  default: { rtpMappings: { vp8, opus }, extMappings },
+  VP8_AND_OPUS: { rtpMappings: { vp8, opus }, extMappings },
+  VP9_AND_OPUS: { rtpMappings: { vp9, opus }, extMappings },
+  H264_AND_OPUS: { rtpMappings: { h264, opus }, extMappings },
 };
 
 var module = module || {};


### PR DESCRIPTION
**Description**

This PR adds support to configure codecs per room, instead of having the same codec configuration for all rooms in a Licode instance. The list of available configurations will be setup in the `rtp_media_config.js` file, and we can add/remove the proposed configurations in `rtp_media_config_default.js`.

The proposed configurations are:
```js
mediaConfig.codecConfigurations = {
  default: { rtpMappings: { vp8, opus }, extMappings },
  VP8_AND_OPUS: { rtpMappings: { vp8, opus }, extMappings },
  VP9_AND_OPUS: { rtpMappings: { vp9, opus }, extMappings },
  H264_AND_OPUS: { rtpMappings: { h264, opus }, extMappings },
};
```

But we could also add other examples like:
```js
  VP8_AND_PCMU: { rtpMappings: { vp8, pcmu }, extMappings },
```

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Now we can specify which media configuration we want to use in a Room.

```js
N.API.createRoom(roomName, function(room) {
  console.log('Room created with id: ', room._id);
}, errorCallback, {mediaConfiguration: 'VP8_AND_OPUS'});
```

NOTE: If no mediaConfiguration is passed or it doesn't exist in the config file we will use the default one.

[] It includes documentation for these changes in `/doc`.