### PR TITLE
gulp watch 60x time faster

### DIFF
--- a/erizo_controller/erizoClient/gulp/erizoFcTasks.js
+++ b/erizo_controller/erizoClient/gulp/erizoFcTasks.js
@@ -16,13 +16,15 @@ const erizoFcTasks = (gulp, plugins, config) => {
     .pipe(gulp.dest(erizoFcConfig.debug))
     .on('error', anError => console.log('An error ', anError));
 
-  that.compile = () => {
-    return gulp.src(`${erizoFcConfig.debug}/**/*.js`)
+  that.compile = () => gulp.src(`${erizoFcConfig.debug}/**/*.js`)
     .pipe(gulp.dest(erizoFcConfig.production));
-  }
 
   that.dist = () =>
     gulp.src(`${erizoFcConfig.production}/**/*.js`)
+    .pipe(gulp.dest(config.paths.spine));
+
+  that.debug = () =>
+    gulp.src(`${erizoFcConfig.debug}/**/*.js`)
     .pipe(gulp.dest(config.paths.spine));
 
   that.clean = () =>

--- a/erizo_controller/erizoClient/gulp/erizoTasks.js
+++ b/erizo_controller/erizoClient/gulp/erizoTasks.js
@@ -33,6 +33,10 @@ const erizoTasks = (gulp, plugins, config) => {
     gulp.src(`${erizoConfig.production}/**/*.js*`)
     .pipe(gulp.dest(config.paths.basicExample));
 
+  that.debug = () =>
+    gulp.src(`${erizoConfig.debug}/**/*.js*`)
+    .pipe(gulp.dest(config.paths.basicExample));
+
   that.clean = () =>
     plugins.del([`${erizoConfig.debug}/**/*.js*`, `${erizoConfig.production}/**/*.js*`],
     { force: true });

--- a/erizo_controller/erizoClient/gulpfile.js
+++ b/erizo_controller/erizoClient/gulpfile.js
@@ -23,10 +23,10 @@ const config = {
   },
 };
 
-const tasks = ['clean', 'bundle', 'compile', 'dist'];
+const tasks = ['clean', 'bundle', 'compile', 'dist', 'debug'];
 const targets = ['erizo', 'erizofc'];
 const allTasks = ['lint'];
-
+const debugTasks = ['clean_erizo', 'bundle_erizo', 'debug_erizo'];
 
 const taskFunctions = {};
 taskFunctions.erizo = require('./gulp/erizoTasks.js')(gulp, plugins, config);
@@ -40,28 +40,28 @@ targets.forEach(
         const taskName = `${task}_${target}`;
         allTasks.push(taskName);
         targetTasks.push(taskName);
-        gulp.task(taskName, () => {
-          return taskFunctions[target][task]()
-        });
+        gulp.task(taskName, () => taskFunctions[target][task]());
       });
     gulp.task(target, () => {
       plugins.runSequence(...targetTasks);
-    })
+    });
   });
 
