### PR TITLE
Fix Erizo Client Resizer and use stream.srcObject

### DIFF
--- a/erizo_controller/erizoClient/src/utils/L.Resizer.js
+++ b/erizo_controller/erizoClient/src/utils/L.Resizer.js
@@ -215,11 +215,11 @@ L.ElementQueries = function ElementQueries() {
        * @param {CssRule[]|String} rules
        */
   function readRules(originalRules) {
-    let selector = '';
-    let rules = [];
     if (!originalRules) {
       return;
     }
+    let selector = '';
+    let rules = originalRules;
     if (typeof originalRules === 'string') {
       rules = originalRules.toLowerCase();
       if (rules.indexOf('min-width') !== -1 || rules.indexOf('max-width') !== -1) {

--- a/erizo_controller/erizoClient/src/views/AudioPlayer.js
+++ b/erizo_controller/erizoClient/src/views/AudioPlayer.js
@@ -1,8 +1,7 @@
-/* global window, document, webkitURL */
+/* global document */
 
 import View from './View';
 import Bar from './Bar';
-import Logger from '../utils/Logger';
 
 /*
  * AudioPlayer represents a Licode Audio component that shows either a local or a remote Audio.
@@ -26,10 +25,6 @@ const AudioPlayer = (spec) => {
   // DOM element in which the AudioPlayer will be appended
   that.elementID = spec.elementID;
 
-
-  Logger.debug(`Creating URL from stream ${that.stream}`);
-  const myURL = window.URL || webkitURL;
-  that.streamUrl = myURL.createObjectURL(that.stream);
 
     // Audio tag
   that.audio = document.createElement('audio');
@@ -100,7 +95,7 @@ const AudioPlayer = (spec) => {
     that.parentNode = document.body;
   }
 
-  that.audio.src = that.streamUrl;
+  that.audio.srcObject = that.stream;
 
   return that;
 };

--- a/erizo_controller/erizoClient/src/views/VideoPlayer.js
+++ b/erizo_controller/erizoClient/src/views/VideoPlayer.js
@@ -1,8 +1,7 @@
-/* global window, document, webkitURL, L */
+/* global document, L */
 
 import View from './View';
 import Bar from './Bar';
-import Logger from '../utils/Logger';
 
 /*
  * VideoPlayer represents a Licode video component that shows either a local or a remote video.
@@ -76,10 +75,6 @@ const VideoPlayer = (spec) => {
       document.getElementById(key).value = unescape(value);
   }); */
 
-  Logger.debug(`Creating URL from stream ${that.stream}`);
-  const myURL = window.URL || webkitURL;
-  that.streamUrl = myURL.createObjectURL(that.stream);
-
   // Container
   that.div = document.createElement('div');
   that.div.setAttribute('id', `player_${that.id}`);
@@ -150,7 +145,7 @@ const VideoPlayer = (spec) => {
     that.media = that.video;
   }
 
-  that.video.src = that.streamUrl;
+  that.video.srcObject = that.stream;
 
   return that;
 };


### PR DESCRIPTION
**Description**

Fixes #1021 . Wrong CSS rules initialization in Erizo Client Resizer. Thanks @HemanthAnakapalle for the heads up.

It also adds two small changes to get rid of some warning on client side.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.