### PR TITLE
Add close ErizoController on KeepAlive failure

### DIFF
--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -201,7 +201,8 @@ var addToCloudHandler = function (callback) {
           if (!result) {
               nuve.killMe(publicIP);
               if (EXIT_ON_NUVE_CHECK_FAIL) {
-                  log.error('message: Closing ErizoController - does not exist in Nuve CloudHandler');
+                  log.error('message: Closing ErizoController ' +
+                   '- does not exist in Nuve CloudHandler');
                   process.exit(-1);
               }
           }

--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -198,10 +198,10 @@ var addToCloudHandler = function (callback) {
           }
           return true;
         }).then((result) => {
-          if (!result) { 
+          if (!result) {
               nuve.killMe(publicIP);
-              log.error('message: This erizoController Killing ErizoController');
               if (EXIT_ON_NUVE_CHECK_FAIL) {
+                  log.error('message: Closing ErizoController - does not exist in Nuve CloudHandler');
                   process.exit(-1);
               }
           }

--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -33,6 +33,7 @@ global.config.erizoController.report.session_events =
   global.config.erizoController.report.session_events || false;
 global.config.erizoController.recording_path =
   global.config.erizoController.recording_path || undefined;
+global.config.erizoController.exitOnNuveCheckFail = global.config.erizoController.exitOnNuveCheckFail || false;
 // jshint ignore:end
 global.config.erizoController.roles = global.config.erizoController.roles ||
                   {'presenter': {'publish': true, 'subscribe': true, 'record': true},
@@ -132,6 +133,7 @@ var io = require('socket.io').listen(server, {log:false});
 
 io.set('transports', ['websocket']);
 
+var EXIT_ON_NUVE_CHECK_FAIL = global.config.erizoController.exitOnNuveCheckFail;
 var WARNING_N_ROOMS = global.config.erizoController.warning_n_rooms; // jshint ignore:line
 var LIMIT_N_ROOMS = global.config.erizoController.limit_n_rooms; // jshint ignore:line
 
@@ -196,7 +198,14 @@ var addToCloudHandler = function (callback) {
           }
           return true;
         }).then((result) => {
-          if (!result) return nuve.killMe(publicIP);
+          if (!result) { 
+              nuve.killMe(publicIP);
+              log.error('message: This erizoController Killing ErizoController');
+              if (EXIT_ON_NUVE_CHECK_FAIL) {
+                  process.exit(-1);
+              }
+          }
+
         });
       }, INTERVAL_TIME_KEEPALIVE);
     };
@@ -225,7 +234,7 @@ var addToCloudHandler = function (callback) {
           callback('callback');
         }).catch(reason => {
           if (reason === 'timeout') {
-            log.warn('message: addECToCloudHandler cloudHandler does not respondr, ' +
+            log.warn('message: addECToCloudHandler cloudHandler does not respond, ' +
                      'attemptsLeft: ' + attempt );
 
             // We'll try it more!

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -80,6 +80,8 @@ config.erizoController.listen_port = 8080; //default value: 8080
 // Use the name of the inferface you want to bind to for websockets
 // config.erizoController.networkInterface = 'eth1' // default value: undefined
 
+config.erizoController.exitOnNuveCheckFail = false;  // default value: false
+
 config.erizoController.warning_n_rooms = 15; // default value: 15
 config.erizoController.limit_n_rooms = 20; // default value: 20
 config.erizoController.interval_time_keepAlive = 1000; // default value: 1000


### PR DESCRIPTION

**Description**
ErizoControllers send keep alive messages to Nuve as a health check. If Nuve receives a message from an unknown (not previously identified) ErizoController, it will answer the keep alive message with `whoareyou`. 

This PR allows to modify the behavior of ErizoController when receiving this message by configuration. If `exitOnNuveCheckFail` is enabled, ErizoController will automatically exit.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.