-gulp.task('lint', () => {
-  return gulp.src(config.paths.js)
+gulp.task('lint', () => gulp.src(config.paths.js)
   .pipe(plugins.eslint())
   .pipe(plugins.eslint.format())
-  .pipe(plugins.eslint.failAfterError());
-});
+  .pipe(plugins.eslint.failAfterError()));
 
 gulp.task('watch', () => {
   const watcher = gulp.watch('src/**/*.js');
   watcher.on('change', (event) => {
-    console.log('File ' + event.path + ' was ' + event.type + ', running tasks...');
-    plugins.runSequence('default');
+    console.log(`File ${event.path} was ${event.type}, running tasks...`);
+    plugins.runSequence('debug');
   });
+});
+
+gulp.task('debug', () => {
+  plugins.runSequence(...debugTasks);
 });
 
 gulp.task('default', () => {

--- a/erizo_controller/erizoClient/gulpfile.js
+++ b/erizo_controller/erizoClient/gulpfile.js
@@ -23,7 +23,7 @@ const config = {
   },
 };
 
-const tasks = ['clean', 'bundle', 'compile', 'dist', 'debug'];
+const tasks = ['clean', 'bundle', 'debug', 'compile', 'dist'];
 const targets = ['erizo', 'erizofc'];
 const allTasks = ['lint'];
 const debugTasks = ['clean_erizo', 'bundle_erizo', 'debug_erizo'];

--- a/nuve/nuveAPI/mdb/serviceRegistry.js
+++ b/nuve/nuveAPI/mdb/serviceRegistry.js
@@ -55,9 +55,10 @@ exports.addService = function (service, callback) {
 /*
  * Updates a determined service in the data base.
  */
-exports.updateService = function (service) {
+exports.updateService = function (service, callback) {
     db.services.save(service, function (error) {
         if (error) log.info('message: updateService error, ' + logger.objectToLog(error));
+        if (callback) callback();
     });
 };
 

--- a/nuve/nuveAPI/mdb/serviceRegistry.js
+++ b/nuve/nuveAPI/mdb/serviceRegistry.js
@@ -63,6 +63,17 @@ exports.updateService = function (service, callback) {
 };
 
 /*
+ * Updates a determined service in the data base with a new room.
+ */
+exports.addRoomToService = function (service, room, callback) {
+    db.services.update({_id: db.ObjectId(service._id)}, {$addToSet: {rooms: room}},
+    function (error) {
+        if (error) log.info('message: updateService error, ' + logger.objectToLog(error));
+        if (callback) callback();
+    });
+};
+
+/*
  * Removes a determined service from the data base.
  */
 exports.removeService = function (id) {

--- a/nuve/nuveAPI/resource/roomsResource.js
+++ b/nuve/nuveAPI/resource/roomsResource.js
@@ -34,7 +34,7 @@ exports.createRoom = function (req, res) {
             roomRegistry.addRoom(room, function (result) {
                 currentService.testRoom = result;
                 currentService.rooms.push(result);
-                serviceRegistry.updateService(currentService);
+                serviceRegistry.addRoomToService(currentService, result);
                 log.info('message: testRoom created, serviceId: ' + currentService.name);
                 res.send(result);
             });

--- a/nuve/nuveAPI/resource/roomsResource.js
+++ b/nuve/nuveAPI/resource/roomsResource.js
@@ -2,21 +2,8 @@
 'use strict';
 var roomRegistry = require('./../mdb/roomRegistry');
 var serviceRegistry = require('./../mdb/serviceRegistry');
-var async = require ('async');
 var logger = require('./../logger').logger;
 var log = logger.getLogger('RoomsResource');
-
-var addRoom = async.queue((task, done) => {
-  serviceRegistry.getService(task.currentService._id, function (serv) {
-    serv.rooms.push(task.result);
-    serviceRegistry.updateService(serv, function() {
-      log.info('message: createRoom success, roomName: ' + task.req.body.name + ', serviceId: ' +
-               serv.name + ', p2p: ' + !!task.req.body.options.p2p + ', roomId: ', task.result._id);
-      task.callback(task.result);
-      done();
-    });
-  });
-});
 
 /*
  * Post Room. Creates a new room for a determined service.
@@ -62,13 +49,11 @@ exports.createRoom = function (req, res) {
             room.mediaConfiguration = req.body.options.mediaConfiguration;
         }
         roomRegistry.addRoom(room, function (result) {
-          addRoom.push({result: result,
-                        currentService: currentService,
-                        req: req,
-                        callback: function(result) {
-                          res.send(result);
-                        }
-          });
+          currentService.rooms.push(result);
+          serviceRegistry.addRoomToService(currentService, result);
+          log.info('message: createRoom success, roomName:' + req.body.name + ', serviceId: ' +
+                   currentService.name + ', p2p: ' + room.p2p);
+          res.send(result);
         });
     }
 };


### PR DESCRIPTION
Simply create new task in webpack which skips the google closure compiler when launching gulp watch.
Useful in development since every change we made it only takes couple of seconds to clean / bundle / dist
It also copy the debug version of licode client to basicexample instead of the production one.

[] It needs and includes Unit Tests
[] It includes documentation for these changes in `/doc`.