### PR TITLE
Gulp watch 60x faster

### DIFF
--- a/erizo_controller/erizoClient/gulp/erizoFcTasks.js
+++ b/erizo_controller/erizoClient/gulp/erizoFcTasks.js
@@ -16,13 +16,15 @@ const erizoFcTasks = (gulp, plugins, config) => {
     .pipe(gulp.dest(erizoFcConfig.debug))
     .on('error', anError => console.log('An error ', anError));
 
-  that.compile = () => {
-    return gulp.src(`${erizoFcConfig.debug}/**/*.js`)
+  that.compile = () => gulp.src(`${erizoFcConfig.debug}/**/*.js`)
     .pipe(gulp.dest(erizoFcConfig.production));
-  }
 
   that.dist = () =>
     gulp.src(`${erizoFcConfig.production}/**/*.js`)
+    .pipe(gulp.dest(config.paths.spine));
+
+  that.debug = () =>
+    gulp.src(`${erizoFcConfig.debug}/**/*.js`)
     .pipe(gulp.dest(config.paths.spine));
 
   that.clean = () =>

--- a/erizo_controller/erizoClient/gulp/erizoTasks.js
+++ b/erizo_controller/erizoClient/gulp/erizoTasks.js
@@ -33,6 +33,10 @@ const erizoTasks = (gulp, plugins, config) => {
     gulp.src(`${erizoConfig.production}/**/*.js*`)
     .pipe(gulp.dest(config.paths.basicExample));
 
+  that.debug = () =>
+    gulp.src(`${erizoConfig.debug}/**/*.js*`)
+    .pipe(gulp.dest(config.paths.basicExample));
+
   that.clean = () =>
     plugins.del([`${erizoConfig.debug}/**/*.js*`, `${erizoConfig.production}/**/*.js*`],
     { force: true });

--- a/erizo_controller/erizoClient/gulpfile.js
+++ b/erizo_controller/erizoClient/gulpfile.js
@@ -23,10 +23,10 @@ const config = {
   },
 };
 
-const tasks = ['clean', 'bundle', 'compile', 'dist'];
+const tasks = ['clean', 'bundle', 'debug', 'compile', 'dist'];
 const targets = ['erizo', 'erizofc'];
 const allTasks = ['lint'];
-
+const debugTasks = ['clean_erizo', 'bundle_erizo', 'debug_erizo'];
 
 const taskFunctions = {};
 taskFunctions.erizo = require('./gulp/erizoTasks.js')(gulp, plugins, config);
@@ -40,28 +40,28 @@ targets.forEach(
         const taskName = `${task}_${target}`;
         allTasks.push(taskName);
         targetTasks.push(taskName);
-        gulp.task(taskName, () => {
-          return taskFunctions[target][task]()
-        });
+        gulp.task(taskName, () => taskFunctions[target][task]());
       });
     gulp.task(target, () => {
       plugins.runSequence(...targetTasks);
-    })
+    });
   });
 
-gulp.task('lint', () => {
-  return gulp.src(config.paths.js)
+gulp.task('lint', () => gulp.src(config.paths.js)
   .pipe(plugins.eslint())
   .pipe(plugins.eslint.format())
-  .pipe(plugins.eslint.failAfterError());
-});
+  .pipe(plugins.eslint.failAfterError()));
 
 gulp.task('watch', () => {
   const watcher = gulp.watch('src/**/*.js');
   watcher.on('change', (event) => {
-    console.log('File ' + event.path + ' was ' + event.type + ', running tasks...');
-    plugins.runSequence('default');
+    console.log(`File ${event.path} was ${event.type}, running tasks...`);
+    plugins.runSequence('debug');
   });
+});
+
+gulp.task('debug', () => {
+  plugins.runSequence(...debugTasks);
 });
 
 gulp.task('default', () => {


### PR DESCRIPTION
Simply create new task in webpack which skips the google closure compiler when launching gulp watch.
Useful in development since every change we made it only takes couple of seconds to clean / bundle / dist
It also copy the debug version of licode client to basicexample instead of the production one.

