### PR TITLE
Remove usage of "throw errors" in Erizo

### DIFF
--- a/erizo/src/erizo/pipeline/Pipeline-inl.h
+++ b/erizo/src/erizo/pipeline/Pipeline-inl.h
@@ -63,10 +63,6 @@ PipelineBase& PipelineBase::removeHelper(H* handler, bool checkEqual) {
     }
   }
 
-  if (!removed) {
-    throw std::invalid_argument("No such handler in pipeline");
-  }
-
   return *this;
 }
 
@@ -188,10 +184,6 @@ void PipelineBase::removeService() {
         break;
       }
     }
-  }
-
-  if (!removed) {
-    throw std::invalid_argument("No such handler in pipeline");
   }
 }
 

--- a/erizo/src/erizo/pipeline/Pipeline.cpp
+++ b/erizo/src/erizo/pipeline/Pipeline.cpp
@@ -37,7 +37,7 @@ PipelineBase::ContextIterator PipelineBase::removeAt(
 
 PipelineBase& PipelineBase::removeFront() {
   if (ctxs_.empty()) {
-    throw std::invalid_argument("No handlers in pipeline");
+    return *this;
   }
   removeAt(ctxs_.begin());
   return *this;
@@ -45,7 +45,7 @@ PipelineBase& PipelineBase::removeFront() {
 
 PipelineBase& PipelineBase::removeBack() {
   if (ctxs_.empty()) {
-    throw std::invalid_argument("No handlers in pipeline");
+    return *this;
   }
   removeAt(--ctxs_.end());
   return *this;

--- a/erizo/src/erizo/thread/Scheduler.cpp
+++ b/erizo/src/erizo/thread/Scheduler.cpp
@@ -48,7 +48,7 @@ void Scheduler::serviceQueue() {
       lock.lock();
     } catch (...) {
       --n_threads_servicing_queue_;
-      throw;
+      assert(false && "An exception has been thrown inside Scheduler");
     }
   }
   --n_threads_servicing_queue_;


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

We've seen some crashes in Erizo that does not show info such as a backtrace, and it seems like it can be cause by an error thrown that is not properly [handled by GCC probably](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55917).

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.