### PR TITLE
Fix nuve createroom

### DIFF
--- a/nuve/nuveAPI/mdb/serviceRegistry.js
+++ b/nuve/nuveAPI/mdb/serviceRegistry.js
@@ -55,9 +55,10 @@ exports.addService = function (service, callback) {
 /*
  * Updates a determined service in the data base.
  */
-exports.updateService = function (service) {
+exports.updateService = function (service, callback) {
     db.services.save(service, function (error) {
         if (error) log.info('message: updateService error, ' + logger.objectToLog(error));
+        if (callback) callback();
     });
 };
 

--- a/nuve/nuveAPI/mdb/serviceRegistry.js
+++ b/nuve/nuveAPI/mdb/serviceRegistry.js
@@ -63,6 +63,17 @@ exports.updateService = function (service, callback) {
 };
 
 /*
+ * Updates a determined service in the data base with a new room.
+ */
+exports.addRoomToService = function (service, room, callback) {
+    db.services.update({_id: db.ObjectId(service._id)}, {$addToSet: {rooms: room}},
+    function (error) {
+        if (error) log.info('message: updateService error, ' + logger.objectToLog(error));
+        if (callback) callback();
+    });
+};
+
+/*
  * Removes a determined service from the data base.
  */
 exports.removeService = function (id) {

--- a/nuve/nuveAPI/resource/roomsResource.js
+++ b/nuve/nuveAPI/resource/roomsResource.js
@@ -34,7 +34,7 @@ exports.createRoom = function (req, res) {
             roomRegistry.addRoom(room, function (result) {
                 currentService.testRoom = result;
                 currentService.rooms.push(result);
-                serviceRegistry.updateService(currentService);
+                serviceRegistry.addRoomToService(currentService, result);
                 log.info('message: testRoom created, serviceId: ' + currentService.name);
                 res.send(result);
             });

--- a/nuve/nuveAPI/resource/roomsResource.js
+++ b/nuve/nuveAPI/resource/roomsResource.js
@@ -2,21 +2,8 @@
 'use strict';
 var roomRegistry = require('./../mdb/roomRegistry');
 var serviceRegistry = require('./../mdb/serviceRegistry');
-var async = require ('async');
 var logger = require('./../logger').logger;
 var log = logger.getLogger('RoomsResource');
-
-var addRoom = async.queue((task, done) => {
-  serviceRegistry.getService(task.currentService._id, function (serv) {
-    serv.rooms.push(task.result);
-    serviceRegistry.updateService(serv, function() {
-      log.info('message: createRoom success, roomName: ' + task.req.body.name + ', serviceId: ' +
-               serv.name + ', p2p: ' + !!task.req.body.options.p2p + ', roomId: ', task.result._id);
-      task.callback(task.result);
-      done();
-    });
-  });
-});
 
 /*
  * Post Room. Creates a new room for a determined service.
@@ -62,13 +49,11 @@ exports.createRoom = function (req, res) {
             room.mediaConfiguration = req.body.options.mediaConfiguration;
         }
         roomRegistry.addRoom(room, function (result) {
-          addRoom.push({result: result,
-                        currentService: currentService,
-                        req: req,
-                        callback: function(result) {
-                          res.send(result);
-                        }
-          });
+          currentService.rooms.push(result);
+          serviceRegistry.addRoomToService(currentService, result);
+          log.info('message: createRoom success, roomName:' + req.body.name + ', serviceId: ' +
+                   currentService.name + ', p2p: ' + room.p2p);
+          res.send(result);
         });
     }
 };

--- a/nuve/nuveAPI/resource/roomsResource.js
+++ b/nuve/nuveAPI/resource/roomsResource.js
@@ -41,7 +41,9 @@ exports.createRoom = function (req, res) {
         }
     } else {
         room = {name: req.body.name};
-        room.p2p = !!req.body.options.p2p;
+        if (req.body.options.p2p) {
+            room.p2p = true;
+        }
         if (req.body.options.data) {
             room.data = req.body.options.data;
         }


### PR DESCRIPTION
**Description**

This PR fixes with the help of a queue the createroom method in nuve.
The bug manifest itself when creating 2 or more different rooms at the same time (only the last were added to services/room in mongodb.

[] It needs and includes Unit Tests

Step to reproduce the issue without this fix:
open basicServer.js and call somewhere these 2 functions
`          
function testCreateRoom() {
  N.API.createRoom('test1', function(roomID) {},function error(){});
  N.API.createRoom('test2', function(roomID) {},function error(){});
}
`
go to your mongo instance and check rooms collection: OK, there are both.
now check your room object in your service object: FAIL, only test2 is present.

Why? because the service object is attached to request when doing the authenticate method.
so, both calls arrives to the server, the server authenticate then, attach to request the currentservice object and then both call createroom. they add their own room to the previosly obtained service object then call updateservice (which rewrite the service in mongo instead of taking in account differences from before and after.

with this method we simply update rooms inside without the risk of losing it

[] It includes documentation for these changes in `/doc`.