### PR TITLE
Fix Erizo SDP parser

### DIFF
--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -854,9 +854,11 @@ namespace erizo {
           std::string value = "none";
           if (key_value.size() == 1) {
             value = key_value[0];
-          } else {
+          } else if (key_value.size() == 2) {
             option = key_value[0];
             value = key_value[1];
+          } else {
+            continue;
           }
 
           ELOG_DEBUG("message: Parsing format parameter, option: %s, value: %s, PT: %u",

--- a/erizo/src/test/assets/Chrome.sdp
+++ b/erizo/src/test/assets/Chrome.sdp
@@ -18,7 +18,7 @@ a=sendrecv
 a=rtcp-mux
 a=rtpmap:111 opus/48000/2
 a=rtcp-fb:111 transport-cc
-a=fmtp:111 minptime=10_
+a=fmtp:111 minptime=10; useinbandfec=1;
 a=rtpmap:103 ISAC/16000
 a=rtpmap:104 ISAC/32000
 a=rtpmap:9 G722/8000

--- a/extras/docker/initDockerLicode.sh
+++ b/extras/docker/initDockerLicode.sh
@@ -128,7 +128,6 @@ run_erizoAgent() {
 run_basicExample() {
   echo "Starting basicExample"
   sleep 5
-  cp $ROOT/erizo_controller/erizoClient/dist/erizo.js $EXTRAS/basic_example/public/
   cp $ROOT/nuve/nuveClient/dist/nuve.js $EXTRAS/basic_example/
   cd $EXTRAS/basic_example
   node basicServer.js &


### PR DESCRIPTION
**Description**

There was an issue parsing the SDP issued by old versions of Chrome.

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.