### PR TITLE
Fixed screen sharing when no video param is included in config

### DIFF
--- a/erizo_controller/erizoClient/src/Connection.js
+++ b/erizo_controller/erizoClient/src/Connection.js
@@ -125,7 +125,7 @@ const GetUserMedia = (config, callback = () => {}, error = () => {}) => {
                 }
                 const theId = response.streamId;
                 if (config.video.mandatory !== undefined) {
-                  screenConfig.video = config.video;
+                  screenConfig.video = config.video || { mandatory: {} };
                   screenConfig.video.mandatory.chromeMediaSource = 'desktop';
                   screenConfig.video.mandatory.chromeMediaSourceId = theId;
                 } else {


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR fixes screen sharing streams initialization when no video parameter is included.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.