### PR TITLE
Update libnice

### DIFF
--- a/erizo/src/CMakeLists.txt
+++ b/erizo/src/CMakeLists.txt
@@ -61,16 +61,22 @@ set(THIRD_PARTY_LIB "${CMAKE_CURRENT_SOURCE_DIR}/../../build/libdeps/build/lib/"
 ## Depencencies
 
 # GLIB
-find_package(Glib REQUIRED)
-include_directories(${GLIB_INCLUDE_DIRS})
+if (APPLE)
+    message("APPLE")
+    find_package(Glib REQUIRED)
+    set (GLIB2_LIBRARIES ${GLIB_LIBRARIES} gio-2.0 gobject-2.0 gthread-2.0)
+    include_directories(${GLIB_INCLUDE_DIRS})
+elseif(UNIX)
+    message("UNIX")
+    set(ENV{PKG_CONFIG_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../../build/libdeps/build/lib/pkgconfig")
+    pkg_check_modules(GLIB2 glib-2.0>=2.44)
+    include_directories(${GLIB2_INCLUDE_DIRS})
+    set (GLIB2_LIBRARIES ${GLIB2_LIBRARIES} gio-2.0 gobject-2.0 gthread-2.0)
+endif()
 
 # BOOST
 set (BOOST_LIBS thread regex system)
 find_package(Boost COMPONENTS ${BOOST_LIBS} REQUIRED)
-
-# GTHREAD
-find_library(GTHREAD gthread-2.0 HINTS "${THIRD_PARTY_LIB}")
-test_lib(${GTHREAD})
 
 # SRTP
 find_library(SRTP srtp2 HINTS "${THIRD_PARTY_LIB}")

--- a/erizo/src/erizo/CMakeLists.txt
+++ b/erizo/src/erizo/CMakeLists.txt
@@ -21,4 +21,4 @@ add_library(erizo SHARED ${ERIZO_SOURCES})
 
 #message("Libs ${SRTP} ${NICE} ${GTHREAD} ${SSL} ${CRYPTO} ${LIBS} ${LOG}")
 
-target_link_libraries(erizo ${GLIB_LIBRARIES} ${Boost_LIBRARIES} ${SRTP} ${NICE} ${GTHREAD} ${SSL} ${CRYPTO} ${LIBS} ${LOG} webrtc nicer nrappkit)
+target_link_libraries(erizo ${GLIB2_LIBRARIES} ${Boost_LIBRARIES} ${SRTP} ${NICE} ${SSL} ${CRYPTO} ${LIBS} ${LOG} webrtc nicer nrappkit)

--- a/erizo/src/erizo/LibNiceConnection.cpp
+++ b/erizo/src/erizo/LibNiceConnection.cpp
@@ -133,7 +133,7 @@ int LibNiceConnection::sendData(unsigned int component_id, const void* buf, int 
   if (this->checkIceState() == IceState::READY) {
     val = lib_nice_->NiceAgentSend(agent_, 1, component_id, len, reinterpret_cast<const gchar*>(buf));
   }
-  if (val != len) {
+  if (val != 1) {
     ELOG_DEBUG("%s message: Sending less data than expected, sent: %d, to_send: %d", toLog(), val, len);
   }
   return val;

--- a/erizo/src/erizo/lib/LibNiceInterfaceImpl.cpp
+++ b/erizo/src/erizo/lib/LibNiceInterfaceImpl.cpp
@@ -63,7 +63,10 @@ namespace erizo {
   }
   int LibNiceInterfaceImpl::NiceAgentSend(NiceAgent* agent, unsigned int stream_id, unsigned int component_id,
       unsigned int len, const char* buf) {
-    return nice_agent_send(agent, stream_id, component_id, len, buf);
+	GError *error = NULL;
+	GOutputVector vec[1] = {{ buf, len }};
+	NiceOutputMessage message = {vec, G_N_ELEMENTS(vec)};
+	return nice_agent_send_messages_nonblocking(agent, stream_id, component_id, &message, 1, NULL, &error);
   }
 
 }  // namespace erizo

--- a/scripts/installMacDeps.sh
+++ b/scripts/installMacDeps.sh
@@ -54,7 +54,7 @@ check_result() {
 install_homebrew_from_cache(){
   if [ -f cache/homebrew-cache.tar.gz ]; then
     tar xzf cache/homebrew-cache.tar.gz --directory /usr/local/Cellar
-    brew link glib pkg-config boost cmake yasm log4cxx gettext coreutils
+    brew link glib pkg-config boost cmake yasm log4cxx gettext coreutils gnutls
   fi
 }
 
@@ -92,7 +92,7 @@ install_homebrew(){
 }
 
 install_brew_deps(){
-  brew install glib pkg-config boost cmake yasm log4cxx gettext coreutils
+  brew install glib pkg-config boost cmake yasm log4cxx gettext coreutils gnutls
   install_nvm_node
   nvm use
   npm install
@@ -139,12 +139,11 @@ install_openssl(){
 install_libnice(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -OL https://nice.freedesktop.org/releases/libnice-0.1.4.tar.gz
-    tar -zxvf libnice-0.1.4.tar.gz
-    cd libnice-0.1.4
+    curl -OL https://nice.freedesktop.org/releases/libnice-0.1.14.tar.gz
+    tar -zxvf libnice-0.1.14.tar.gz
+    cd libnice-0.1.14
     check_result $?
-    patch -R ./agent/conncheck.c < $PATHNAME/libnice-014.patch0
-    ./configure --prefix=$PREFIX_DIR && make $FAST_MAKE -s V=0 && make install
+    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR && make $FAST_MAKE -s V=0 && make install
     check_result $?
     cd $CURRENT_DIR
   else

--- a/scripts/installMacDeps.sh
+++ b/scripts/installMacDeps.sh
@@ -92,7 +92,7 @@ install_homebrew(){
 }
 
 install_brew_deps(){
-  brew install glib pkg-config boost cmake yasm log4cxx gettext coreutils gnutls
+  brew install glib pkg-config boost cmake yasm log4cxx gettext coreutils gnutls gtk-doc
   install_nvm_node
   nvm use
   npm install
@@ -139,11 +139,11 @@ install_openssl(){
 install_libnice(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -OL https://nice.freedesktop.org/releases/libnice-0.1.14.tar.gz
-    tar -zxvf libnice-0.1.14.tar.gz
-    cd libnice-0.1.14
+    curl -L -o libnice-fbdccf0c2787ebdc65fe13ac64bd25c829ea7972.tar.gz https://github.com/libnice/libnice/archive/fbdccf0c2787ebdc65fe13ac64bd25c829ea7972.tar.gz
+    tar -zxvf libnice-fbdccf0c2787ebdc65fe13ac64bd25c829ea7972.tar.gz
+    cd libnice-fbdccf0c2787ebdc65fe13ac64bd25c829ea7972
     check_result $?
-    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR && make $FAST_MAKE -s V=0 && make install
+    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./autogen.sh --prefix=$PREFIX_DIR && make -s V=0 && make install
     check_result $?
     cd $CURRENT_DIR
   else

--- a/scripts/installMacDeps.sh
+++ b/scripts/installMacDeps.sh
@@ -143,7 +143,7 @@ install_libnice(){
     tar -zxvf libnice-fbdccf0c2787ebdc65fe13ac64bd25c829ea7972.tar.gz
     cd libnice-fbdccf0c2787ebdc65fe13ac64bd25c829ea7972
     check_result $?
-    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./autogen.sh --prefix=$PREFIX_DIR && make -s V=0 && make install
+    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig CFLAGS=-Wno-error ./autogen.sh --prefix=$PREFIX_DIR && make -s V=0 && make install
     check_result $?
     cd $CURRENT_DIR
   else

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -75,7 +75,7 @@ install_apt_deps(){
   sudo apt-get install -qq software-properties-common -y
   sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   sudo apt-get update -y
-  sudo apt-get install -qq git make gcc-5 g++-5 libssl-dev cmake libgnutls-dev pkg-config libboost-regex-dev libboost-thread-dev libboost-system-dev liblog4cxx10-dev rabbitmq-server mongodb curl libboost-test-dev -y
+  sudo apt-get install -qq git make gcc-5 g++-5 libssl-dev cmake texinfo gettext gtk-doc-tools libtool autoconf libgnutls-dev pkg-config libboost-regex-dev libboost-thread-dev libboost-system-dev liblog4cxx10-dev rabbitmq-server mongodb curl libboost-test-dev -y
   sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5
 
   sudo chown -R `whoami` ~/.npm ~/tmp/ || true
@@ -160,11 +160,11 @@ install_glib(){
 install_libnice(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    if [ ! -f ./libnice-0.1.14.tar.gz ]; then
-      curl -OL https://nice.freedesktop.org/releases/libnice-0.1.14.tar.gz
-      tar -zxvf libnice-0.1.14.tar.gz
-      cd libnice-0.1.14
-      PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR
+    if [ ! -f ./libnice-fbdccf0c2787ebdc65fe13ac64bd25c829ea7972.tar.gz ]; then
+      curl -L -o libnice-fbdccf0c2787ebdc65fe13ac64bd25c829ea7972.tar.gz https://github.com/libnice/libnice/archive/fbdccf0c2787ebdc65fe13ac64bd25c829ea7972.tar.gz
+      tar -zxvf libnice-fbdccf0c2787ebdc65fe13ac64bd25c829ea7972.tar.gz
+      cd libnice-fbdccf0c2787ebdc65fe13ac64bd25c829ea7972
+      PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./autogen.sh --prefix=$PREFIX_DIR
       make -s V=0
       make install
     else

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -75,7 +75,7 @@ install_apt_deps(){
   sudo apt-get install -qq software-properties-common -y
   sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   sudo apt-get update -y
-  sudo apt-get install -qq git make gcc-5 g++-5 libssl-dev cmake libglib2.0-dev pkg-config libboost-regex-dev libboost-thread-dev libboost-system-dev liblog4cxx10-dev rabbitmq-server mongodb curl libboost-test-dev -y
+  sudo apt-get install -qq git make gcc-5 g++-5 libssl-dev cmake libgnutls-dev pkg-config libboost-regex-dev libboost-thread-dev libboost-system-dev liblog4cxx10-dev rabbitmq-server mongodb curl libboost-test-dev -y
   sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5
 
   sudo chown -R `whoami` ~/.npm ~/tmp/ || true
@@ -115,16 +115,57 @@ install_openssl(){
   fi
 }
 
+install_libffi(){
+  if [ -d $LIB_DIR ]; then
+    cd $LIB_DIR
+    if [ ! -f ./libffi-3.2.1.tar.gz ]; then
+      curl -L -o libffi-3.2.1.tar.gz https://github.com/libffi/libffi/archive/v3.2.1.tar.gz
+      tar -zxvf libffi-3.2.1.tar.gz
+      cd libffi-3.2.1
+      ./autogen.sh
+      ./configure --prefix=$PREFIX_DIR
+      make -s V=0
+      make install
+    else
+      echo "libffi already installed"
+    fi
+    cd $CURRENT_DIR
+  else
+    mkdir -p $LIB_DIR
+    install_libffi
+  fi
+}
+
+install_glib(){
+  if [ -d $LIB_DIR ]; then
+    cd $LIB_DIR
+    if [ ! -f ./glib-2.54.1.tar.gz ]; then
+      curl -L -o glib-2.54.1.tar.gz https://github.com/GNOME/glib/archive/2.54.1.tar.gz
+      tar -zxvf glib-2.54.1.tar.gz
+      cd glib-2.54.1
+      ./autogen.sh
+      PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --disable-libmount
+      make -s V=0
+      make install
+    else
+      echo "glib already installed"
+    fi
+    cd $CURRENT_DIR
+  else
+    mkdir -p $LIB_DIR
+    install_glib
+  fi
+}
+
 install_libnice(){
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    if [ ! -f ./libnice-0.1.4.tar.gz ]; then
-      curl -OL https://nice.freedesktop.org/releases/libnice-0.1.4.tar.gz
-      tar -zxvf libnice-0.1.4.tar.gz
-      cd libnice-0.1.4
-      patch -R ./agent/conncheck.c < $PATHNAME/libnice-014.patch0
-      ./configure --prefix=$PREFIX_DIR
-      make $FAST_MAKE -s V=0
+    if [ ! -f ./libnice-0.1.14.tar.gz ]; then
+      curl -OL https://nice.freedesktop.org/releases/libnice-0.1.14.tar.gz
+      tar -zxvf libnice-0.1.14.tar.gz
+      cd libnice-0.1.14
+      PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR
+      make -s V=0
       make install
     else
       echo "libnice already installed"
@@ -232,6 +273,8 @@ mkdir -p $PREFIX_DIR
 install_apt_deps
 check_proxy
 install_openssl
+install_libffi
+install_glib
 install_libnice
 install_libsrtp
 


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see:
http://lynckia.com/licode/contribute.html
-->

**Description**

This's a PR to update libnice to the revision: fbdccf0c2787ebdc65fe13ac64bd25c829ea7972 (from libnice mirror github), which is their current head.

We previously tried to link erizo against libnice 0.1.14 tag, but the latter works only in localhost. It seems there was a bug with srflx candidates that was discovered and fixed a year after the release.

On Ubuntu, glib is now built from source together with its dependency (libffi) and the necessary system-wide libraries are installed with apt. On Mac, brew is used to install system-wide dependencies.

It would be a great help to us if you could try this version of libnice with a couple different networks to see if there are issues.

<!--
Add a short description here, please.
If the contribution needs and includes Unit Tests check the box below.
-->

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.
