### PR TITLE
Separate Media from WebRTCConnection

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -1,0 +1,515 @@
+
+/*
+ * MediaStream.cpp
+ */
+
+#include <cstdio>
+#include <map>
+#include <algorithm>
+#include <string>
+#include <cstring>
+#include <vector>
+
+#include "./MediaStream.h"
+#include "./SdpInfo.h"
+#include"./WebRtcConnection.h"
+#include "rtp/RtpHeaders.h"
+#include "rtp/RtpVP8Parser.h"
+#include "rtp/RtcpAggregator.h"
+#include "rtp/RtcpForwarder.h"
+#include "rtp/RtpSlideShowHandler.h"
+#include "rtp/RtpTrackMuteHandler.h"
+#include "rtp/BandwidthEstimationHandler.h"
+#include "rtp/FecReceiverHandler.h"
+#include "rtp/RtcpProcessorHandler.h"
+#include "rtp/RtpRetransmissionHandler.h"
+#include "rtp/RtcpFeedbackGenerationHandler.h"
+#include "rtp/RtpPaddingRemovalHandler.h"
+#include "rtp/StatsHandler.h"
+#include "rtp/SRPacketHandler.h"
+#include "rtp/SenderBandwidthEstimationHandler.h"
+#include "rtp/LayerDetectorHandler.h"
+#include "rtp/LayerBitrateCalculationHandler.h"
+#include "rtp/QualityFilterHandler.h"
+#include "rtp/QualityManager.h"
+#include "rtp/PliPacerHandler.h"
+#include "rtp/RtpPaddingGeneratorHandler.h"
+#include "rtp/RtpUtils.h"
+
+namespace erizo {
+DEFINE_LOGGER(MediaStream, "MediaStream");
+
+MediaStream::MediaStream(
+  std::shared_ptr<WebRtcConnection> connection,
+  const std::string& media_stream_id) :
+    audioEnabled_{false}, videoEnabled_{false},
+    connection_{connection},
+    stream_id_{media_stream_id},
+    bundle_{false},
+    pipeline_{Pipeline::create()}, audio_muted_{false}, video_muted_{false},
+    pipeline_initialized_{false} {
+  setVideoSinkSSRC(kDefaultVideoSinkSSRC);
+  setAudioSinkSSRC(kDefaultAudioSinkSSRC);
+  ELOG_INFO("%s message: constructor, id: %s",
+      toLog(), media_stream_id.c_str());
+  source_fb_sink_ = this;
+  sink_fb_source_ = this;
+  stats_ = connection->getStatsService();
+  quality_manager_ = std::make_shared<QualityManager>();
+  packet_buffer_ = std::make_shared<PacketBufferService>();
+  worker_ = connection->getWorker();
+
+  rtcp_processor_ = std::make_shared<RtcpForwarder>(static_cast<MediaSink*>(this), static_cast<MediaSource*>(this));
+
+  shouldSendFeedback_ = true;
+  slide_show_mode_ = false;
+
+  mark_ = clock::now();
+
+  rateControl_ = 0;
+  sending_ = true;
+}
+
+MediaStream::~MediaStream() {
+  ELOG_DEBUG("%s message:Destructor called", toLog());
+  if (sending_) {
+    close();
+  }
+  ELOG_DEBUG("%s message: Destructor ended", toLog());
+}
+
+void MediaStream::close() {
+  ELOG_DEBUG("%s message:Close called", toLog());
+  if (!sending_) {
+    return;
+  }
+  sending_ = false;
+  video_sink_ = nullptr;
+  audio_sink_ = nullptr;
+  fb_sink_ = nullptr;
+  pipeline_->close();
+  pipeline_.reset();
+  connection_.reset();
+  ELOG_DEBUG("%s message: Close ended", toLog());
+}
+
+bool MediaStream::init() {
+  return true;
+}
+
+bool MediaStream::isSourceSSRC(uint32_t ssrc) {
+  return isVideoSourceSSRC(ssrc) || isAudioSourceSSRC(ssrc);
+}
+
+bool MediaStream::isSinkSSRC(uint32_t ssrc) {
+  return isVideoSinkSSRC(ssrc) || isAudioSinkSSRC(ssrc);
+}
+
+bool MediaStream::setRemoteSdp(std::shared_ptr<SdpInfo> sdp) {
+  ELOG_DEBUG("%s message: setting remote SDP", toLog());
+  remote_sdp_ = sdp;
+  if (remote_sdp_->videoBandwidth != 0) {
+    ELOG_DEBUG("%s message: Setting remote BW, maxVideoBW: %u", toLog(), remote_sdp_->videoBandwidth);
+    this->rtcp_processor_->setMaxVideoBW(remote_sdp_->videoBandwidth*1000);
+  }
+
+  if (pipeline_initialized_) {
+    pipeline_->notifyUpdate();
+    return true;
+  }
+
+
+  bundle_ = remote_sdp_->isBundle;
+
+  setVideoSourceSSRCList(remote_sdp_->video_ssrc_list);
+  setAudioSourceSSRC(remote_sdp_->audio_ssrc);
+
+  audioEnabled_ = remote_sdp_->hasAudio;
+  videoEnabled_ = remote_sdp_->hasVideo;
+
+  rtcp_processor_->addSourceSsrc(getAudioSourceSSRC());
+  std::for_each(video_source_ssrc_list_.begin(), video_source_ssrc_list_.end(), [this] (uint32_t new_ssrc){
+      rtcp_processor_->addSourceSsrc(new_ssrc);
+  });
+
+  initializePipeline();
+
+  return true;
+}
+
+bool MediaStream::setLocalSdp(std::shared_ptr<SdpInfo> sdp) {
+  local_sdp_ = sdp;
+  return true;
+}
+
+void MediaStream::initializePipeline() {
+  pipeline_->addService(shared_from_this());
+  pipeline_->addService(rtcp_processor_);
+  pipeline_->addService(stats_);
+  pipeline_->addService(quality_manager_);
+  pipeline_->addService(packet_buffer_);
+
+  pipeline_->addFront(PacketReader(this));
+
+  pipeline_->addFront(LayerDetectorHandler());
+  pipeline_->addFront(RtcpProcessorHandler());
+  pipeline_->addFront(FecReceiverHandler());
+  pipeline_->addFront(LayerBitrateCalculationHandler());
+  pipeline_->addFront(QualityFilterHandler());
+  pipeline_->addFront(IncomingStatsHandler());
+  pipeline_->addFront(RtpTrackMuteHandler());
+  pipeline_->addFront(RtpSlideShowHandler());
+  pipeline_->addFront(RtpPaddingGeneratorHandler());
+  pipeline_->addFront(PliPacerHandler());
+  pipeline_->addFront(BandwidthEstimationHandler());
+  pipeline_->addFront(RtpPaddingRemovalHandler());
+  pipeline_->addFront(RtcpFeedbackGenerationHandler());
+  pipeline_->addFront(RtpRetransmissionHandler());
+  pipeline_->addFront(SRPacketHandler());
+  pipeline_->addFront(SenderBandwidthEstimationHandler());
+  pipeline_->addFront(OutgoingStatsHandler());
+
+  pipeline_->addFront(PacketWriter(this));
+  pipeline_->finalize();
+  pipeline_initialized_ = true;
+}
+
+int MediaStream::deliverAudioData_(std::shared_ptr<DataPacket> audio_packet) {
+  if (audioEnabled_ == true) {
+    sendPacketAsync(std::make_shared<DataPacket>(*audio_packet));
+  }
+  return audio_packet->length;
+}
+
+int MediaStream::deliverVideoData_(std::shared_ptr<DataPacket> video_packet) {
+  if (videoEnabled_ == true) {
+    sendPacketAsync(std::make_shared<DataPacket>(*video_packet));
+  }
+  return video_packet->length;
+}
+
+int MediaStream::deliverFeedback_(std::shared_ptr<DataPacket> fb_packet) {
+  RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(fb_packet->data);
+  uint32_t recvSSRC = chead->getSourceSSRC();
+  if (isVideoSourceSSRC(recvSSRC)) {
+    fb_packet->type = VIDEO_PACKET;
+    sendPacketAsync(fb_packet);
+  } else if (isAudioSourceSSRC(recvSSRC)) {
+    fb_packet->type = AUDIO_PACKET;
+    sendPacketAsync(fb_packet);
+  } else {
+    ELOG_DEBUG("%s deliverFeedback unknownSSRC: %u, localVideoSSRC: %u, localAudioSSRC: %u",
+                toLog(), recvSSRC, this->getVideoSourceSSRC(), this->getAudioSourceSSRC());
+  }
+  return fb_packet->length;
+}
+
+int MediaStream::deliverEvent_(MediaEventPtr event) {
+  auto conn_ptr = shared_from_this();
+  worker_->task([conn_ptr, event]{
+    if (!conn_ptr->pipeline_initialized_) {
+      return;
+    }
+    conn_ptr->pipeline_->notifyEvent(event);
+  });
+  return 1;
+}
+
+void MediaStream::onTransportData(std::shared_ptr<DataPacket> packet, Transport *transport) {
+  if ((audio_sink_ == nullptr && video_sink_ == nullptr && fb_sink_ == nullptr)) {
+    return;
+  }
+
+  if (transport->mediaType == AUDIO_TYPE) {
+    packet->type = AUDIO_PACKET;
+  } else if (transport->mediaType == VIDEO_TYPE) {
+    packet->type = VIDEO_PACKET;
+  }
+
+  char* buf = packet->data;
+  RtpHeader *head = reinterpret_cast<RtpHeader*> (buf);
+  RtcpHeader *chead = reinterpret_cast<RtcpHeader*> (buf);
+  if (!chead->isRtcp()) {
+    uint32_t recvSSRC = head->getSSRC();
+    if (isVideoSourceSSRC(recvSSRC)) {
+      packet->type = VIDEO_PACKET;
+    } else if (isAudioSourceSSRC(recvSSRC)) {
+      packet->type = AUDIO_PACKET;
+    }
+  }
+
+  if (!pipeline_initialized_) {
+    ELOG_DEBUG("%s message: Pipeline not initialized yet.", toLog());
+    return;
+  }
+
+  pipeline_->read(std::move(packet));
+}
+
+void MediaStream::read(std::shared_ptr<DataPacket> packet) {
+  char* buf = packet->data;
+  int len = packet->length;
+  // PROCESS RTCP
+  RtpHeader *head = reinterpret_cast<RtpHeader*> (buf);
+  RtcpHeader *chead = reinterpret_cast<RtcpHeader*> (buf);
+  uint32_t recvSSRC;
+  if (!chead->isRtcp()) {
+    recvSSRC = head->getSSRC();
+  } else if (chead->packettype == RTCP_Sender_PT) {  // Sender Report
+    recvSSRC = chead->getSSRC();
+  }
+  // DELIVER FEEDBACK (RR, FEEDBACK PACKETS)
+  if (chead->isFeedback()) {
+    if (fb_sink_ != nullptr && shouldSendFeedback_) {
+      fb_sink_->deliverFeedback(std::move(packet));
+    }
+  } else {
+    // RTP or RTCP Sender Report
+    if (bundle_) {
+      // Check incoming SSRC
+      // Deliver data
+      if (isVideoSourceSSRC(recvSSRC)) {
+        parseIncomingPayloadType(buf, len, VIDEO_PACKET);
+        video_sink_->deliverVideoData(std::move(packet));
+      } else if (isAudioSourceSSRC(recvSSRC)) {
+        parseIncomingPayloadType(buf, len, AUDIO_PACKET);
+        audio_sink_->deliverAudioData(std::move(packet));
+      } else {
+        ELOG_DEBUG("%s read video unknownSSRC: %u, localVideoSSRC: %u, localAudioSSRC: %u",
+                    toLog(), recvSSRC, this->getVideoSourceSSRC(), this->getAudioSourceSSRC());
+      }
+    } else {
+      if (packet->type == AUDIO_PACKET && audio_sink_ != nullptr) {
+        parseIncomingPayloadType(buf, len, AUDIO_PACKET);
+        // Firefox does not send SSRC in SDP
+        if (getAudioSourceSSRC() == 0) {
+          ELOG_DEBUG("%s discoveredAudioSourceSSRC:%u", toLog(), recvSSRC);
+          this->setAudioSourceSSRC(recvSSRC);
+        }
+        audio_sink_->deliverAudioData(std::move(packet));
+      } else if (packet->type == VIDEO_PACKET && video_sink_ != nullptr) {
+        parseIncomingPayloadType(buf, len, VIDEO_PACKET);
+        // Firefox does not send SSRC in SDP
+        if (getVideoSourceSSRC() == 0) {
+          ELOG_DEBUG("%s discoveredVideoSourceSSRC:%u", toLog(), recvSSRC);
+          this->setVideoSourceSSRC(recvSSRC);
+        }
+        // change ssrc for RTP packets, don't touch here if RTCP
+        video_sink_->deliverVideoData(std::move(packet));
+      }
+    }  // if not bundle
+  }  // if not Feedback
+}
+
+void MediaStream::notifyToEventSink(MediaEventPtr event) {
+  event_sink_->deliverEvent(event);
+}
+
+int MediaStream::sendPLI() {
+  RtcpHeader thePLI;
+  thePLI.setPacketType(RTCP_PS_Feedback_PT);
+  thePLI.setBlockCount(1);
+  thePLI.setSSRC(this->getVideoSinkSSRC());
+  thePLI.setSourceSSRC(this->getVideoSourceSSRC());
+  thePLI.setLength(2);
+  char *buf = reinterpret_cast<char*>(&thePLI);
+  int len = (thePLI.getLength() + 1) * 4;
+  sendPacketAsync(std::make_shared<DataPacket>(0, buf, len, VIDEO_PACKET));
+  return len;
+}
+
+void MediaStream::sendPLIToFeedback() {
+  if (fb_sink_) {
+    fb_sink_->deliverFeedback(RtpUtils::createPLI(this->getVideoSinkSSRC(),
+      this->getVideoSourceSSRC()));
+  }
+}
+// changes the outgoing payload type for in the given data packet
+void MediaStream::sendPacketAsync(std::shared_ptr<DataPacket> packet) {
+  if (!sending_) {
+    return;
+  }
+  auto conn_ptr = shared_from_this();
+  if (packet->comp == -1) {
+    sending_ = false;
+    auto p = std::make_shared<DataPacket>();
+    p->comp = -1;
+    worker_->task([conn_ptr, p]{
+      conn_ptr->sendPacket(p);
+    });
+    return;
+  }
+
+  changeDeliverPayloadType(packet.get(), packet->type);
+  worker_->task([conn_ptr, packet]{
+    conn_ptr->sendPacket(packet);
+  });
+}
+
+void MediaStream::setSlideShowMode(bool state) {
+  ELOG_DEBUG("%s slideShowMode: %u", toLog(), state);
+  if (slide_show_mode_ == state) {
+    return;
+  }
+  asyncTask([state] (std::shared_ptr<MediaStream> connection) {
+    connection->stats_->getNode()[connection->getVideoSinkSSRC()].insertStat("erizoSlideShow", CumulativeStat{state});
+  });
+  slide_show_mode_ = state;
+  notifyUpdateToHandlers();
+}
+
+void MediaStream::muteStream(bool mute_video, bool mute_audio) {
+  asyncTask([mute_audio, mute_video] (std::shared_ptr<MediaStream> connection) {
+    ELOG_DEBUG("%s message: muteStream, mute_video: %u, mute_audio: %u", connection->toLog(), mute_video, mute_audio);
+    connection->audio_muted_ = mute_audio;
+    connection->video_muted_ = mute_video;
+    connection->stats_->getNode()[connection->getAudioSinkSSRC()].insertStat("erizoAudioMute",
+                                                                             CumulativeStat{mute_audio});
+    connection->stats_->getNode()[connection->getAudioSinkSSRC()].insertStat("erizoVideoMute",
+                                                                             CumulativeStat{mute_video});
+    connection->pipeline_->notifyUpdate();
+  });
+}
+
+void MediaStream::setVideoConstraints(int max_video_width, int max_video_height, int max_video_frame_rate) {
+  asyncTask([max_video_width, max_video_height, max_video_frame_rate] (std::shared_ptr<MediaStream> connection) {
+    connection->quality_manager_->setVideoConstraints(max_video_width, max_video_height, max_video_frame_rate);
+  });
+}
+
+void MediaStream::setFeedbackReports(bool will_send_fb, uint32_t target_bitrate) {
+  if (slide_show_mode_) {
+    target_bitrate = 0;
+  }
+
+  this->shouldSendFeedback_ = will_send_fb;
+  if (target_bitrate == 1) {
+    this->videoEnabled_ = false;
+  }
+  this->rateControl_ = target_bitrate;
+}
+
+void MediaStream::setMetadata(std::map<std::string, std::string> metadata) {
+  setLogContext(metadata);
+}
+
+WebRTCEvent MediaStream::getCurrentState() {
+  return connection_->getCurrentState();
+}
+
+void MediaStream::getJSONStats(std::function<void(std::string)> callback) {
+  asyncTask([callback] (std::shared_ptr<MediaStream> connection) {
+    std::string requested_stats = connection->stats_->getStats();
+    //  ELOG_DEBUG("%s message: Stats, stats: %s", connection->toLog(), requested_stats.c_str());
+    callback(requested_stats);
+  });
+}
+
+void MediaStream::changeDeliverPayloadType(DataPacket *dp, packetType type) {
+  RtpHeader* h = reinterpret_cast<RtpHeader*>(dp->data);
+  RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(dp->data);
+  if (!chead->isRtcp()) {
+      int internalPT = h->getPayloadType();
+      int externalPT = internalPT;
+      if (type == AUDIO_PACKET) {
+          externalPT = remote_sdp_->getAudioExternalPT(internalPT);
+      } else if (type == VIDEO_PACKET) {
+          externalPT = remote_sdp_->getVideoExternalPT(externalPT);
+      }
+      if (internalPT != externalPT) {
+          h->setPayloadType(externalPT);
+      }
+  }
+}
+
+// parses incoming payload type, replaces occurence in buf
+void MediaStream::parseIncomingPayloadType(char *buf, int len, packetType type) {
+  RtcpHeader* chead = reinterpret_cast<RtcpHeader*>(buf);
+  RtpHeader* h = reinterpret_cast<RtpHeader*>(buf);
+  if (!chead->isRtcp()) {
+    int externalPT = h->getPayloadType();
+    int internalPT = externalPT;
+    if (type == AUDIO_PACKET) {
+      internalPT = remote_sdp_->getAudioInternalPT(externalPT);
+    } else if (type == VIDEO_PACKET) {
+      internalPT = remote_sdp_->getVideoInternalPT(externalPT);
+    }
+    if (externalPT != internalPT) {
+      h->setPayloadType(internalPT);
+    } else {
+//        ELOG_WARN("onTransportData did not find mapping for %i", externalPT);
+    }
+  }
+}
+
+void MediaStream::write(std::shared_ptr<DataPacket> packet) {
+  connection_->write(packet);
+}
+
+void MediaStream::enableHandler(const std::string &name) {
+  asyncTask([name] (std::shared_ptr<MediaStream> conn) {
+    conn->pipeline_->enable(name);
+  });
+}
+
+void MediaStream::disableHandler(const std::string &name) {
+  asyncTask([name] (std::shared_ptr<MediaStream> conn) {
+    conn->pipeline_->disable(name);
+  });
+}
+
+void MediaStream::notifyUpdateToHandlers() {
+  asyncTask([] (std::shared_ptr<MediaStream> conn) {
+    conn->pipeline_->notifyUpdate();
+  });
+}
+
+void MediaStream::asyncTask(std::function<void(std::shared_ptr<MediaStream>)> f) {
+  std::weak_ptr<MediaStream> weak_this = shared_from_this();
+  worker_->task([weak_this, f] {
+    if (auto this_ptr = weak_this.lock()) {
+      f(this_ptr);
+    }
+  });
+}
+
+void MediaStream::sendPacket(std::shared_ptr<DataPacket> p) {
+  if (!sending_) {
+    return;
+  }
+  uint32_t partial_bitrate = 0;
+  uint64_t sentVideoBytes = 0;
+  uint64_t lastSecondVideoBytes = 0;
+
+  if (rateControl_ && !slide_show_mode_) {
+    if (p->type == VIDEO_PACKET) {
+      if (rateControl_ == 1) {
+        return;
+      }
+      now_ = clock::now();
+      if ((now_ - mark_) >= kBitrateControlPeriod) {
+        mark_ = now_;
+        lastSecondVideoBytes = sentVideoBytes;
+      }
+      partial_bitrate = ((sentVideoBytes - lastSecondVideoBytes) * 8) * 10;
+      if (partial_bitrate > this->rateControl_) {
+        return;
+      }
+      sentVideoBytes += p->length;
+    }
+  }
+  if (!pipeline_initialized_) {
+    ELOG_DEBUG("%s message: Pipeline not initialized yet.", toLog());
+    return;
+  }
+
+  pipeline_->write(std::move(p));
+}
+
+void MediaStream::setQualityLayer(int spatial_layer, int temporal_layer) {
+  asyncTask([spatial_layer, temporal_layer] (std::shared_ptr<MediaStream> connection) {
+    connection->quality_manager_->forceLayers(spatial_layer, temporal_layer);
+  });
+}
+
+}  // namespace erizo

--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -26,6 +26,13 @@
 
 namespace erizo {
 
+class MediaStreamStatsListener {
+ public:
+    virtual ~MediaStreamStatsListener() {
+    }
+    virtual void notifyStats(const std::string& message) = 0;
+};
+
 /**
  * A MediaStream. This class represents a Media Stream that can be established with other peers via a SDP negotiation
  */
@@ -36,8 +43,8 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
 
  public:
   typedef typename Handler::Context Context;
-  bool audioEnabled_;
-  bool videoEnabled_;
+  bool audio_enabled_;
+  bool video_enabled_;
 
   /**
    * Constructor.
@@ -63,6 +70,14 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   void setQualityLayer(int spatial_layer, int temporal_layer);
 
   WebRTCEvent getCurrentState();
+
+  /**
+   * Sets the Stats Listener for this MediaStream
+   */
+  inline void setMediaStreamStatsListener(
+            MediaStreamStatsListener* listener) {
+    stats_->setStatsListener(listener);
+  }
 
   void getJSONStats(std::function<void(std::string)> callback);
 
@@ -126,14 +141,14 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
  private:
   std::shared_ptr<WebRtcConnection> connection_;
   std::string stream_id_;
-  bool shouldSendFeedback_;
+  bool should_send_feedback_;
   bool slide_show_mode_;
   bool sending_;
   int bundle_;
 
-  uint32_t rateControl_;  // Target bitrate for hacky rate control in BPS
+  uint32_t rate_control_;  // Target bitrate for hacky rate control in BPS
 
-  std::string stunServer_;
+  std::string stun_server_;
 
   time_point now_, mark_;
 

--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -1,0 +1,203 @@
+
+#ifndef ERIZO_SRC_ERIZO_MEDIASTREAM_H_
+#define ERIZO_SRC_ERIZO_MEDIASTREAM_H_
+
+#include <boost/thread/mutex.hpp>
+
+#include <string>
+#include <map>
+#include <vector>
+
+#include "./logger.h"
+#include "./SdpInfo.h"
+#include "./MediaDefinitions.h"
+#include "./Stats.h"
+#include "./Transport.h"
+#include "./WebRtcConnection.h"
+#include "pipeline/Pipeline.h"
+#include "thread/Worker.h"
+#include "rtp/RtcpProcessor.h"
+#include "rtp/RtpExtensionProcessor.h"
+#include "lib/Clock.h"
+#include "pipeline/Handler.h"
+#include "pipeline/Service.h"
+#include "rtp/QualityManager.h"
+#include "rtp/PacketBufferService.h"
+
+namespace erizo {
+
+/**
+ * A MediaStream. This class represents a Media Stream that can be established with other peers via a SDP negotiation
+ */
+class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
+                        public FeedbackSource, public LogContext,
+                        public std::enable_shared_from_this<MediaStream>, public Service {
+  DECLARE_LOGGER();
+
+ public:
+  typedef typename Handler::Context Context;
+  bool audioEnabled_;
+  bool videoEnabled_;
+
+  /**
+   * Constructor.
+   * Constructs an empty MediaStream without any configuration.
+   */
+  MediaStream(std::shared_ptr<WebRtcConnection> connection,
+      const std::string& media_stream_id);
+  /**
+   * Destructor.
+   */
+  virtual ~MediaStream();
+  bool init();
+  void close() override;
+  bool setRemoteSdp(std::shared_ptr<SdpInfo> sdp);
+  bool setLocalSdp(std::shared_ptr<SdpInfo> sdp);
+
+  /**
+   * Sends a PLI Packet
+   * @return the size of the data sent
+   */
+  int sendPLI() override;
+  void sendPLIToFeedback();
+  void setQualityLayer(int spatial_layer, int temporal_layer);
+
+  WebRTCEvent getCurrentState();
+
+  void getJSONStats(std::function<void(std::string)> callback);
+
+  void onTransportData(std::shared_ptr<DataPacket> packet, Transport *transport);
+
+  void sendPacketAsync(std::shared_ptr<DataPacket> packet);
+
+
+  void setFeedbackReports(bool will_send_feedback, uint32_t target_bitrate = 0);
+  void setSlideShowMode(bool state);
+  void muteStream(bool mute_video, bool mute_audio);
+  void setVideoConstraints(int max_video_width, int max_video_height, int max_video_frame_rate);
+
+  void setMetadata(std::map<std::string, std::string> metadata);
+
+  void read(std::shared_ptr<DataPacket> packet);
+  void write(std::shared_ptr<DataPacket> packet);
+
+  void enableHandler(const std::string &name);
+  void disableHandler(const std::string &name);
+  void notifyUpdateToHandlers();
+
+  void notifyToEventSink(MediaEventPtr event);
+
+  void asyncTask(std::function<void(std::shared_ptr<MediaStream>)> f);
+
+  bool isAudioMuted() { return audio_muted_; }
+  bool isVideoMuted() { return video_muted_; }
+
+  SdpInfo* getRemoteSdpInfo() { return remote_sdp_.get(); }
+
+  bool isSlideShowModeEnabled() { return slide_show_mode_; }
+
+  RtpExtensionProcessor& getRtpExtensionProcessor() { return connection_->getRtpExtensionProcessor(); }
+  std::shared_ptr<Worker> getWorker() { return worker_; }
+
+  std::string& getId() { return stream_id_; }
+
+  bool isSourceSSRC(uint32_t ssrc);
+  bool isSinkSSRC(uint32_t ssrc);
+  void parseIncomingPayloadType(char *buf, int len, packetType type);
+
+  bool isPipelineInitialized() { return pipeline_initialized_; }
+  Pipeline::Ptr getPipeline() { return pipeline_; }
+
+  inline const char* toLog() {
+    return ("id: " + stream_id_ + ", " + printLogContext()).c_str();
+  }
+
+ private:
+  void sendPacket(std::shared_ptr<DataPacket> packet);
+  int deliverAudioData_(std::shared_ptr<DataPacket> audio_packet) override;
+  int deliverVideoData_(std::shared_ptr<DataPacket> video_packet) override;
+  int deliverFeedback_(std::shared_ptr<DataPacket> fb_packet) override;
+  int deliverEvent_(MediaEventPtr event) override;
+  void initializePipeline();
+
+  void changeDeliverPayloadType(DataPacket *dp, packetType type);
+  // parses incoming payload type, replaces occurence in buf
+
+ private:
+  std::shared_ptr<WebRtcConnection> connection_;
+  std::string stream_id_;
+  bool shouldSendFeedback_;
+  bool slide_show_mode_;
+  bool sending_;
+  int bundle_;
+
+  uint32_t rateControl_;  // Target bitrate for hacky rate control in BPS
+
+  std::string stunServer_;
+
+  time_point now_, mark_;
+
+  std::shared_ptr<RtcpProcessor> rtcp_processor_;
+  std::shared_ptr<Stats> stats_;
+  std::shared_ptr<QualityManager> quality_manager_;
+  std::shared_ptr<PacketBufferService> packet_buffer_;
+
+  Pipeline::Ptr pipeline_;
+
+  std::shared_ptr<Worker> worker_;
+
+  bool audio_muted_;
+  bool video_muted_;
+
+  bool pipeline_initialized_;
+ protected:
+  std::shared_ptr<SdpInfo> remote_sdp_;
+  std::shared_ptr<SdpInfo> local_sdp_;
+};
+
+class PacketReader : public InboundHandler {
+ public:
+  explicit PacketReader(MediaStream *media_stream) : media_stream_{media_stream} {}
+
+  void enable() override {}
+  void disable() override {}
+
+  std::string getName() override {
+    return "reader";
+  }
+
+  void read(Context *ctx, std::shared_ptr<DataPacket> packet) override {
+    media_stream_->read(std::move(packet));
+  }
+
+  void notifyUpdate() override {
+  }
+
+ private:
+  MediaStream *media_stream_;
+};
+
+class PacketWriter : public OutboundHandler {
+ public:
+  explicit PacketWriter(MediaStream *media_stream) : media_stream_{media_stream} {}
+
+  void enable() override {}
+  void disable() override {}
+
+  std::string getName() override {
+    return "writer";
+  }
+
+  void write(Context *ctx, std::shared_ptr<DataPacket> packet) override {
+    media_stream_->write(std::move(packet));
+  }
+
+  void notifyUpdate() override {
+  }
+
+ private:
+  MediaStream *media_stream_;
+};
+
+}  // namespace erizo
+#endif  // ERIZO_SRC_ERIZO_MEDIASTREAM_H_

--- a/erizo/src/erizo/OneToManyProcessor.h
+++ b/erizo/src/erizo/OneToManyProcessor.h
@@ -15,7 +15,7 @@
 
 namespace erizo {
 
-class WebRtcConnection;
+class MediaStream;
 
 /**
 * Represents a One to Many connection.
@@ -32,20 +32,20 @@ class OneToManyProcessor : public MediaSink, public FeedbackSink {
   virtual ~OneToManyProcessor();
   /**
   * Sets the Publisher
-  * @param webRtcConn The WebRtcConnection of the Publisher
+  * @param webRtcConn The MediaStream of the Publisher
   */
-  void setPublisher(std::shared_ptr<MediaSource> webRtcConn);
+  void setPublisher(std::shared_ptr<MediaSource> publisher_stream);
   /**
   * Sets the subscriber
-  * @param webRtcConn The WebRtcConnection of the subscriber
+  * @param webRtcConn The MediaStream of the subscriber
   * @param peerId An unique Id for the subscriber
   */
-  void addSubscriber(std::shared_ptr<MediaSink> webRtcConn, const std::string& peerId);
+  void addSubscriber(std::shared_ptr<MediaSink> subscriber_stream, const std::string& peer_id);
   /**
   * Eliminates the subscriber given its peer id
   * @param peerId the peerId
   */
-  void removeSubscriber(const std::string& peerId);
+  void removeSubscriber(const std::string& peer_id);
 
   void close() override;
 
@@ -57,7 +57,7 @@ class OneToManyProcessor : public MediaSink, public FeedbackSink {
   int deliverVideoData_(std::shared_ptr<DataPacket> video_packet) override;
   int deliverFeedback_(std::shared_ptr<DataPacket> fb_packet) override;
   int deliverEvent_(MediaEventPtr event) override;
-  std::future<void> deleteAsync(std::shared_ptr<WebRtcConnection> connection);
+  std::future<void> deleteAsync(std::shared_ptr<MediaStream> connection);
   void closeAll();
 };
 

--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -514,22 +514,22 @@ namespace erizo {
     ELOG_DEBUG("Setting Offer SDP");
   }
 
-  void SdpInfo::setOfferSdp(const SdpInfo& offerSdp) {
-    this->videoCodecs = offerSdp.videoCodecs;
-    this->audioCodecs = offerSdp.audioCodecs;
-    this->payloadVector = offerSdp.payloadVector;
-    this->isBundle = offerSdp.isBundle;
-    this->profile = offerSdp.profile;
-    this->isRtcpMux = offerSdp.isRtcpMux;
-    this->videoSdpMLine = offerSdp.videoSdpMLine;
-    this->audioSdpMLine = offerSdp.audioSdpMLine;
-    this->inOutPTMap = offerSdp.inOutPTMap;
-    this->outInPTMap = offerSdp.outInPTMap;
-    this->hasVideo = offerSdp.hasVideo;
-    this->hasAudio = offerSdp.hasAudio;
-    this->bundleTags = offerSdp.bundleTags;
-    this->extMapVector = offerSdp.extMapVector;
-    switch (offerSdp.videoDirection) {
+  void SdpInfo::setOfferSdp(std::shared_ptr<SdpInfo> offerSdp) {
+    this->videoCodecs = offerSdp->videoCodecs;
+    this->audioCodecs = offerSdp->audioCodecs;
+    this->payloadVector = offerSdp->payloadVector;
+    this->isBundle = offerSdp->isBundle;
+    this->profile = offerSdp->profile;
+    this->isRtcpMux = offerSdp->isRtcpMux;
+    this->videoSdpMLine = offerSdp->videoSdpMLine;
+    this->audioSdpMLine = offerSdp->audioSdpMLine;
+    this->inOutPTMap = offerSdp->inOutPTMap;
+    this->outInPTMap = offerSdp->outInPTMap;
+    this->hasVideo = offerSdp->hasVideo;
+    this->hasAudio = offerSdp->hasAudio;
+    this->bundleTags = offerSdp->bundleTags;
+    this->extMapVector = offerSdp->extMapVector;
+    switch (offerSdp->videoDirection) {
       case SENDONLY:
         this->videoDirection = RECVONLY;
         break;
@@ -543,7 +543,7 @@ namespace erizo {
         this->videoDirection = SENDRECV;
         break;
     }
-    switch (offerSdp.audioDirection) {
+    switch (offerSdp->audioDirection) {
       case SENDONLY:
         this->audioDirection = RECVONLY;
         break;

--- a/erizo/src/erizo/SdpInfo.h
+++ b/erizo/src/erizo/SdpInfo.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <memory>
 
 #include "./logger.h"
 

--- a/erizo/src/erizo/SdpInfo.h
+++ b/erizo/src/erizo/SdpInfo.h
@@ -222,7 +222,7 @@ class SdpInfo {
    * @brief copies relevant information from the offer sdp for which this will be an answer sdp
    * @param offerSdp The offer SDP as received via signaling and parsed
    */
-  void setOfferSdp(const SdpInfo& offerSdp);
+  void setOfferSdp(std::shared_ptr<SdpInfo> offerSdp);
 
   void updateSupportedExtensionMap(const std::vector<ExtMap> &ext_map);
   bool isValidExtension(std::string uri);

--- a/erizo/src/erizo/Stats.cpp
+++ b/erizo/src/erizo/Stats.cpp
@@ -7,7 +7,7 @@
 #include <string>
 
 #include "Stats.h"
-#include "WebRtcConnection.h"
+#include "MediaStream.h"
 #include "lib/ClockUtils.h"
 
 namespace erizo {

--- a/erizo/src/erizo/Stats.h
+++ b/erizo/src/erizo/Stats.h
@@ -16,7 +16,7 @@
 
 namespace erizo {
 
-class WebRtcConnectionStatsListener;
+class MediaStreamStatsListener;
 
 class Stats : public Service {
   DECLARE_LOGGER();
@@ -29,14 +29,14 @@ class Stats : public Service {
 
   std::string getStats();
 
-  inline void setStatsListener(WebRtcConnectionStatsListener* listener) {
+  inline void setStatsListener(MediaStreamStatsListener* listener) {
     listener_ = listener;
   }
 
   void sendStats();
 
  private:
-  WebRtcConnectionStatsListener* listener_;
+  MediaStreamStatsListener* listener_;
   StatNode root_;
 };
 

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -50,13 +50,6 @@ class WebRtcConnectionEventListener {
     virtual void notifyEvent(WebRTCEvent newEvent, const std::string& message) = 0;
 };
 
-class WebRtcConnectionStatsListener {
- public:
-    virtual ~WebRtcConnectionStatsListener() {
-    }
-    virtual void notifyStats(const std::string& message) = 0;
-};
-
 /**
  * A WebRTC Connection. This class represents a WebRTC Connection that can be established with other peers via a SDP negotiation
  * it comprises all the necessary Transport components.
@@ -73,7 +66,7 @@ class WebRtcConnection: public TransportListener, public LogContext,
    * Constructs an empty WebRTCConnection without any configuration.
    */
   WebRtcConnection(std::shared_ptr<Worker> worker, std::shared_ptr<IOWorker> io_worker,
-      const std::string& connection_id, const IceConfig& iceConfig,
+      const std::string& connection_id, const IceConfig& ice_config,
       const std::vector<RtpMap> rtp_mappings, const std::vector<erizo::ExtMap> ext_mappings,
       WebRtcConnectionEventListener* listener);
   /**
@@ -94,7 +87,7 @@ class WebRtcConnection: public TransportListener, public LogContext,
    */
   bool setRemoteSdp(const std::string &sdp);
 
-  bool createOffer(bool videoEnabled, bool audioEnabled, bool bundle);
+  bool createOffer(bool video_enabled, bool audio_enabled, bool bundle);
   /**
    * Add new remote candidate (from remote peer).
    * @param sdp The candidate in SDP format.
@@ -108,27 +101,12 @@ class WebRtcConnection: public TransportListener, public LogContext,
   std::string getLocalSdp();
 
   /**
-   * Sends a PLI Packet
-   * @return the size of the data sent
-   */
-  int sendPLI();
-
-  void setQualityLayer(int spatial_layer, int temporal_layer);
-
-  /**
    * Sets the Event Listener for this WebRtcConnection
    */
   inline void setWebRtcConnectionEventListener(WebRtcConnectionEventListener* listener) {
-    this->connEventListener_ = listener;
+    this->conn_event_listener_ = listener;
   }
 
-  /**
-   * Sets the Stats Listener for this WebRtcConnection
-   */
-  inline void setWebRtcConnectionStatsListener(
-            WebRtcConnectionStatsListener* listener) {
-    stats_->setStatsListener(listener);
-  }
 
   /**
    * Gets the current state of the Ice Connection
@@ -136,26 +114,16 @@ class WebRtcConnection: public TransportListener, public LogContext,
    */
   WebRTCEvent getCurrentState();
 
-  void getJSONStats(std::function<void(std::string)> callback);
-
   void onTransportData(std::shared_ptr<DataPacket> packet, Transport *transport) override;
 
   void updateState(TransportState state, Transport * transport) override;
 
   void onCandidate(const CandidateInfo& cand, Transport *transport) override;
 
-  void setFeedbackReports(bool will_send_feedback, uint32_t target_bitrate = 0);
-  void setSlideShowMode(bool state);
-
-  void muteStream(bool mute_video, bool mute_audio);
-  void setVideoConstraints(int max_video_width, int max_video_height, int max_video_frame_rate);
-
   void setMetadata(std::map<std::string, std::string> metadata);
 
   void read(std::shared_ptr<DataPacket> packet);
   void write(std::shared_ptr<DataPacket> packet);
-
-  void notifyToEventSink(MediaEventPtr event);
 
   void asyncTask(std::function<void(std::shared_ptr<WebRtcConnection>)> f);
 
@@ -168,9 +136,7 @@ class WebRtcConnection: public TransportListener, public LogContext,
 
   std::shared_ptr<Stats> getStatsService() { return stats_; }
 
-  bool isSlideShowModeEnabled() { return slide_show_mode_; }
-
-  RtpExtensionProcessor& getRtpExtensionProcessor() { return extProcessor_; }
+  RtpExtensionProcessor& getRtpExtensionProcessor() { return extension_processor_; }
 
   std::shared_ptr<Worker> getWorker() { return worker_; }
 
@@ -188,30 +154,22 @@ class WebRtcConnection: public TransportListener, public LogContext,
 
  private:
   std::string connection_id_;
-  bool audioEnabled_;
-  bool videoEnabled_;
-  bool trickleEnabled_;
-  bool shouldSendFeedback_;
+  bool audio_enabled_;
+  bool video_enabled_;
+  bool trickle_enabled_;
   bool slide_show_mode_;
   bool sending_;
   int bundle_;
-  WebRtcConnectionEventListener* connEventListener_;
-  IceConfig iceConfig_;
+  WebRtcConnectionEventListener* conn_event_listener_;
+  IceConfig ice_config_;
   std::vector<RtpMap> rtp_mappings_;
-  RtpExtensionProcessor extProcessor_;
-
-  uint32_t rateControl_;  // Target bitrate for hacky rate control in BPS
-
-  std::string stunServer_;
-
+  RtpExtensionProcessor extension_processor_;
   boost::condition_variable cond_;
 
-  time_point now_, mark_;
-
-  std::shared_ptr<Transport> videoTransport_, audioTransport_;
+  std::shared_ptr<Transport> video_transport_, audio_transport_;
 
   std::shared_ptr<Stats> stats_;
-  WebRTCEvent globalState_;
+  WebRTCEvent global_state_;
 
   boost::mutex updateStateMutex_;  // , slideShowMutex_;
 

--- a/erizo/src/erizo/media/ExternalInput.h
+++ b/erizo/src/erizo/media/ExternalInput.h
@@ -21,7 +21,6 @@ extern "C" {
 #include "./logger.h"
 
 namespace erizo {
-class WebRtcConnection;
 
 class ExternalInput : public MediaSource, public RTPDataReceiver {
   DECLARE_LOGGER();

--- a/erizo/src/erizo/media/ExternalOutput.h
+++ b/erizo/src/erizo/media/ExternalOutput.h
@@ -23,7 +23,7 @@ namespace erizo {
 
 constexpr  int kUnpackageBufferSize = 200000;
 
-class WebRtcConnection;
+class MediaStream;
 
 // Our search state for VP8 frames.
 enum vp8SearchState {

--- a/erizo/src/erizo/media/OneToManyTranscoder.cpp
+++ b/erizo/src/erizo/media/OneToManyTranscoder.cpp
@@ -7,7 +7,7 @@
 #include <cstring>
 
 #include "media/OneToManyTranscoder.h"
-#include "./WebRtcConnection.h"
+#include "./MediaStream.h"
 #include "rtp/RtpHeaders.h"
 
 using std::memcpy;

--- a/erizo/src/erizo/media/OneToManyTranscoder.h
+++ b/erizo/src/erizo/media/OneToManyTranscoder.h
@@ -14,7 +14,7 @@
 #include "./logger.h"
 
 namespace erizo {
-class WebRtcConnection;
+class MediaStream;
 class RTPSink;
 
 /**
@@ -32,15 +32,15 @@ class OneToManyTranscoder : public MediaSink, public RawDataReceiver, public RTP
   virtual ~OneToManyTranscoder();
   /**
   * Sets the Publisher
-  * @param webRtcConn The WebRtcConnection of the Publisher
+  * @param webRtcConn The MediaStream of the Publisher
   */
-  void setPublisher(MediaSource* webRtcConn);
+  void setPublisher(MediaSource* media_stream);
   /**
   * Sets the subscriber
-  * @param webRtcConn The WebRtcConnection of the subscriber
+  * @param webRtcConn The MediaStream of the subscriber
   * @param peerId An unique Id for the subscriber
   */
-  void addSubscriber(MediaSink* webRtcConn, const std::string& peerId);
+  void addSubscriber(MediaSink* media_stream, const std::string& peer_id);
   /**
   * Eliminates the subscriber given its peer id
   * @param peerId the peerId
@@ -59,7 +59,7 @@ class OneToManyTranscoder : public MediaSink, public RawDataReceiver, public RTP
   RTPSink* sink_;
   std::vector<DataPacket> head;
   int gotFrame_, gotDecodedFrame_, size_;
-  void sendHead(WebRtcConnection* conn);
+  void sendHead(MediaStream* conn);
   RtpVP8Parser pars;
   unsigned int sentPackets_;
   int deliverAudioData_(std::shared_ptr<DataPacket> audio_packet) override;

--- a/erizo/src/erizo/media/SyntheticInput.cpp
+++ b/erizo/src/erizo/media/SyntheticInput.cpp
@@ -191,7 +191,7 @@ int SyntheticInput::deliverFeedback_(std::shared_ptr<DataPacket> fb_packet) {
       total_length += rtcp_length;
       switch (chead->packettype) {
         case RTCP_RTP_Feedback_PT:
-          // NACKs are already handled by WebRtcConnection. RRs won't be handled.
+          // NACKs are already handled by MediaStream. RRs won't be handled.
           total_packets_nacked_++;
           break;
         case RTCP_PS_Feedback_PT:

--- a/erizo/src/erizo/pipeline/Pipeline.h
+++ b/erizo/src/erizo/pipeline/Pipeline.h
@@ -20,7 +20,6 @@
 namespace erizo {
 
 class PipelineBase;
-class WebRtcConnection;
 
 class PipelineManager {
  public:

--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.h
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.h
@@ -20,8 +20,7 @@
 
 namespace erizo {
 
-class WebRtcConnection;
-
+class MediaStream;
 using webrtc::RemoteBitrateEstimator;
 using webrtc::RemoteBitrateObserver;
 using webrtc::RtpHeaderExtensionMap;
@@ -68,7 +67,7 @@ class BandwidthEstimationHandler: public Handler, public RemoteBitrateObserver,
 
   void updateExtensionMap(bool video, std::array<RTPExtensions, 10> map);
 
-  WebRtcConnection *connection_;
+  MediaStream *stream_;
   std::shared_ptr<Worker> worker_;
   std::shared_ptr<Stats> stats_;
   webrtc::Clock* const clock_;

--- a/erizo/src/erizo/rtp/FecReceiverHandler.cpp
+++ b/erizo/src/erizo/rtp/FecReceiverHandler.cpp
@@ -1,6 +1,6 @@
 #include "rtp/FecReceiverHandler.h"
 #include "./MediaDefinitions.h"
-#include "./WebRtcConnection.h"
+#include "./MediaStream.h"
 
 namespace erizo {
 
@@ -28,13 +28,13 @@ void FecReceiverHandler::notifyUpdate() {
   if (!pipeline) {
     return;
   }
-  std::shared_ptr<WebRtcConnection> connection = pipeline->getService<WebRtcConnection>();
-  if (!connection) {
+  std::shared_ptr<MediaStream> stream = pipeline->getService<MediaStream>();
+  if (!stream) {
     return;
   }
-  SdpInfo &remote_sdp = connection->getRemoteSdpInfo();
-  bool is_slide_show_mode_active = connection->isSlideShowModeEnabled();
-  if (!remote_sdp.supportPayloadType(RED_90000_PT) || is_slide_show_mode_active) {
+  SdpInfo* remote_sdp = stream->getRemoteSdpInfo();
+  bool is_slide_show_mode_active = stream->isSlideShowModeEnabled();
+  if (!remote_sdp->supportPayloadType(RED_90000_PT) || is_slide_show_mode_active) {
     enable();
   } else {
     disable();

--- a/erizo/src/erizo/rtp/FecReceiverHandler.h
+++ b/erizo/src/erizo/rtp/FecReceiverHandler.h
@@ -9,7 +9,7 @@
 
 namespace erizo {
 
-class WebRtcConnection;
+class MediaStream;
 
 class FecReceiverHandler: public OutboundHandler, public webrtc::RtpData {
   DECLARE_LOGGER();

--- a/erizo/src/erizo/rtp/LayerBitrateCalculationHandler.cpp
+++ b/erizo/src/erizo/rtp/LayerBitrateCalculationHandler.cpp
@@ -2,7 +2,6 @@
 
 #include <vector>
 
-#include "./WebRtcConnection.h"
 #include "lib/ClockUtils.h"
 
 namespace erizo {

--- a/erizo/src/erizo/rtp/LayerBitrateCalculationHandler.h
+++ b/erizo/src/erizo/rtp/LayerBitrateCalculationHandler.h
@@ -9,7 +9,6 @@
 
 namespace erizo {
 
-class WebRtcConnection;
 
 constexpr duration kLayerRateStatIntervalSize = std::chrono::milliseconds(100);
 constexpr uint32_t kLayerRateStatIntervals = 30;

--- a/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
+++ b/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
@@ -2,7 +2,7 @@
 
 #include <vector>
 
-#include "./WebRtcConnection.h"
+#include "./MediaStream.h"
 #include "lib/ClockUtils.h"
 
 namespace erizo {
@@ -14,7 +14,7 @@ static constexpr erizo::duration kMinNotifyLayerInfoInterval = std::chrono::seco
 DEFINE_LOGGER(LayerDetectorHandler, "rtp.LayerDetectorHandler");
 
 LayerDetectorHandler::LayerDetectorHandler(std::shared_ptr<erizo::Clock> the_clock)
-    : clock_{the_clock}, connection_{nullptr}, enabled_{true}, initialized_{false},
+    : clock_{the_clock}, stream_{nullptr}, enabled_{true}, initialized_{false},
     last_event_sent_{clock_->now()} {
   for (uint32_t temporal_layer = 0; temporal_layer <= kMaxTemporalLayers; temporal_layer++) {
     video_frame_rate_list_.push_back(MovingIntervalRateStat{std::chrono::milliseconds(500), 10, .5, clock_});
@@ -35,7 +35,7 @@ void LayerDetectorHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
   if (!chead->isRtcp() && enabled_ && packet->type == VIDEO_PACKET) {
     RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
-    RtpMap *codec = connection_->getRemoteSdpInfo().getCodecByExternalPayloadType(rtp_header->getPayloadType());
+    RtpMap *codec = stream_->getRemoteSdpInfo()->getCodecByExternalPayloadType(rtp_header->getPayloadType());
     if (codec && codec->encoding_name == "VP8") {
       packet->codec = "VP8";
       parseLayerInfoFromVP8(packet);
@@ -63,8 +63,8 @@ void LayerDetectorHandler::notifyLayerInfoChangedEvent() {
               temporal_layer, video_frame_rate_list_[temporal_layer].value());
   }
 
-  if (connection_) {
-    connection_->notifyToEventSink(
+  if (stream_) {
+    stream_->notifyToEventSink(
       std::make_shared<LayerInfoChangedEvent>(video_frame_width_list_,
         video_frame_height_list_, video_frame_rate_list));
   }
@@ -206,11 +206,11 @@ void LayerDetectorHandler::notifyUpdate() {
     return;
   }
 
-  connection_ = pipeline->getService<WebRtcConnection>().get();
-  if (!connection_) {
+  stream_ = pipeline->getService<MediaStream>().get();
+  if (!stream_) {
     return;
   }
 
-  video_ssrc_list_ = connection_->getVideoSourceSSRCList();
+  video_ssrc_list_ = stream_->getVideoSourceSSRCList();
 }
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/LayerDetectorHandler.h
+++ b/erizo/src/erizo/rtp/LayerDetectorHandler.h
@@ -33,7 +33,7 @@ class LayerInfoChangedEvent : public MediaEvent {
   std::vector<uint64_t> video_frame_rate_list;
 };
 
-class WebRtcConnection;
+class MediaStream;
 
 class LayerDetectorHandler: public InboundHandler, public std::enable_shared_from_this<LayerDetectorHandler> {
   DECLARE_LOGGER();
@@ -63,7 +63,7 @@ class LayerDetectorHandler: public InboundHandler, public std::enable_shared_fro
 
  private:
   std::shared_ptr<erizo::Clock> clock_;
-  WebRtcConnection *connection_;
+  MediaStream *stream_;
   bool enabled_;
   bool initialized_;
   RtpVP8Parser vp8_parser_;

--- a/erizo/src/erizo/rtp/PliPacerHandler.h
+++ b/erizo/src/erizo/rtp/PliPacerHandler.h
@@ -10,7 +10,7 @@
 
 namespace erizo {
 
-class WebRtcConnection;
+class MediaStream;
 
 class PliPacerHandler: public Handler, public std::enable_shared_from_this<PliPacerHandler> {
   DECLARE_LOGGER();
@@ -40,7 +40,7 @@ class PliPacerHandler: public Handler, public std::enable_shared_from_this<PliPa
 
  private:
   bool enabled_;
-  WebRtcConnection* connection_;
+  MediaStream* stream_;
   std::shared_ptr<erizo::Clock> clock_;
   time_point time_last_keyframe_;
   bool waiting_for_keyframe_;

--- a/erizo/src/erizo/rtp/QualityFilterHandler.cpp
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.cpp
@@ -1,6 +1,6 @@
 #include "rtp/QualityFilterHandler.h"
 
-#include "./WebRtcConnection.h"
+#include "./MediaStream.h"
 #include "lib/ClockUtils.h"
 #include "rtp/RtpUtils.h"
 #include "rtp/RtpVP8Parser.h"
@@ -12,7 +12,7 @@ DEFINE_LOGGER(QualityFilterHandler, "rtp.QualityFilterHandler");
 constexpr duration kSwitchTimeout = std::chrono::seconds(3);
 
 QualityFilterHandler::QualityFilterHandler()
-  : connection_{nullptr}, enabled_{true}, initialized_{false},
+  : stream_{nullptr}, enabled_{true}, initialized_{false},
   receiving_multiple_ssrc_{false}, changing_spatial_layer_{false}, is_scalable_{false},
   target_spatial_layer_{0},
   future_spatial_layer_{-1}, target_temporal_layer_{0},
@@ -196,15 +196,15 @@ void QualityFilterHandler::notifyUpdate() {
     return;
   }
 
-  connection_ = pipeline->getService<WebRtcConnection>().get();
-  if (!connection_) {
+  stream_ = pipeline->getService<MediaStream>().get();
+  if (!stream_) {
     return;
   }
 
   quality_manager_ = pipeline->getService<QualityManager>();
 
-  video_sink_ssrc_ = connection_->getVideoSinkSSRC();
-  video_source_ssrc_ = connection_->getVideoSourceSSRC();
+  video_sink_ssrc_ = stream_->getVideoSinkSSRC();
+  video_source_ssrc_ = stream_->getVideoSourceSSRC();
   initialized_ = true;
 }
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/QualityFilterHandler.h
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.h
@@ -14,7 +14,7 @@
 
 namespace erizo {
 
-class WebRtcConnection;
+class MediaStream;
 
 class QualityFilterHandler: public Handler, public std::enable_shared_from_this<QualityFilterHandler> {
   DECLARE_LOGGER();
@@ -46,7 +46,7 @@ class QualityFilterHandler: public Handler, public std::enable_shared_from_this<
  private:
   std::shared_ptr<QualityManager> quality_manager_;
   SequenceNumberTranslator translator_;
-  WebRtcConnection *connection_;
+  MediaStream *stream_;
   bool enabled_;
   bool initialized_;
   bool receiving_multiple_ssrc_;

--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -1,7 +1,7 @@
 #include "rtp/QualityManager.h"
 #include <memory>
 
-#include "WebRtcConnection.h"
+#include "MediaStream.h"
 #include "rtp/LayerDetectorHandler.h"
 
 namespace erizo {
@@ -157,9 +157,9 @@ void QualityManager::selectLayer(bool try_higher_layers) {
     if (below_min_layer || try_higher_layers) {
       slideshow_mode_active_ = below_min_layer;
       ELOG_DEBUG("Slideshow fallback mode %d", slideshow_mode_active_);
-      WebRtcConnection *connection = getContext()->getPipelineShared()->getService<WebRtcConnection>().get();
-      if (connection) {
-        connection->notifyUpdateToHandlers();
+      MediaStream *media_stream = getContext()->getPipelineShared()->getService<MediaStream>().get();
+      if (media_stream) {
+        media_stream->notifyUpdateToHandlers();
       }
     }
   }
@@ -258,7 +258,7 @@ void QualityManager::setTemporalLayer(int temporal_layer) {
 void QualityManager::setPadding(bool enabled) {
   if (padding_enabled_ != enabled) {
     padding_enabled_ = enabled;
-    getContext()->getPipelineShared()->getService<WebRtcConnection>()->notifyUpdateToHandlers();
+    getContext()->getPipelineShared()->getService<MediaStream>()->notifyUpdateToHandlers();
   }
 }
 

--- a/erizo/src/erizo/rtp/RtcpFeedbackGenerationHandler.h
+++ b/erizo/src/erizo/rtp/RtcpFeedbackGenerationHandler.h
@@ -15,7 +15,7 @@
 
 namespace erizo {
 
-class WebRtcConnection;
+class MediaStream;
 
 class RtcpGeneratorPair {
  public:
@@ -45,7 +45,7 @@ class RtcpFeedbackGenerationHandler: public Handler {
   void notifyUpdate() override;
 
  private:
-  WebRtcConnection *connection_;
+  MediaStream *stream_;
   std::map<uint32_t, std::shared_ptr<RtcpGeneratorPair>> generators_map_;
 
   bool enabled_, initialized_;

--- a/erizo/src/erizo/rtp/RtcpNackGenerator.cpp
+++ b/erizo/src/erizo/rtp/RtcpNackGenerator.cpp
@@ -1,7 +1,6 @@
 #include <algorithm>
 #include "rtp/RtcpNackGenerator.h"
 #include "rtp/RtpUtils.h"
-#include "./WebRtcConnection.h"
 
 namespace erizo {
 

--- a/erizo/src/erizo/rtp/RtcpNackGenerator.h
+++ b/erizo/src/erizo/rtp/RtcpNackGenerator.h
@@ -13,9 +13,6 @@
 
 namespace erizo {
 
-class WebRtcConnection;
-
-
 class NackInfo {
  public:
   NackInfo(): seq_num{0}, retransmits{0}, sent_time{0} {}

--- a/erizo/src/erizo/rtp/RtcpProcessorHandler.cpp
+++ b/erizo/src/erizo/rtp/RtcpProcessorHandler.cpp
@@ -1,12 +1,12 @@
 #include "rtp/RtcpProcessorHandler.h"
 #include "./MediaDefinitions.h"
-#include "./WebRtcConnection.h"
+#include "./MediaStream.h"
 
 namespace erizo {
 
 DEFINE_LOGGER(RtcpProcessorHandler, "rtp.RtcpProcessorHandler");
 
-RtcpProcessorHandler::RtcpProcessorHandler() : connection_{nullptr} {
+RtcpProcessorHandler::RtcpProcessorHandler() : stream_{nullptr} {
 }
 
 void RtcpProcessorHandler::enable() {
@@ -44,8 +44,8 @@ void RtcpProcessorHandler::write(Context *ctx, std::shared_ptr<DataPacket> packe
 
 void RtcpProcessorHandler::notifyUpdate() {
   auto pipeline = getContext()->getPipelineShared();
-  if (pipeline && !connection_) {
-    connection_ = pipeline->getService<WebRtcConnection>().get();
+  if (pipeline && !stream_) {
+    stream_ = pipeline->getService<MediaStream>().get();
     processor_ = pipeline->getService<RtcpProcessor>();
     stats_ = pipeline->getService<Stats>();
   }

--- a/erizo/src/erizo/rtp/RtcpProcessorHandler.h
+++ b/erizo/src/erizo/rtp/RtcpProcessorHandler.h
@@ -10,7 +10,7 @@
 
 namespace erizo {
 
-class WebRtcConnection;
+class MediaStream;
 
 class RtcpProcessorHandler: public Handler {
   DECLARE_LOGGER();
@@ -30,7 +30,7 @@ class RtcpProcessorHandler: public Handler {
   void notifyUpdate() override;
 
  private:
-  WebRtcConnection* connection_;
+  MediaStream* stream_;
   std::shared_ptr<RtcpProcessor> processor_;
   std::shared_ptr<Stats> stats_;
 };

--- a/erizo/src/erizo/rtp/RtcpRrGenerator.cpp
+++ b/erizo/src/erizo/rtp/RtcpRrGenerator.cpp
@@ -1,5 +1,4 @@
 #include "rtp/RtcpRrGenerator.h"
-#include "./WebRtcConnection.h"
 #include "lib/ClockUtils.h"
 #include "rtp/RtpUtils.h"
 

--- a/erizo/src/erizo/rtp/RtcpRrGenerator.h
+++ b/erizo/src/erizo/rtp/RtcpRrGenerator.h
@@ -14,9 +14,6 @@
 
 namespace erizo {
 
-class WebRtcConnection;
-
-
 class RtcpRrGenerator {
   DECLARE_LOGGER();
 

--- a/erizo/src/erizo/rtp/RtpExtensionProcessor.cpp
+++ b/erizo/src/erizo/rtp/RtpExtensionProcessor.cpp
@@ -27,10 +27,10 @@ RtpExtensionProcessor::RtpExtensionProcessor(const std::vector<erizo::ExtMap> ex
 RtpExtensionProcessor::~RtpExtensionProcessor() {
 }
 
-void RtpExtensionProcessor::setSdpInfo(const SdpInfo& theInfo) {
+void RtpExtensionProcessor::setSdpInfo(std::shared_ptr<SdpInfo> theInfo) {
   // We build the Extension Map
-  for (unsigned int i = 0; i < theInfo.extMapVector.size(); i++) {
-    const ExtMap& theMap = theInfo.extMapVector[i];
+  for (unsigned int i = 0; i < theInfo->extMapVector.size(); i++) {
+    const ExtMap& theMap = theInfo->extMapVector[i];
     std::map<std::string, uint8_t>::iterator it;
     switch (theMap.mediaType) {
       case VIDEO_TYPE:

--- a/erizo/src/erizo/rtp/RtpExtensionProcessor.h
+++ b/erizo/src/erizo/rtp/RtpExtensionProcessor.h
@@ -30,7 +30,7 @@ class RtpExtensionProcessor{
   explicit RtpExtensionProcessor(const std::vector<erizo::ExtMap> ext_mappings);
   virtual ~RtpExtensionProcessor();
 
-  void setSdpInfo(const SdpInfo& theInfo);
+  void setSdpInfo(std::shared_ptr<SdpInfo> theInfo);
   uint32_t processRtpExtensions(std::shared_ptr<DataPacket> p);
 
   std::array<RTPExtensions, 10> getVideoExtensionMap() {

--- a/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.cpp
@@ -4,7 +4,7 @@
 #include <string>
 
 #include "./MediaDefinitions.h"
-#include "./WebRtcConnection.h"
+#include "./MediaStream.h"
 #include "./RtpUtils.h"
 
 namespace erizo {
@@ -18,7 +18,7 @@ constexpr uint64_t kInitialBitrate = 300000;
 constexpr uint64_t kPaddingBurstSize = 255 * 10;
 
 RtpPaddingGeneratorHandler::RtpPaddingGeneratorHandler(std::shared_ptr<erizo::Clock> the_clock) :
-  clock_{the_clock}, connection_{nullptr}, max_video_bw_{0}, higher_sequence_number_{0},
+  clock_{the_clock}, stream_{nullptr}, max_video_bw_{0}, higher_sequence_number_{0},
   video_sink_ssrc_{0}, audio_source_ssrc_{0},
   number_of_full_padding_packets_{0}, last_padding_packet_size_{0},
   last_rate_calculation_time_{clock_->now()}, started_at_{clock_->now()},
@@ -38,10 +38,10 @@ void RtpPaddingGeneratorHandler::disable() {
 
 void RtpPaddingGeneratorHandler::notifyUpdate() {
   auto pipeline = getContext()->getPipelineShared();
-  if (pipeline && !connection_) {
-    connection_ = pipeline->getService<WebRtcConnection>().get();
-    video_sink_ssrc_ = connection_->getVideoSinkSSRC();
-    audio_source_ssrc_ = connection_->getAudioSinkSSRC();
+  if (pipeline && !stream_) {
+    stream_ = pipeline->getService<MediaStream>().get();
+    video_sink_ssrc_ = stream_->getVideoSinkSSRC();
+    audio_source_ssrc_ = stream_->getAudioSinkSSRC();
     stats_ = pipeline->getService<Stats>();
     stats_->getNode()["total"].insertStat("paddingBitrate",
         MovingIntervalRateStat{std::chrono::milliseconds(100), 30, 8., clock_});
@@ -69,7 +69,7 @@ void RtpPaddingGeneratorHandler::write(Context *ctx, std::shared_ptr<DataPacket>
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
   bool is_higher_sequence_number = false;
   if (packet->type == VIDEO_PACKET && !chead->isRtcp()) {
-    connection_->getWorker()->unschedule(scheduled_task_);
+    stream_->getWorker()->unschedule(scheduled_task_);
     is_higher_sequence_number = isHigherSequenceNumber(packet);
     if (!first_packet_received_) {
       started_at_ = clock_->now();
@@ -112,7 +112,7 @@ void RtpPaddingGeneratorHandler::onPacketWithMarkerSet(std::shared_ptr<DataPacke
   }
   sendPaddingPacket(packet, last_padding_packet_size_);
   std::weak_ptr<RtpPaddingGeneratorHandler> weak_this = shared_from_this();
-  scheduled_task_ = connection_->getWorker()->scheduleFromNow([packet, weak_this] {
+  scheduled_task_ = stream_->getWorker()->scheduleFromNow([packet, weak_this] {
     if (auto this_ptr = weak_this.lock()) {
       this_ptr->onPacketWithMarkerSet(packet);
     }

--- a/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.h
+++ b/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.h
@@ -13,7 +13,7 @@
 
 namespace erizo {
 
-class WebRtcConnection;
+class MediaStream;
 
 class RtpPaddingGeneratorHandler: public Handler, public std::enable_shared_from_this<RtpPaddingGeneratorHandler> {
   DECLARE_LOGGER();
@@ -50,7 +50,7 @@ class RtpPaddingGeneratorHandler: public Handler, public std::enable_shared_from
  private:
   std::shared_ptr<erizo::Clock> clock_;
   SequenceNumberTranslator translator_;
-  WebRtcConnection* connection_;
+  MediaStream* stream_;
   std::shared_ptr<Stats> stats_;
   uint64_t max_video_bw_;
   uint16_t higher_sequence_number_;

--- a/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.h
+++ b/erizo/src/erizo/rtp/RtpPaddingRemovalHandler.h
@@ -7,11 +7,10 @@
 #include "./logger.h"
 #include "pipeline/Handler.h"
 #include "rtp/SequenceNumberTranslator.h"
-#include "WebRtcConnection.h"
 
 namespace erizo {
 
-class WebRtcConnection;
+class MediaStream;
 
 class RtpPaddingRemovalHandler: public Handler, public std::enable_shared_from_this<RtpPaddingRemovalHandler> {
   DECLARE_LOGGER();
@@ -41,7 +40,7 @@ class RtpPaddingRemovalHandler: public Handler, public std::enable_shared_from_t
   bool enabled_;
   bool initialized_;
   std::map<uint32_t, std::shared_ptr<SequenceNumberTranslator>> translator_map_;
-  WebRtcConnection* connection_;
+  MediaStream* stream_;
 };
 }  // namespace erizo
 

--- a/erizo/src/erizo/rtp/RtpRetransmissionHandler.h
+++ b/erizo/src/erizo/rtp/RtpRetransmissionHandler.h
@@ -7,8 +7,7 @@
 #include "pipeline/Handler.h"
 #include "lib/Clock.h"
 #include "lib/TokenBucket.h"
-
-#include "./WebRtcConnection.h"
+#include "Stats.h"
 #include "rtp/PacketBufferService.h"
 
 static constexpr uint kRetransmissionsBufferSize = 256;
@@ -19,6 +18,9 @@ static constexpr float kMarginRtxBitrate = 0.1;
 static constexpr int kBurstSize = 1300 * 20;  // 20 packets with almost max size
 
 namespace erizo {
+
+class MediaStream;
+
 class RtpRetransmissionHandler : public Handler {
  public:
   DECLARE_LOGGER();
@@ -43,7 +45,7 @@ class RtpRetransmissionHandler : public Handler {
 
  private:
   std::shared_ptr<erizo::Clock> clock_;
-  WebRtcConnection *connection_;
+  MediaStream *stream_;
   bool initialized_, enabled_;
   std::shared_ptr<Stats> stats_;
   std::shared_ptr<PacketBufferService> packet_buffer_;

--- a/erizo/src/erizo/rtp/RtpSlideShowHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpSlideShowHandler.cpp
@@ -1,8 +1,7 @@
 #include "rtp/RtpSlideShowHandler.h"
-
+#include "MediaStream.h"
 #include <vector>
 
-#include "./MediaStream.h"
 #include "./MediaDefinitions.h"
 #include "rtp/RtpUtils.h"
 
@@ -96,8 +95,8 @@ void RtpSlideShowHandler::write(Context *ctx, std::shared_ptr<DataPacket> packet
   uint16_t packet_seq_num = rtp_header->getSeqNumber();
   bool is_keyframe = false;
   RtpMap *codec = stream_->getRemoteSdpInfo()->getCodecByExternalPayloadType(rtp_header->getPayloadType());
-  if (codec && codec->encoding_name == "VP8") {
-    is_keyframe = isVP8Keyframe(packet);
+  if (codec && (codec->encoding_name == "VP8" || codec->encoding_name == "H264")) {
+    is_keyframe = isVP8OrH264Keyframe(packet);
   } else if (codec && codec->encoding_name == "VP9") {
     is_keyframe = isVP9Keyframe(packet);
   }
@@ -123,7 +122,7 @@ void RtpSlideShowHandler::write(Context *ctx, std::shared_ptr<DataPacket> packet
   }
 }
 
-bool RtpSlideShowHandler::isVP8Keyframe(std::shared_ptr<DataPacket> packet) {
+bool RtpSlideShowHandler::isVP8OrH264Keyframe(std::shared_ptr<DataPacket> packet) {
   bool is_keyframe = false;
   RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
   uint16_t seq_num = rtp_header->getSeqNumber();

--- a/erizo/src/erizo/rtp/RtpSlideShowHandler.h
+++ b/erizo/src/erizo/rtp/RtpSlideShowHandler.h
@@ -38,7 +38,7 @@ class RtpSlideShowHandler : public Handler {
   void setSlideShowMode(bool activated);
 
  private:
-  bool isVP8Keyframe(std::shared_ptr<DataPacket> packet);
+  bool isVP8OrH264Keyframe(std::shared_ptr<DataPacket> packet);
   bool isVP9Keyframe(std::shared_ptr<DataPacket> packet);
   void maybeUpdateHighestSeqNum(uint16_t seq_num);
   void resetKeyframeBuilding();

--- a/erizo/src/erizo/rtp/RtpSlideShowHandler.h
+++ b/erizo/src/erizo/rtp/RtpSlideShowHandler.h
@@ -5,7 +5,6 @@
 
 #include "pipeline/Handler.h"
 #include "./logger.h"
-#include "./WebRtcConnection.h"
 #include "rtp/SequenceNumberTranslator.h"
 #include "rtp/PacketBufferService.h"
 #include "rtp/RtpVP8Parser.h"
@@ -16,6 +15,9 @@ static constexpr uint16_t kMaxKeyframeSize = 20;
 static constexpr erizo::duration kFallbackKeyframeTimeout = std::chrono::seconds(5);
 
 namespace erizo {
+
+class MediaStream;
+
 class RtpSlideShowHandler : public Handler {
   DECLARE_LOGGER();
 
@@ -46,7 +48,7 @@ class RtpSlideShowHandler : public Handler {
 
  private:
   std::shared_ptr<Clock> clock_;
-  WebRtcConnection* connection_;
+  MediaStream* stream_;
   SequenceNumberTranslator translator_;
   bool highest_seq_num_initialized_;
   bool is_building_keyframe_;

--- a/erizo/src/erizo/rtp/RtpTrackMuteHandler.h
+++ b/erizo/src/erizo/rtp/RtpTrackMuteHandler.h
@@ -8,7 +8,7 @@
 
 namespace erizo {
 
-class WebRtcConnection;
+class MediaStream;
 
 class TrackMuteInfo {
  public:
@@ -51,7 +51,7 @@ class RtpTrackMuteHandler: public Handler {
   TrackMuteInfo audio_info_;
   TrackMuteInfo video_info_;
 
-  WebRtcConnection* connection_;
+  MediaStream* stream_;
 };
 
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/SRPacketHandler.cpp
+++ b/erizo/src/erizo/rtp/SRPacketHandler.cpp
@@ -1,5 +1,5 @@
 #include "rtp/SRPacketHandler.h"
-#include "./WebRtcConnection.h"
+#include "./MediaStream.h"
 #include "lib/ClockUtils.h"
 
 namespace erizo {
@@ -7,7 +7,7 @@ namespace erizo {
 DEFINE_LOGGER(SRPacketHandler, "rtp.SRPacketHandler");
 
 SRPacketHandler::SRPacketHandler() :
-    enabled_{true}, initialized_{false}, connection_(nullptr) {}
+    enabled_{true}, initialized_{false}, stream_(nullptr) {}
 
 
 void SRPacketHandler::enable() {
@@ -72,10 +72,10 @@ void SRPacketHandler::notifyUpdate() {
     return;
   }
   auto pipeline = getContext()->getPipelineShared();
-  if (pipeline && !connection_) {
-    connection_ = pipeline->getService<WebRtcConnection>().get();
+  if (pipeline && !stream_) {
+    stream_ = pipeline->getService<MediaStream>().get();
   }
-  if (!connection_) {
+  if (!stream_) {
     return;
   }
   initialized_ = true;

--- a/erizo/src/erizo/rtp/SRPacketHandler.h
+++ b/erizo/src/erizo/rtp/SRPacketHandler.h
@@ -11,7 +11,7 @@
 
 namespace erizo {
 
-class WebRtcConnection;
+class MediaStream;
 
 class SRPacketHandler: public Handler {
   DECLARE_LOGGER();
@@ -40,7 +40,7 @@ class SRPacketHandler: public Handler {
   };
 
   bool enabled_, initialized_;
-  WebRtcConnection* connection_;
+  MediaStream* stream_;
   std::map<uint32_t, std::shared_ptr<SRInfo>> sr_info_map_;
 
   void handleRtpPacket(std::shared_ptr<DataPacket> packet);

--- a/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
@@ -8,14 +8,14 @@ DEFINE_LOGGER(SenderBandwidthEstimationHandler, "rtp.SenderBandwidthEstimationHa
 constexpr duration SenderBandwidthEstimationHandler::kMinUpdateEstimateInterval;
 
 SenderBandwidthEstimationHandler::SenderBandwidthEstimationHandler(std::shared_ptr<Clock> the_clock) :
-  connection_{nullptr}, bwe_listener_{nullptr}, clock_{the_clock}, initialized_{false}, enabled_{true},
+  stream_{nullptr}, bwe_listener_{nullptr}, clock_{the_clock}, initialized_{false}, enabled_{true},
   received_remb_{false}, period_packets_sent_{0}, estimated_bitrate_{0}, estimated_loss_{0},
   estimated_rtt_{0}, last_estimate_update_{clock::now()}, sender_bwe_{new SendSideBandwidthEstimation()} {
     sender_bwe_->SetSendBitrate(kStartSendBitrate);
   };
 
 SenderBandwidthEstimationHandler::SenderBandwidthEstimationHandler(const SenderBandwidthEstimationHandler&& handler) :  // NOLINT
-    connection_{handler.connection_},
+    stream_{handler.stream_},
     bwe_listener_{handler.bwe_listener_},
     clock_{handler.clock_},
     initialized_{handler.initialized_},
@@ -42,11 +42,11 @@ void SenderBandwidthEstimationHandler::notifyUpdate() {
     return;
   }
   auto pipeline = getContext()->getPipelineShared();
-  if (pipeline && !connection_) {
-    connection_ = pipeline->getService<WebRtcConnection>().get();
+  if (pipeline && !stream_) {
+    stream_ = pipeline->getService<MediaStream>().get();
     processor_ = pipeline->getService<RtcpProcessor>();
   }
-  if (!connection_) {
+  if (!stream_) {
     return;
   }
   stats_ = pipeline->getService<Stats>();
@@ -69,19 +69,19 @@ void SenderBandwidthEstimationHandler::read(Context *ctx, std::shared_ptr<DataPa
       chead = reinterpret_cast<RtcpHeader*>(packet_pointer);
       rtcp_length = (ntohs(chead->length) + 1) * 4;
       total_length += rtcp_length;
-      ELOG_DEBUG("%s ssrc %u, sourceSSRC %u, PacketType %u", connection_->toLog(),
+      ELOG_DEBUG("%s ssrc %u, sourceSSRC %u, PacketType %u", stream_->toLog(),
           chead->getSSRC(),
           chead->getSourceSSRC(),
           chead->getPacketType());
       switch (chead->packettype) {
         case RTCP_Receiver_PT:
           {
-            if (chead->getSourceSSRC() != connection_->getVideoSinkSSRC()) {
+            if (chead->getSourceSSRC() != stream_->getVideoSinkSSRC()) {
               continue;
             }
             ELOG_DEBUG("%s, Analyzing Video RR: PacketLost %u, Ratio %u, current_block %d, blocks %d"
                 ", sourceSSRC %u, ssrc %u",
-                connection_->toLog(),
+                stream_->toLog(),
                 chead->getLostPackets(),
                 chead->getFractionLost(),
                 current_block,
@@ -102,7 +102,7 @@ void SenderBandwidthEstimationHandler::read(Context *ctx, std::shared_ptr<DataPa
                 uint32_t delay = now_ms - (*value)->sr_send_time - delay_since_last_ms;
                 ELOG_DEBUG("%s message: Updating Estimate with RR, fraction_lost: %u, "
                     "delay: %u, period_packets_sent_: %u",
-                    connection_->toLog(), chead->getFractionLost(), delay, period_packets_sent_);
+                    stream_->toLog(), chead->getFractionLost(), delay, period_packets_sent_);
                 sender_bwe_->UpdateReceiverBlock(chead->getFractionLost(),
                     delay, period_packets_sent_, now_ms);
                 period_packets_sent_ = 0;
@@ -121,12 +121,12 @@ void SenderBandwidthEstimationHandler::read(Context *ctx, std::shared_ptr<DataPa
                 uint64_t cappedBitrate = bitrate < processor_->getMaxVideoBW() ? bitrate : processor_->getMaxVideoBW();
                 chead->setREMBBitRate(cappedBitrate);
 
-                ELOG_DEBUG("%s message: Updating Estimate with REMB, bitrate %lu", connection_->toLog(),
+                ELOG_DEBUG("%s message: Updating Estimate with REMB, bitrate %lu", stream_->toLog(),
                     cappedBitrate);
                 sender_bwe_->UpdateReceiverEstimate(now_ms, cappedBitrate);
                 updateEstimate();
               } else {
-                ELOG_DEBUG("%s message: Unsupported AFB Packet not REMB", connection_->toLog());
+                ELOG_DEBUG("%s message: Unsupported AFB Packet not REMB", stream_->toLog());
               }
             }
           }
@@ -151,7 +151,7 @@ void SenderBandwidthEstimationHandler::write(Context *ctx, std::shared_ptr<DataP
       last_estimate_update_ = now;
     }
   } else if (chead->getPacketType() == RTCP_Sender_PT &&
-      chead->getSSRC() == connection_->getVideoSinkSSRC()) {
+      chead->getSSRC() == stream_->getVideoSinkSSRC()) {
     analyzeSr(chead);
   }
   ctx->fireWrite(std::move(packet));
@@ -161,7 +161,7 @@ void SenderBandwidthEstimationHandler::analyzeSr(RtcpHeader* chead) {
   uint64_t now = ClockUtils::timePointToMs(clock_->now());
   uint32_t ntp;
   ntp = chead->get32MiddleNtp();
-  ELOG_DEBUG("%s message: adding incoming SR to list, ntp: %u", connection_->toLog(), ntp);
+  ELOG_DEBUG("%s message: adding incoming SR to list, ntp: %u", stream_->toLog(), ntp);
   sr_delay_data_.push_back(std::shared_ptr<SrDelayData>( new SrDelayData(ntp, now)));
   if (sr_delay_data_.size() >= kMaxSrListSize) {
     sr_delay_data_.pop_front();
@@ -174,7 +174,7 @@ void SenderBandwidthEstimationHandler::updateEstimate() {
   stats_->getNode()["total"].insertStat("senderBitrateEstimation",
       CumulativeStat{static_cast<uint64_t>(estimated_bitrate_)});
   ELOG_DEBUG("%s message: estimated bitrate %d, loss %u, rtt %ld",
-      connection_->toLog(), estimated_bitrate_, estimated_loss_, estimated_rtt_);
+      stream_->toLog(), estimated_bitrate_, estimated_loss_, estimated_rtt_);
   if (bwe_listener_) {
     bwe_listener_->onBandwidthEstimate(estimated_bitrate_, estimated_loss_, estimated_rtt_);
   }

--- a/erizo/src/erizo/rtp/SenderBandwidthEstimationHandler.h
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimationHandler.h
@@ -2,7 +2,7 @@
 #define ERIZO_SRC_ERIZO_RTP_SENDERBANDWIDTHESTIMATIONHANDLER_H_
 #include "pipeline/Handler.h"
 #include "./logger.h"
-#include "./WebRtcConnection.h"
+#include "./MediaStream.h"
 #include "./rtp/RtcpProcessor.h"
 #include "lib/Clock.h"
 
@@ -51,7 +51,7 @@ class SenderBandwidthEstimationHandler : public Handler,
   }
 
  private:
-  WebRtcConnection* connection_;
+  MediaStream* stream_;
   std::shared_ptr<RtcpProcessor> processor_;
   SenderBandwidthEstimationListener* bwe_listener_;
   std::shared_ptr<Clock> clock_;

--- a/erizo/src/erizo/rtp/StatsHandler.cpp
+++ b/erizo/src/erizo/rtp/StatsHandler.cpp
@@ -3,7 +3,7 @@
 #include <string>
 
 #include "./MediaDefinitions.h"
-#include "./WebRtcConnection.h"
+#include "./MediaStream.h"
 
 
 
@@ -13,9 +13,9 @@ DEFINE_LOGGER(StatsCalculator, "rtp.StatsCalculator");
 DEFINE_LOGGER(IncomingStatsHandler, "rtp.IncomingStatsHandler");
 DEFINE_LOGGER(OutgoingStatsHandler, "rtp.OutgoingStatsHandler");
 
-void StatsCalculator::update(WebRtcConnection *connection, std::shared_ptr<Stats> stats) {
-  if (!connection_) {
-    connection_ = connection;
+void StatsCalculator::update(MediaStream *stream, std::shared_ptr<Stats> stats) {
+  if (!stream_) {
+    stream_ = stream;
     stats_ = stats;
     if (!getStatsInfo().hasChild("total")) {
       getStatsInfo()["total"].insertStat("bitrateCalculated", MovingIntervalRateStat{kRateStatIntervalSize,
@@ -38,14 +38,14 @@ void StatsCalculator::processRtpPacket(std::shared_ptr<DataPacket> packet) {
   int len = packet->length;
   RtpHeader* head = reinterpret_cast<RtpHeader*>(buf);
   uint32_t ssrc = head->getSSRC();
-  if (!connection_->isSinkSSRC(ssrc) && !connection_->isSourceSSRC(ssrc)) {
+  if (!stream_->isSinkSSRC(ssrc) && !stream_->isSourceSSRC(ssrc)) {
     ELOG_DEBUG("message: Unknown SSRC in processRtpPacket, ssrc: %u, PT: %u", ssrc, head->getPayloadType());
     return;
   }
   if (!getStatsInfo()[ssrc].hasChild("bitrateCalculated")) {
-    if (connection_->isVideoSourceSSRC(ssrc) || connection_->isVideoSinkSSRC(ssrc)) {
+    if (stream_->isVideoSourceSSRC(ssrc) || stream_->isVideoSinkSSRC(ssrc)) {
       getStatsInfo()[ssrc].insertStat("type", StringStat{"video"});
-    } else if (connection_->isAudioSourceSSRC(ssrc) || connection_->isAudioSinkSSRC(ssrc)) {
+    } else if (stream_->isAudioSourceSSRC(ssrc) || stream_->isAudioSinkSSRC(ssrc)) {
       getStatsInfo()[ssrc].insertStat("type", StringStat{"audio"});
     }
     getStatsInfo()[ssrc].insertStat("bitrateCalculated", MovingIntervalRateStat{kRateStatIntervalSize,
@@ -80,12 +80,12 @@ void StatsCalculator::processRtcpPacket(std::shared_ptr<DataPacket> packet) {
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(movingBuf);
   if (chead->isFeedback()) {
     ssrc = chead->getSourceSSRC();
-    if (!connection_->isSinkSSRC(ssrc)) {
+    if (!stream_->isSinkSSRC(ssrc)) {
       is_feedback_on_publisher = true;
     }
   } else {
     ssrc = chead->getSSRC();
-    if (!connection_->isSourceSSRC(ssrc)) {
+    if (!stream_->isSourceSSRC(ssrc)) {
       return;
     }
   }
@@ -171,18 +171,18 @@ void StatsCalculator::processRtcpPacket(std::shared_ptr<DataPacket> packet) {
   notifyStats();
 }
 
-IncomingStatsHandler::IncomingStatsHandler() : connection_{nullptr} {}
+IncomingStatsHandler::IncomingStatsHandler() : stream_{nullptr} {}
 
 void IncomingStatsHandler::enable() {}
 
 void IncomingStatsHandler::disable() {}
 
 void IncomingStatsHandler::notifyUpdate() {
-  if (connection_) {
+  if (stream_) {
     return;
   }
   auto pipeline = getContext()->getPipelineShared();
-  update(pipeline->getService<WebRtcConnection>().get(),
+  update(pipeline->getService<MediaStream>().get(),
              pipeline->getService<Stats>());
 }
 
@@ -191,18 +191,18 @@ void IncomingStatsHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet
   ctx->fireRead(std::move(packet));
 }
 
-OutgoingStatsHandler::OutgoingStatsHandler() : connection_{nullptr} {}
+OutgoingStatsHandler::OutgoingStatsHandler() : stream_{nullptr} {}
 
 void OutgoingStatsHandler::enable() {}
 
 void OutgoingStatsHandler::disable() {}
 
 void OutgoingStatsHandler::notifyUpdate() {
-  if (connection_) {
+  if (stream_) {
     return;
   }
   auto pipeline = getContext()->getPipelineShared();
-  update(pipeline->getService<WebRtcConnection>().get(),
+  update(pipeline->getService<MediaStream>().get(),
              pipeline->getService<Stats>());
 }
 

--- a/erizo/src/erizo/rtp/StatsHandler.h
+++ b/erizo/src/erizo/rtp/StatsHandler.h
@@ -12,16 +12,16 @@ namespace erizo {
 constexpr duration kRateStatIntervalSize = std::chrono::milliseconds(100);
 constexpr uint32_t kRateStatIntervals = 30;
 
-class WebRtcConnection;
+class MediaStream;
 
 class StatsCalculator {
   DECLARE_LOGGER();
 
  public:
-  StatsCalculator() : connection_{nullptr} {}
+  StatsCalculator() : stream_{nullptr} {}
   virtual ~StatsCalculator() {}
 
-  void update(WebRtcConnection *connection, std::shared_ptr<Stats> stats);
+  void update(MediaStream *connection, std::shared_ptr<Stats> stats);
   void processPacket(std::shared_ptr<DataPacket> packet);
 
   StatNode& getStatsInfo() {
@@ -38,7 +38,7 @@ class StatsCalculator {
   void incrStat(uint32_t ssrc, std::string stat);
 
  private:
-  WebRtcConnection *connection_;
+  MediaStream* stream_;
   std::shared_ptr<Stats> stats_;
 };
 
@@ -59,7 +59,7 @@ class IncomingStatsHandler: public InboundHandler, public StatsCalculator {
   void notifyUpdate() override;
 
  private:
-  WebRtcConnection* connection_;
+  MediaStream* stream_;
 };
 
 class OutgoingStatsHandler: public OutboundHandler, public StatsCalculator {
@@ -79,7 +79,7 @@ class OutgoingStatsHandler: public OutboundHandler, public StatsCalculator {
   void notifyUpdate() override;
 
  private:
-  WebRtcConnection* connection_;
+  MediaStream* stream_;
 };
 
 }  // namespace erizo

--- a/erizo/src/test/rtp/LayerDetectorHandlerTest.cpp
+++ b/erizo/src/test/rtp/LayerDetectorHandlerTest.cpp
@@ -68,13 +68,13 @@ class LayerDetectorHandlerVp8Test : public erizo::BaseHandlerTest,
   }
 
   void setHandler() override {
-    std::vector<RtpMap>& payloads = connection->getRemoteSdpInfo().getPayloadInfos();
+    std::vector<RtpMap>& payloads = media_stream->getRemoteSdpInfo()->getPayloadInfos();
     payloads.push_back({96, "VP8"});
     payloads.push_back({98, "VP9"});
     layer_detector_handler = std::make_shared<LayerDetectorHandler>();
     pipeline->addBack(layer_detector_handler);
 
-    connection->setVideoSourceSSRCList({kArbitrarySsrc1, kArbitrarySsrc2});
+    media_stream->setVideoSourceSSRCList({kArbitrarySsrc1, kArbitrarySsrc2});
     createVP8Packet(ssrc, tid, false);
   }
 

--- a/erizo/src/test/rtp/RtcpProcessorHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtcpProcessorHandlerTest.cpp
@@ -70,8 +70,8 @@ TEST_F(RtcpProcessorHandlerTest, basicBehaviourShouldWritePackets) {
 }
 
 TEST_F(RtcpProcessorHandlerTest, shouldWriteRTCPIfProcessorAcceptsIt) {
-    uint ssrc = connection->getVideoSourceSSRC();
-    uint source_ssrc = connection->getVideoSinkSSRC();
+    uint ssrc = media_stream->getVideoSourceSSRC();
+    uint source_ssrc = media_stream->getVideoSinkSSRC();
     auto packet = erizo::PacketTools::createReceiverReport(ssrc, source_ssrc, erizo::kArbitrarySeqNumber, VIDEO_PACKET);
 
     EXPECT_CALL(*processor, analyzeFeedback(_, _)).Times(1).WillOnce(Return(1));
@@ -82,8 +82,8 @@ TEST_F(RtcpProcessorHandlerTest, shouldWriteRTCPIfProcessorAcceptsIt) {
 }
 
 TEST_F(RtcpProcessorHandlerTest, shouldNotWriteRTCPIfProcessorRejectsIt) {
-    uint ssrc = connection->getVideoSourceSSRC();
-    uint source_ssrc = connection->getVideoSinkSSRC();
+    uint ssrc = media_stream->getVideoSourceSSRC();
+    uint source_ssrc = media_stream->getVideoSinkSSRC();
     auto packet = erizo::PacketTools::createReceiverReport(ssrc, source_ssrc, erizo::kArbitrarySeqNumber, VIDEO_PACKET);
 
     EXPECT_CALL(*processor, analyzeFeedback(_, _)).Times(1).WillOnce(Return(0));
@@ -93,7 +93,7 @@ TEST_F(RtcpProcessorHandlerTest, shouldNotWriteRTCPIfProcessorRejectsIt) {
 }
 
 TEST_F(RtcpProcessorHandlerTest, shouldCallAnalyzeSrWhenReceivingSenderReports) {
-    uint ssrc = connection->getVideoSourceSSRC();
+    uint ssrc = media_stream->getVideoSourceSSRC();
     auto packet = erizo::PacketTools::createSenderReport(ssrc, VIDEO_PACKET);
 
     EXPECT_CALL(*processor, analyzeSr(_)).Times(1);

--- a/erizo/src/test/rtp/RtpRetransmissionHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpRetransmissionHandlerTest.cpp
@@ -65,8 +65,8 @@ TEST_F(RtpRetransmissionHandlerTest, basicBehaviourShouldWritePackets) {
 
 TEST_F(RtpRetransmissionHandlerTest, shouldRetransmitPackets_whenReceivingNacksWithGoodSeqNum) {
     auto rtp_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
-    uint ssrc = connection->getVideoSourceSSRC();
-    uint source_ssrc = connection->getVideoSinkSSRC();
+    uint ssrc = media_stream->getVideoSourceSSRC();
+    uint source_ssrc = media_stream->getVideoSinkSSRC();
     auto nack_packet = erizo::PacketTools::createNack(ssrc, source_ssrc, erizo::kArbitrarySeqNumber, VIDEO_PACKET);
 
     EXPECT_CALL(*writer.get(), write(_, _)).
@@ -79,8 +79,8 @@ TEST_F(RtpRetransmissionHandlerTest, shouldRetransmitPackets_whenReceivingNacksW
 
 TEST_F(RtpRetransmissionHandlerTest, shouldNotRetransmitPackets_whenReceivingNacksWithBadSeqNum) {
     auto rtp_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
-    uint ssrc = connection->getVideoSourceSSRC();
-    uint source_ssrc = connection->getVideoSinkSSRC();
+    uint ssrc = media_stream->getVideoSourceSSRC();
+    uint source_ssrc = media_stream->getVideoSinkSSRC();
     auto nack_packet = erizo::PacketTools::createNack(ssrc, source_ssrc, erizo::kArbitrarySeqNumber + 1, VIDEO_PACKET);
 
     EXPECT_CALL(*writer.get(), write(_, _)).
@@ -95,8 +95,8 @@ TEST_F(RtpRetransmissionHandlerTest, shouldNotRetransmitPackets_whenReceivingNac
 
 TEST_F(RtpRetransmissionHandlerTest, shouldNotRetransmitPackets_whenReceivingNacksFromDifferentType) {
     auto rtp_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
-    uint ssrc = connection->getAudioSourceSSRC();
-    uint source_ssrc = connection->getAudioSinkSSRC();
+    uint ssrc = media_stream->getAudioSourceSSRC();
+    uint source_ssrc = media_stream->getAudioSinkSSRC();
     auto nack_packet = erizo::PacketTools::createNack(ssrc, source_ssrc, erizo::kArbitrarySeqNumber, AUDIO_PACKET);
 
     EXPECT_CALL(*writer.get(), write(_, _)).
@@ -108,8 +108,8 @@ TEST_F(RtpRetransmissionHandlerTest, shouldNotRetransmitPackets_whenReceivingNac
 }
 
 TEST_F(RtpRetransmissionHandlerTest, shouldRetransmitPackets_whenReceivingWithSeqNumBeforeGeneralRollover) {
-    uint ssrc = connection->getVideoSourceSSRC();
-    uint source_ssrc = connection->getVideoSinkSSRC();
+    uint ssrc = media_stream->getVideoSourceSSRC();
+    uint source_ssrc = media_stream->getVideoSinkSSRC();
     auto nack_packet = erizo::PacketTools::createNack(ssrc, source_ssrc, erizo::kFirstSequenceNumber, VIDEO_PACKET);
 
     EXPECT_CALL(*writer.get(), write(_, _)).
@@ -124,8 +124,8 @@ TEST_F(RtpRetransmissionHandlerTest, shouldRetransmitPackets_whenReceivingWithSe
 }
 
 TEST_F(RtpRetransmissionHandlerTest, shouldRetransmitPackets_whenReceivingWithSeqNumBeforeBufferRollover) {
-    uint ssrc = connection->getVideoSourceSSRC();
-    uint source_ssrc = connection->getVideoSinkSSRC();
+    uint ssrc = media_stream->getVideoSourceSSRC();
+    uint source_ssrc = media_stream->getVideoSinkSSRC();
     auto nack_packet = erizo::PacketTools::createNack(ssrc, source_ssrc, kRetransmissionsBufferSize - 1, VIDEO_PACKET);
 
     EXPECT_CALL(*writer.get(), write(_, _)).
@@ -140,8 +140,8 @@ TEST_F(RtpRetransmissionHandlerTest, shouldRetransmitPackets_whenReceivingWithSe
 }
 
 TEST_F(RtpRetransmissionHandlerTest, shouldRetransmitPackets_whenReceivingNackWithMultipleSeqNums) {
-    uint ssrc = connection->getVideoSourceSSRC();
-    uint source_ssrc = connection->getVideoSinkSSRC();
+    uint ssrc = media_stream->getVideoSourceSSRC();
+    uint source_ssrc = media_stream->getVideoSinkSSRC();
     auto nack_packet = erizo::PacketTools::createNack(ssrc, source_ssrc, erizo::kArbitrarySeqNumber, VIDEO_PACKET, 1);
 
     EXPECT_CALL(*writer.get(), write(_, _)).

--- a/erizo/src/test/rtp/RtpSlideShowHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpSlideShowHandlerTest.cpp
@@ -42,7 +42,7 @@ class RtpSlideShowHandlerTest : public erizo::HandlerTest {
 
  protected:
   void setHandler() {
-    std::vector<RtpMap>& payloads = connection->getRemoteSdpInfo().getPayloadInfos();
+    std::vector<RtpMap>& payloads = media_stream->getRemoteSdpInfo()->getPayloadInfos();
     payloads.push_back({96, "VP8"});
     payloads.push_back({98, "VP9"});
     clock = std::make_shared<erizo::SimulatedClock>();
@@ -239,8 +239,8 @@ TEST_F(RtpSlideShowHandlerTest, shouldAdjustSequenceNumberAfterSlideShow) {
       pipeline->write(packet_queue.front());
       packet_queue.pop();
     }
-    uint ssrc = connection->getVideoSourceSSRC();
-    uint source_ssrc = connection->getVideoSinkSSRC();
+    uint ssrc = media_stream->getVideoSourceSSRC();
+    uint source_ssrc = media_stream->getVideoSinkSSRC();
     auto nack = erizo::PacketTools::createNack(ssrc, source_ssrc,
                                 erizo::kArbitrarySeqNumber + packets_after_handler, VIDEO_PACKET);
     pipeline->read(nack);

--- a/erizo/src/test/rtp/RtpTrackMuteHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpTrackMuteHandlerTest.cpp
@@ -155,8 +155,8 @@ TEST_F(RtpTrackMuteHandlerTest, shouldAdjustSequenceNumbers) {
       With(Args<1>(erizo::ReceiverReportHasSequenceNumber(last_sent_seq_number))).
       Times(1);
 
-    uint source_ssrc = connection->getAudioSinkSSRC();
-    uint ssrc = connection->getAudioSourceSSRC();
+    uint source_ssrc = media_stream->getAudioSinkSSRC();
+    uint ssrc = media_stream->getAudioSourceSSRC();
     auto nack = erizo::PacketTools::createNack(ssrc, source_ssrc, erizo::kArbitrarySeqNumber + 3, AUDIO_PACKET);
     pipeline->read(nack);
     auto receiver_report = erizo::PacketTools::createReceiverReport(ssrc, source_ssrc, erizo::kArbitrarySeqNumber + 3,

--- a/erizo/src/test/rtp/SRPacketHandlerTest.cpp
+++ b/erizo/src/test/rtp/SRPacketHandlerTest.cpp
@@ -6,6 +6,7 @@
 #include <rtp/RtpHeaders.h>
 #include <MediaDefinitions.h>
 #include <WebRtcConnection.h>
+#include <MediaStream.h>
 
 #include <string>
 #include <vector>
@@ -91,4 +92,3 @@ TEST_F(SRPacketHandlerTest, shouldRewriteOctetsSent) {
   pipeline->write(packet);
   pipeline->write(sr_packet);
 }
-

--- a/erizo/src/test/utils/Mocks.h
+++ b/erizo/src/test/utils/Mocks.h
@@ -70,6 +70,16 @@ class MockWebRtcConnection: public WebRtcConnection {
   }
 };
 
+class MockMediaStream: public MediaStream {
+ public:
+  MockMediaStream(std::shared_ptr<WebRtcConnection> connection, const std::string& media_stream_id,
+    std::vector<RtpMap> rtp_mappings) :
+  MediaStream(connection, media_stream_id) {
+    local_sdp_ = std::make_shared<SdpInfo>(rtp_mappings);
+    remote_sdp_ = std::make_shared<SdpInfo>(rtp_mappings);
+  }
+};
+
 class Reader : public InboundHandler {
  public:
   MOCK_METHOD0(enable, void());

--- a/erizo/src/test/utils/Tools.h
+++ b/erizo/src/test/utils/Tools.h
@@ -198,14 +198,15 @@ class BaseHandlerTest  {
     io_worker = std::make_shared<erizo::IOWorker>();
     io_worker->start();
     connection = std::make_shared<erizo::MockWebRtcConnection>(simulated_worker, io_worker, ice_config, rtp_maps);
+    media_stream = std::make_shared<erizo::MockMediaStream>(connection, "", rtp_maps);
     processor = std::make_shared<erizo::MockRtcpProcessor>();
     quality_manager = std::make_shared<erizo::MockQualityManager>();
     packet_buffer_service = std::make_shared<erizo::PacketBufferService>();
     stats = std::make_shared<erizo::Stats>();
-    connection->setVideoSinkSSRC(erizo::kVideoSsrc);
-    connection->setAudioSinkSSRC(erizo::kAudioSsrc);
-    connection->setVideoSourceSSRC(erizo::kVideoSsrc);
-    connection->setAudioSourceSSRC(erizo::kAudioSsrc);
+    media_stream->setVideoSinkSSRC(erizo::kVideoSsrc);
+    media_stream->setAudioSinkSSRC(erizo::kAudioSsrc);
+    media_stream->setVideoSourceSSRC(erizo::kVideoSsrc);
+    media_stream->setAudioSourceSSRC(erizo::kAudioSsrc);
 
     pipeline = Pipeline::create();
     reader = std::make_shared<erizo::Reader>();
@@ -218,7 +219,8 @@ class BaseHandlerTest  {
     EXPECT_CALL(*writer, write(_, _)).Times(testing::AtLeast(0));
 
     std::shared_ptr<erizo::WebRtcConnection> connection_ptr = std::dynamic_pointer_cast<WebRtcConnection>(connection);
-    pipeline->addService(connection_ptr);
+    std::shared_ptr<erizo::MediaStream> stream_ptr = std::dynamic_pointer_cast<MediaStream>(media_stream);
+    pipeline->addService(stream_ptr);
     pipeline->addService(std::dynamic_pointer_cast<RtcpProcessor>(processor));
     pipeline->addService(std::dynamic_pointer_cast<QualityManager>(quality_manager));
     pipeline->addService(packet_buffer_service);
@@ -245,6 +247,7 @@ class BaseHandlerTest  {
   std::vector<RtpMap> rtp_maps;
   std::shared_ptr<erizo::Stats> stats;
   std::shared_ptr<erizo::MockWebRtcConnection> connection;
+  std::shared_ptr<erizo::MockMediaStream> media_stream;
   std::shared_ptr<erizo::MockRtcpProcessor> processor;
   std::shared_ptr<erizo::MockQualityManager> quality_manager;
   Pipeline::Ptr pipeline;

--- a/erizoAPI/MediaStream.cc
+++ b/erizoAPI/MediaStream.cc
@@ -1,0 +1,229 @@
+#ifndef BUILDING_NODE_EXTENSION
+#define BUILDING_NODE_EXTENSION
+#endif
+
+#include "MediaStream.h"
+
+#include "lib/json.hpp"
+#include "ThreadPool.h"
+
+using v8::HandleScope;
+using v8::Function;
+using v8::FunctionTemplate;
+using v8::Local;
+using v8::Persistent;
+using v8::Exception;
+using v8::Value;
+using json = nlohmann::json;
+
+Nan::Persistent<Function> MediaStream::constructor;
+
+MediaStream::MediaStream() {
+}
+
+MediaStream::~MediaStream() {
+}
+
+NAN_MODULE_INIT(MediaStream::Init) {
+  // Prepare constructor template
+  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+  tpl->SetClassName(Nan::New("MediaStream").ToLocalChecked());
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+  // Prototype
+  Nan::SetPrototypeMethod(tpl, "close", close);
+  Nan::SetPrototypeMethod(tpl, "init", init);
+  Nan::SetPrototypeMethod(tpl, "setAudioReceiver", setAudioReceiver);
+  Nan::SetPrototypeMethod(tpl, "setVideoReceiver", setVideoReceiver);
+  Nan::SetPrototypeMethod(tpl, "getCurrentState", getCurrentState);
+  Nan::SetPrototypeMethod(tpl, "generatePLIPacket", generatePLIPacket);
+  Nan::SetPrototypeMethod(tpl, "setFeedbackReports", setFeedbackReports);
+  Nan::SetPrototypeMethod(tpl, "setSlideShowMode", setSlideShowMode);
+  Nan::SetPrototypeMethod(tpl, "muteStream", muteStream);
+  Nan::SetPrototypeMethod(tpl, "setQualityLayer", setQualityLayer);
+  Nan::SetPrototypeMethod(tpl, "setVideoConstraints", setVideoConstraints);
+  Nan::SetPrototypeMethod(tpl, "setMetadata", setMetadata);
+  Nan::SetPrototypeMethod(tpl, "enableHandler", enableHandler);
+  Nan::SetPrototypeMethod(tpl, "disableHandler", disableHandler);
+
+  constructor.Reset(tpl->GetFunction());
+  Nan::Set(target, Nan::New("MediaStream").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
+}
+
+
+NAN_METHOD(MediaStream::New) {
+  if (info.Length() < 2) {
+    Nan::ThrowError("Wrong number of arguments");
+  }
+
+  if (info.IsConstructCall()) {
+    // Invoked as a constructor with 'new WebRTC()'
+    WebRtcConnection* connection =
+     Nan::ObjectWrap::Unwrap<WebRtcConnection>(Nan::To<v8::Object>(info[0]).ToLocalChecked());
+
+    std::shared_ptr<erizo::WebRtcConnection> wrtc = connection->me;
+
+    v8::String::Utf8Value paramId(Nan::To<v8::String>(info[1]).ToLocalChecked());
+    std::string wrtcId = std::string(*paramId);
+    MediaStream* obj = new MediaStream();
+    obj->me = std::make_shared<erizo::MediaStream>(wrtc, wrtcId);
+    obj->msink = obj->me.get();
+    obj->Wrap(info.This());
+    info.GetReturnValue().Set(info.This());
+  } else {
+    // TODO(pedro) Check what happens here
+  }
+}
+
+NAN_METHOD(MediaStream::close) {
+  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  obj->me.reset();
+}
+
+NAN_METHOD(MediaStream::init) {
+  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  std::shared_ptr<erizo::MediaStream> me = obj->me;
+  bool r = me->init();
+
+  info.GetReturnValue().Set(Nan::New(r));
+}
+
+NAN_METHOD(MediaStream::setSlideShowMode) {
+  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  std::shared_ptr<erizo::MediaStream> me = obj->me;
+
+  bool v = info[0]->BooleanValue();
+  me->setSlideShowMode(v);
+  info.GetReturnValue().Set(Nan::New(v));
+}
+
+NAN_METHOD(MediaStream::muteStream) {
+  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  std::shared_ptr<erizo::MediaStream> me = obj->me;
+
+  bool mute_video = info[0]->BooleanValue();
+  bool mute_audio = info[1]->BooleanValue();
+  me->muteStream(mute_video, mute_audio);
+}
+
+NAN_METHOD(MediaStream::setVideoConstraints) {
+  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  std::shared_ptr<erizo::MediaStream> me = obj->me;
+  int max_video_width = info[0]->IntegerValue();
+  int max_video_height = info[1]->IntegerValue();
+  int max_video_frame_rate = info[2]->IntegerValue();
+  me->setVideoConstraints(max_video_width, max_video_height, max_video_frame_rate);
+}
+
+NAN_METHOD(MediaStream::setMetadata) {
+  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  std::shared_ptr<erizo::MediaStream> me = obj->me;
+
+  v8::String::Utf8Value json_param(Nan::To<v8::String>(info[0]).ToLocalChecked());
+  std::string metadata_string = std::string(*json_param);
+  json metadata_json = json::parse(metadata_string);
+  std::map<std::string, std::string> metadata;
+  for (json::iterator item = metadata_json.begin(); item != metadata_json.end(); ++item) {
+    std::string value = item.value().dump();
+    if (item.value().is_object()) {
+      value = "[object]";
+    }
+    if (item.value().is_string()) {
+      value = item.value();
+    }
+    metadata[item.key()] = value;
+  }
+
+  me->setMetadata(metadata);
+
+  info.GetReturnValue().Set(Nan::New(true));
+}
+
+
+NAN_METHOD(MediaStream::getCurrentState) {
+  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  std::shared_ptr<erizo::MediaStream> me = obj->me;
+
+  int state = me->getCurrentState();
+
+  info.GetReturnValue().Set(Nan::New(state));
+}
+
+
+NAN_METHOD(MediaStream::setAudioReceiver) {
+  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  std::shared_ptr<erizo::MediaStream> me = obj->me;
+
+  MediaSink* param = Nan::ObjectWrap::Unwrap<MediaSink>(Nan::To<v8::Object>(info[0]).ToLocalChecked());
+  erizo::MediaSink *mr = param->msink;
+
+  me->setAudioSink(mr);
+  me->setEventSink(mr);
+}
+
+NAN_METHOD(MediaStream::setVideoReceiver) {
+  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  std::shared_ptr<erizo::MediaStream> me = obj->me;
+
+  MediaSink* param = Nan::ObjectWrap::Unwrap<MediaSink>(Nan::To<v8::Object>(info[0]).ToLocalChecked());
+  erizo::MediaSink *mr = param->msink;
+
+  me->setVideoSink(mr);
+  me->setEventSink(mr);
+}
+
+
+NAN_METHOD(MediaStream::generatePLIPacket) {
+  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+
+  if (obj->me == NULL) {
+    return;
+  }
+
+  std::shared_ptr<erizo::MediaStream> me = obj->me;
+  me->sendPLI();
+  return;
+}
+
+NAN_METHOD(MediaStream::enableHandler) {
+  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  std::shared_ptr<erizo::MediaStream> me = obj->me;
+
+  v8::String::Utf8Value param(Nan::To<v8::String>(info[0]).ToLocalChecked());
+  std::string name = std::string(*param);
+
+  me->enableHandler(name);
+  return;
+}
+
+NAN_METHOD(MediaStream::disableHandler) {
+  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  std::shared_ptr<erizo::MediaStream> me = obj->me;
+
+  v8::String::Utf8Value param(Nan::To<v8::String>(info[0]).ToLocalChecked());
+  std::string name = std::string(*param);
+
+  me->disableHandler(name);
+  return;
+}
+
+NAN_METHOD(MediaStream::setQualityLayer) {
+  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  std::shared_ptr<erizo::MediaStream> me = obj->me;
+
+  int spatial_layer = info[0]->IntegerValue();
+  int temporal_layer = info[1]->IntegerValue();
+
+  me->setQualityLayer(spatial_layer, temporal_layer);
+
+  return;
+}
+
+NAN_METHOD(MediaStream::setFeedbackReports) {
+  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  std::shared_ptr<erizo::MediaStream> me = obj->me;
+
+  bool v = info[0]->BooleanValue();
+  int fbreps = info[1]->IntegerValue();  // From bps to Kbps
+  me->setFeedbackReports(v, fbreps);
+}

--- a/erizoAPI/MediaStream.h
+++ b/erizoAPI/MediaStream.h
@@ -1,0 +1,106 @@
+
+#ifndef ERIZOAPI_MEDIASTREAM_H_
+#define ERIZOAPI_MEDIASTREAM_H_
+
+#include <nan.h>
+#include <MediaStream.h>
+#include "MediaDefinitions.h"
+#include "OneToManyProcessor.h"
+
+#include <queue>
+#include <string>
+#include <future>  // NOLINT
+
+/*
+ * Wrapper class of erizo::MediaStream
+ *
+ * A WebRTC Connection. This class represents a MediaStream that can be established with other peers via a SDP negotiation
+ * it comprises all the necessary ICE and SRTP components.
+ */
+class MediaStream : public MediaSink {
+ public:
+    static NAN_MODULE_INIT(Init);
+
+    std::shared_ptr<erizo::MediaStream> me;
+
+ private:
+    MediaStream();
+    ~MediaStream();
+
+    /*
+     * Constructor.
+     * Constructs an empty MediaStream without any configuration.
+     */
+    static NAN_METHOD(New);
+    /*
+     * Closes the webRTC connection.
+     * The object cannot be used after this call.
+     */
+    static NAN_METHOD(close);
+    /*
+     * Inits the MediaStream and passes the callback to get Events.
+     * Returns true if the candidates are gathered.
+     */
+    static NAN_METHOD(init);
+    /*
+     * Sets a MediaReceiver that is going to receive Audio Data
+     * Param: the MediaReceiver to send audio to.
+     */
+    static NAN_METHOD(setAudioReceiver);
+    /*
+     * Sets a MediaReceiver that is going to receive Video Data
+     * Param: the MediaReceiver
+     */
+    static NAN_METHOD(setVideoReceiver);
+    /*
+     * Gets the current state of the Ice Connection
+     * Returns the state.
+     */
+    static NAN_METHOD(getCurrentState);
+    /*
+     * Request a PLI packet from this WRTCConn
+     */
+    static NAN_METHOD(generatePLIPacket);
+    /*
+     * Enables or disables Feedback reports from this WRTC
+     * Param: A boolean indicating what to do
+     */
+    static NAN_METHOD(setFeedbackReports);
+    /*
+     * Enables or disables SlideShowMode for this WRTC
+     * Param: A boolean indicating what to do
+     */
+    static NAN_METHOD(setSlideShowMode);
+    /*
+     * Mutes or unmutes streams for this WRTC
+     * Param: A boolean indicating what to do
+     */
+    static NAN_METHOD(muteStream);
+    /*
+     * Sets constraints to the subscribing video
+     * Param: Max width, height and framerate.
+     */
+    static NAN_METHOD(setVideoConstraints);
+
+    /*
+     * Sets Metadata that will be logged in every message
+     * Param: An object with metadata {key1:value1, key2: value2}
+     */
+    static NAN_METHOD(setMetadata);
+    /*
+     * Enable a specific Handler in the pipeline
+     * Param: Name of the handler
+     */
+    static NAN_METHOD(enableHandler);
+    /*
+     * Disables a specific Handler in the pipeline
+     * Param: Name of the handler
+     */
+    static NAN_METHOD(disableHandler);
+
+    static NAN_METHOD(setQualityLayer);
+
+    static Nan::Persistent<v8::Function> constructor;
+};
+
+#endif  // ERIZOAPI_MEDIASTREAM_H_

--- a/erizoAPI/MediaStream.h
+++ b/erizoAPI/MediaStream.h
@@ -11,29 +11,49 @@
 #include <string>
 #include <future>  // NOLINT
 
+class StatCallWorker : public Nan::AsyncWorker {
+ public:
+  StatCallWorker(Nan::Callback *callback, std::weak_ptr<erizo::MediaStream> weak_stream);
+
+  void Execute();
+
+  void HandleOKCallback();
+
+ private:
+  std::weak_ptr<erizo::MediaStream> weak_stream_;
+  std::string stat_;
+};
+
 /*
  * Wrapper class of erizo::MediaStream
  *
  * A WebRTC Connection. This class represents a MediaStream that can be established with other peers via a SDP negotiation
  * it comprises all the necessary ICE and SRTP components.
  */
-class MediaStream : public MediaSink {
+class MediaStream : public MediaSink, public erizo::MediaStreamStatsListener {
  public:
     static NAN_MODULE_INIT(Init);
 
     std::shared_ptr<erizo::MediaStream> me;
+    std::queue<std::string> statsMsgs;
+
+    boost::mutex mutex;
 
  private:
     MediaStream();
     ~MediaStream();
 
+    Nan::Callback *statsCallback_;
+
+    uv_async_t asyncStats_;
+    bool hasCallback_;
     /*
      * Constructor.
      * Constructs an empty MediaStream without any configuration.
      */
     static NAN_METHOD(New);
     /*
-     * Closes the webRTC connection.
+     * Closes the MediaStream.
      * The object cannot be used after this call.
      */
     static NAN_METHOD(close);
@@ -58,21 +78,21 @@ class MediaStream : public MediaSink {
      */
     static NAN_METHOD(getCurrentState);
     /*
-     * Request a PLI packet from this WRTCConn
+     * Request a PLI packet from this MediaStream
      */
     static NAN_METHOD(generatePLIPacket);
     /*
-     * Enables or disables Feedback reports from this WRTC
+     * Enables or disables Feedback reports from this MediaStream
      * Param: A boolean indicating what to do
      */
     static NAN_METHOD(setFeedbackReports);
     /*
-     * Enables or disables SlideShowMode for this WRTC
+     * Enables or disables SlideShowMode for this MediaStream
      * Param: A boolean indicating what to do
      */
     static NAN_METHOD(setSlideShowMode);
     /*
-     * Mutes or unmutes streams for this WRTC
+     * Mutes or unmutes streams for this MediaStream
      * Param: A boolean indicating what to do
      */
     static NAN_METHOD(muteStream);
@@ -81,6 +101,23 @@ class MediaStream : public MediaSink {
      * Param: Max width, height and framerate.
      */
     static NAN_METHOD(setVideoConstraints);
+    /*
+     * Gets Stats from this MediaStream
+     * Param: None
+     * Returns: The Current stats
+     * Param: Callback that will get periodic stats reports
+     * Returns: True if the callback was set successfully
+     */
+    static NAN_METHOD(getStats);
+
+    /*
+     * Gets Stats from this MediaStream
+     * Param: None
+     * Returns: The Current stats
+     * Param: Callback that will get periodic stats reports
+     * Returns: True if the callback was set successfully
+     */
+    static NAN_METHOD(getPeriodicStats);
 
     /*
      * Sets Metadata that will be logged in every message
@@ -99,8 +136,10 @@ class MediaStream : public MediaSink {
     static NAN_METHOD(disableHandler);
 
     static NAN_METHOD(setQualityLayer);
-
     static Nan::Persistent<v8::Function> constructor;
+
+    static NAUV_WORK_CB(statsCallback);
+    virtual void notifyStats(const std::string& message);
 };
 
 #endif  // ERIZOAPI_MEDIASTREAM_H_

--- a/erizoAPI/OneToManyProcessor.cc
+++ b/erizoAPI/OneToManyProcessor.cc
@@ -110,8 +110,8 @@ NAN_METHOD(OneToManyProcessor::setPublisher) {
   OneToManyProcessor* obj = Nan::ObjectWrap::Unwrap<OneToManyProcessor>(info.Holder());
   erizo::OneToManyProcessor *me = (erizo::OneToManyProcessor*)obj->me;
 
-  WebRtcConnection* param = Nan::ObjectWrap::Unwrap<WebRtcConnection>(Nan::To<v8::Object>(info[0]).ToLocalChecked());
-  auto wr = std::shared_ptr<erizo::WebRtcConnection>(param->me);
+  MediaStream* param = Nan::ObjectWrap::Unwrap<MediaStream>(Nan::To<v8::Object>(info[0]).ToLocalChecked());
+  auto wr = std::shared_ptr<erizo::MediaStream>(param->me);
 
   std::shared_ptr<erizo::MediaSource> ms = std::dynamic_pointer_cast<erizo::MediaSource>(wr);
   me->setPublisher(ms);
@@ -149,7 +149,7 @@ NAN_METHOD(OneToManyProcessor::getPublisherState) {
   OneToManyProcessor* obj = Nan::ObjectWrap::Unwrap<OneToManyProcessor>(info.Holder());
   erizo::OneToManyProcessor *me = (erizo::OneToManyProcessor*)obj->me;
 
-  auto wr = std::dynamic_pointer_cast<erizo::WebRtcConnection>(me->publisher);
+  auto wr = std::dynamic_pointer_cast<erizo::MediaStream>(me->publisher);
 
   int state = wr->getCurrentState();
   info.GetReturnValue().Set(Nan::New(state));
@@ -172,8 +172,8 @@ NAN_METHOD(OneToManyProcessor::addSubscriber) {
   OneToManyProcessor* obj = Nan::ObjectWrap::Unwrap<OneToManyProcessor>(info.Holder());
   erizo::OneToManyProcessor *me = (erizo::OneToManyProcessor*)obj->me;
 
-  WebRtcConnection* param = Nan::ObjectWrap::Unwrap<WebRtcConnection>(Nan::To<v8::Object>(info[0]).ToLocalChecked());
-  auto wr = std::shared_ptr<erizo::WebRtcConnection>(param->me);
+  MediaStream* param = Nan::ObjectWrap::Unwrap<MediaStream>(Nan::To<v8::Object>(info[0]).ToLocalChecked());
+  auto wr = std::shared_ptr<erizo::MediaStream>(param->me);
 
   std::shared_ptr<erizo::MediaSink> ms = std::dynamic_pointer_cast<erizo::MediaSink>(wr);
   // get the param

--- a/erizoAPI/OneToManyProcessor.h
+++ b/erizoAPI/OneToManyProcessor.h
@@ -3,9 +3,9 @@
 
 #include <nan.h>
 #include <OneToManyProcessor.h>
-#include <WebRtcConnection.h>
+#include <MediaStream.h>
 #include "MediaDefinitions.h"
-#include "WebRtcConnection.h"
+#include "MediaStream.h"
 #include "ExternalInput.h"
 #include "ExternalOutput.h"
 
@@ -42,7 +42,7 @@ class OneToManyProcessor : public MediaSink {
     static NAN_METHOD(setPublisher);
     /*
      * Adds an ExternalOutput
-     * Param: The ExternalOutput   
+     * Param: The ExternalOutput
      */
     static NAN_METHOD(addExternalOutput);
     /*

--- a/erizoAPI/SyntheticInput.cc
+++ b/erizoAPI/SyntheticInput.cc
@@ -127,7 +127,7 @@ NAN_METHOD(SyntheticInput::setFeedbackSource) {
   SyntheticInput* obj = ObjectWrap::Unwrap<SyntheticInput>(info.Holder());
   std::shared_ptr<erizo::SyntheticInput> me = obj->me;
 
-  WebRtcConnection* param = ObjectWrap::Unwrap<WebRtcConnection>(Nan::To<v8::Object>(info[0]).ToLocalChecked());
+  MediaStream* param = ObjectWrap::Unwrap<MediaStream>(Nan::To<v8::Object>(info[0]).ToLocalChecked());
   erizo::FeedbackSource* fb_source = param->me->getFeedbackSource();
 
   if (fb_source != nullptr) {

--- a/erizoAPI/SyntheticInput.h
+++ b/erizoAPI/SyntheticInput.h
@@ -4,7 +4,7 @@
 #include <nan.h>
 #include <media/SyntheticInput.h>
 #include "MediaDefinitions.h"
-#include "WebRtcConnection.h"
+#include "MediaStream.h"
 
 
 /*

--- a/erizoAPI/WebRtcConnection.h
+++ b/erizoAPI/WebRtcConnection.h
@@ -10,19 +10,6 @@
 #include <string>
 #include <future>  // NOLINT
 
-class StatCallWorker : public Nan::AsyncWorker {
- public:
-  StatCallWorker(Nan::Callback *callback, std::weak_ptr<erizo::WebRtcConnection> weak_connection);
-
-  void Execute();
-
-  void HandleOKCallback();
-
- private:
-  std::weak_ptr<erizo::WebRtcConnection> weak_connection_;
-  std::string stat_;
-};
-
 /*
  * Wrapper class of erizo::WebRtcConnection
  *
@@ -30,14 +17,14 @@ class StatCallWorker : public Nan::AsyncWorker {
  * it comprises all the necessary ICE and SRTP components.
  */
 class WebRtcConnection : public erizo::WebRtcConnectionEventListener,
-  public erizo::WebRtcConnectionStatsListener, public Nan::ObjectWrap{
+   public Nan::ObjectWrap{
  public:
     static NAN_MODULE_INIT(Init);
 
     std::shared_ptr<erizo::WebRtcConnection> me;
     int eventSt;
     std::queue<int> eventSts;
-    std::queue<std::string> eventMsgs, statsMsgs;
+    std::queue<std::string> eventMsgs;
 
     boost::mutex mutex;
 
@@ -46,11 +33,9 @@ class WebRtcConnection : public erizo::WebRtcConnectionEventListener,
     ~WebRtcConnection();
 
     Nan::Callback *eventCallback_;
-    Nan::Callback *statsCallback_;
 
     uv_async_t async_;
     uv_async_t asyncStats_;
-    bool hasCallback_;
     /*
      * Constructor.
      * Constructs an empty WebRtcConnection without any configuration.
@@ -95,56 +80,10 @@ class WebRtcConnection : public erizo::WebRtcConnectionEventListener,
      */
     static NAN_METHOD(getCurrentState);
     /*
-     * Request a PLI packet from this WRTCConn
-     */
-    static NAN_METHOD(generatePLIPacket);
-    /*
-     * Enables or disables Feedback reports from this WRTC
-     * Param: A boolean indicating what to do
-     */
-    static NAN_METHOD(setFeedbackReports);
-    /*
-     * Enables or disables SlideShowMode for this WRTC
-     * Param: A boolean indicating what to do
-     */
-    static NAN_METHOD(setSlideShowMode);
-    /*
-     * Mutes or unmutes streams for this WRTC
-     * Param: A boolean indicating what to do
-     */
-    static NAN_METHOD(muteStream);
-    /*
-     * Sets constraints to the subscribing video
-     * Param: Max width, height and framerate.
-     */
-    static NAN_METHOD(setVideoConstraints);
-    /*
-     * Gets Stats from this Wrtc
-     * Param: None
-     * Returns: The Current stats
-     * Param: Callback that will get periodic stats reports
-     * Returns: True if the callback was set successfully
-     */
-    static NAN_METHOD(getStats);
-
-    /*
-     * Gets Stats from this Wrtc
-     * Param: None
-     * Returns: The Current stats
-     * Param: Callback that will get periodic stats reports
-     * Returns: True if the callback was set successfully
-     */
-    static NAN_METHOD(getPeriodicStats);
-    /*
      * Sets Metadata that will be logged in every message
      * Param: An object with metadata {key1:value1, key2: value2}
      */
     static NAN_METHOD(setMetadata);
-    /*
-     * Enable a specific Handler in the pipeline
-     * Param: Name of the handler
-     */
-    static NAN_METHOD(setQualityLayer);
 
     static NAN_METHOD(addMediaStream);
     static NAN_METHOD(removeMediaStream);
@@ -152,10 +91,8 @@ class WebRtcConnection : public erizo::WebRtcConnectionEventListener,
     static Nan::Persistent<v8::Function> constructor;
 
     static NAUV_WORK_CB(eventsCallback);
-    static NAUV_WORK_CB(statsCallback);
 
     virtual void notifyEvent(erizo::WebRTCEvent event, const std::string& message = "");
-    virtual void notifyStats(const std::string& message);
 };
 
 #endif  // ERIZOAPI_WEBRTCCONNECTION_H_

--- a/erizoAPI/WebRtcConnection.h
+++ b/erizoAPI/WebRtcConnection.h
@@ -29,8 +29,8 @@ class StatCallWorker : public Nan::AsyncWorker {
  * A WebRTC Connection. This class represents a WebRtcConnection that can be established with other peers via a SDP negotiation
  * it comprises all the necessary ICE and SRTP components.
  */
-class WebRtcConnection : public MediaSink, public erizo::WebRtcConnectionEventListener,
-  public erizo::WebRtcConnectionStatsListener {
+class WebRtcConnection : public erizo::WebRtcConnectionEventListener,
+  public erizo::WebRtcConnectionStatsListener, public Nan::ObjectWrap{
  public:
     static NAN_MODULE_INIT(Init);
 
@@ -90,16 +90,6 @@ class WebRtcConnection : public MediaSink, public erizo::WebRtcConnectionEventLi
      */
     static NAN_METHOD(getLocalSdp);
     /*
-     * Sets a MediaReceiver that is going to receive Audio Data
-     * Param: the MediaReceiver to send audio to.
-     */
-    static NAN_METHOD(setAudioReceiver);
-    /*
-     * Sets a MediaReceiver that is going to receive Video Data
-     * Param: the MediaReceiver
-     */
-    static NAN_METHOD(setVideoReceiver);
-    /*
      * Gets the current state of the Ice Connection
      * Returns the state.
      */
@@ -154,14 +144,10 @@ class WebRtcConnection : public MediaSink, public erizo::WebRtcConnectionEventLi
      * Enable a specific Handler in the pipeline
      * Param: Name of the handler
      */
-    static NAN_METHOD(enableHandler);
-    /*
-     * Disables a specific Handler in the pipeline
-     * Param: Name of the handler
-     */
-    static NAN_METHOD(disableHandler);
-
     static NAN_METHOD(setQualityLayer);
+
+    static NAN_METHOD(addMediaStream);
+    static NAN_METHOD(removeMediaStream);
 
     static Nan::Persistent<v8::Function> constructor;
 

--- a/erizoAPI/addon.cc
+++ b/erizoAPI/addon.cc
@@ -3,6 +3,7 @@
 #endif
 #include <nan.h>
 #include "WebRtcConnection.h"
+#include "MediaStream.h"
 #include "OneToManyProcessor.h"
 #include "OneToManyTranscoder.h"
 #include "SyntheticInput.h"
@@ -13,6 +14,7 @@
 
 NAN_MODULE_INIT(InitAll) {
   WebRtcConnection::Init(target);
+  MediaStream::Init(target);
   OneToManyProcessor::Init(target);
   ExternalInput::Init(target);
   ExternalOutput::Init(target);

--- a/erizoAPI/binding.gyp
+++ b/erizoAPI/binding.gyp
@@ -1,6 +1,6 @@
 {
   'variables' : {
-    'common_sources': [ 'addon.cc', 'IOThreadPool.cc', 'ThreadPool.cc', 'WebRtcConnection.cc', 'OneToManyProcessor.cc', 'ExternalInput.cc', 'ExternalOutput.cc', 'SyntheticInput.cc'],
+    'common_sources': [ 'addon.cc', 'IOThreadPool.cc', 'ThreadPool.cc', 'MediaStream.cc', 'WebRtcConnection.cc', 'OneToManyProcessor.cc', 'ExternalInput.cc', 'ExternalOutput.cc', 'SyntheticInput.cc'],
     'common_include_dirs' : ["<!(node -e \"require('nan')\")", '$(ERIZO_HOME)/src/erizo', '$(ERIZO_HOME)/../build/libdeps/build/include', '$(ERIZO_HOME)/src/third_party/webrtc/src']
   },
   'targets': [

--- a/erizo_controller/erizoAgent/log4cxx.properties
+++ b/erizo_controller/erizoAgent/log4cxx.properties
@@ -12,6 +12,7 @@ log4j.appender.A1.layout.ConversionPattern=%d  - %p [%t] %c - %m%n
 log4j.logger.DtlsTransport=DEBUG
 log4j.logger.LibNiceConnection=DEBUG
 log4j.logger.NicerConnection=DEBUG
+log4j.logger.MediaStream=DEBUG
 log4j.logger.OneToManyProcessor=WARN
 log4j.logger.Resender=WARN
 log4j.logger.SdpInfo=WARN

--- a/erizo_controller/erizoJS/adapt_schemes/notify-slideshow.js
+++ b/erizo_controller/erizoJS/adapt_schemes/notify-slideshow.js
@@ -25,48 +25,49 @@ exports.MonitorSubscriber = function (log) {
   };
 
 
-  that.monitorMinVideoBw = function(wrtc, callback, idPub, idSub, options, erizoJsController) {
-    wrtc.bwValues = [];
+  that.monitorMinVideoBw = function(mediaStream, callback, idPub,
+     idSub, options, erizoJsController) {
+    mediaStream.bwValues = [];
     var ticks = 0;
     var retries = 0;
     var lastAverage, average, lastBWValue;
     var nextRetry = 0;
-    wrtc.bwStatus = BW_STABLE;
+    mediaStream.bwStatus = BW_STABLE;
     log.info('message: Start wrtc adapt scheme, ' +
-    'id: ' + wrtc.wrtcId + ', ' +
+    'id: ' + mediaStream.wrtcId + ', ' +
     'scheme: notify-slideshow, ' +
-    'minVideoBW: ' + wrtc.minVideoBW);
+    'minVideoBW: ' + mediaStream.minVideoBW);
 
-    wrtc.minVideoBW = wrtc.minVideoBW*1000; // We need it in bps
-    wrtc.lowerThres = Math.floor(wrtc.minVideoBW*(0.8));
-    wrtc.upperThres = Math.ceil(wrtc.minVideoBW);
-    wrtc.monitorInterval = setInterval(() => {
+    mediaStream.minVideoBW = mediaStream.minVideoBW*1000; // We need it in bps
+    mediaStream.lowerThres = Math.floor(mediaStream.minVideoBW*(0.8));
+    mediaStream.upperThres = Math.ceil(mediaStream.minVideoBW);
+    mediaStream.monitorInterval = setInterval(() => {
 
-      schemeHelpers.getBandwidthStat(wrtc).then((bandwidth) => {
-        if (wrtc.slideShowMode) {
+      schemeHelpers.getBandwidthStat(mediaStream).then((bandwidth) => {
+        if (mediaStream.slideShowMode) {
           return;
         }
         if(bandwidth) {
           lastBWValue = bandwidth;
-          wrtc.bwValues.push(lastBWValue);
-          if (wrtc.bwValues.length > 5) {
-            wrtc.bwValues.shift();
+          mediaStream.bwValues.push(lastBWValue);
+          if (mediaStream.bwValues.length > 5) {
+            mediaStream.bwValues.shift();
           }
-          average = calculateAverage(wrtc.bwValues);
+          average = calculateAverage(mediaStream.bwValues);
         }
 
-        switch (wrtc.bwStatus) {
+        switch (mediaStream.bwStatus) {
           case BW_STABLE:
-            if(average <= lastAverage && (average < wrtc.lowerThres)) {
+            if(average <= lastAverage && (average < mediaStream.lowerThres)) {
               if (++ticks > TICKS_PER_TRANSITION){
                 log.info('message: scheme state change, ' +
-                'id: ' + wrtc.wrtcId + ', ' +
+                'id: ' + mediaStream.wrtcId + ', ' +
                 'previousState: BW_STABLE, ' +
                 'newState: BW_SLIDESHOW, ' +
                 'averageBandwidth: ' + average + ', ' +
-                'lowerThreshold: ' + wrtc.lowerThres);
-                wrtc.bwStatus = BW_SLIDESHOW;
-                wrtc.setFeedbackReports(false, 1);
+                'lowerThreshold: ' + mediaStream.lowerThres);
+                mediaStream.bwStatus = BW_SLIDESHOW;
+                mediaStream.setFeedbackReports(false, 1);
                 ticks = 0;
                 callback('callback', {type: 'bandwidthAlert',
                 message: 'insufficient',
@@ -76,28 +77,28 @@ exports.MonitorSubscriber = function (log) {
             break;
           case BW_SLIDESHOW:
             log.info('message: Switched to audio-only, ' +
-            'id: ' + wrtc.wrtcId + ', ' +
+            'id: ' + mediaStream.wrtcId + ', ' +
             'state: BW_SLIDESHOW, ' +
             'averageBandwidth: ' + average + ', ' +
-            'lowerThreshold: ' + wrtc.lowerThres);
+            'lowerThreshold: ' + mediaStream.lowerThres);
             ticks = 0;
             nextRetry = 0;
             retries = 0;
             average = 0;
             lastAverage = 0;
-            wrtc.minVideoBW = false;
+            mediaStream.minVideoBW = false;
             erizoJsController.setSlideShow(true, idSub, idPub);
             callback('callback', {type: 'bandwidthAlert',
             message: 'slideshow',
             bandwidth: average});
-            clearInterval(wrtc.monitorInterval);
+            clearInterval(mediaStream.monitorInterval);
             break;
           default:
-            log.error('Unknown BW status, id: ' + wrtc.wrtcId);
+            log.error('Unknown BW status, id: ' + mediaStream.wrtcId);
         }
         lastAverage = average;
       }).catch((reason) => {
-        clearInterval(wrtc.monitorInterval);
+        clearInterval(mediaStream.monitorInterval);
         log.error('error getting stats: ' + reason);
       });
     }, INTERVAL_STATS);

--- a/erizo_controller/erizoJS/adapt_schemes/notify.js
+++ b/erizo_controller/erizoJS/adapt_schemes/notify.js
@@ -19,38 +19,38 @@ exports.MonitorSubscriber = function (log) {
     };
 
 
-    that.monitorMinVideoBw = function(wrtc, callback) {
-        wrtc.bwValues = [];
+    that.monitorMinVideoBw = function(mediaStream, callback) {
+        mediaStream.bwValues = [];
         var tics = 0;
         var lastAverage, average, lastBWValue;
         log.info('message: Start wrtc adapt scheme, ' +
-                 'id: ' + wrtc.wrtcId + ', ' +
-                'scheme: notify, minVideoBW: ' + wrtc.minVideoBW);
+                 'id: ' + mediaStream.wrtcId + ', ' +
+                'scheme: notify, minVideoBW: ' + mediaStream.minVideoBW);
 
-        wrtc.minVideoBW = wrtc.minVideoBW*1000; // We need it in bps
-        wrtc.lowerThres = Math.floor(wrtc.minVideoBW*(0.8));
-        wrtc.upperThres = Math.ceil(wrtc.minVideoBW);
-        wrtc.monitorInterval = setInterval(() => {
-            schemeHelpers.getBandwidthStat(wrtc).then((bandwidth) => {
-              if (wrtc.slideShowMode) {
+        mediaStream.minVideoBW = mediaStream.minVideoBW*1000; // We need it in bps
+        mediaStream.lowerThres = Math.floor(mediaStream.minVideoBW*(0.8));
+        mediaStream.upperThres = Math.ceil(mediaStream.minVideoBW);
+        mediaStream.monitorInterval = setInterval(() => {
+            schemeHelpers.getBandwidthStat(mediaStream).then((bandwidth) => {
+              if (mediaStream.slideShowMode) {
                 return;
               }
               if(bandwidth) {
                 lastBWValue = bandwidth;
-                wrtc.bwValues.push(lastBWValue);
-                if (wrtc.bwValues.length > 5) {
-                  wrtc.bwValues.shift();
+                mediaStream.bwValues.push(lastBWValue);
+                if (mediaStream.bwValues.length > 5) {
+                  mediaStream.bwValues.shift();
                 }
-                average = calculateAverage(wrtc.bwValues);
+                average = calculateAverage(mediaStream.bwValues);
               }
 
               log.debug('message: Measuring interval, average: ' + average);
-              if (average <= lastAverage && (average < wrtc.lowerThres)) {
+              if (average <= lastAverage && (average < mediaStream.lowerThres)) {
                 if (++tics > TICS_PER_TRANSITION){
                   log.info('message: Insufficient Bandwidth, ' +
-                  'id: ' + wrtc.wrtcId + ', ' +
+                  'id: ' + mediaStream.wrtcId + ', ' +
                   'averageBandwidth: ' + average + ', ' +
-                  'lowerThreshold: ' + wrtc.lowerThres);
+                  'lowerThreshold: ' + mediaStream.lowerThres);
                   tics = 0;
                   callback('callback', {type: 'bandwidthAlert',
                   message: 'insufficient',
@@ -59,7 +59,7 @@ exports.MonitorSubscriber = function (log) {
               }
               lastAverage = average;
             }).catch((reason) => {
-              clearInterval(wrtc.monitorInterval);
+              clearInterval(mediaStream.monitorInterval);
               log.error('error getting stats: ' + reason);
             });
         }, INTERVAL_STATS);

--- a/erizo_controller/erizoJS/adapt_schemes/schemeHelpers.js
+++ b/erizo_controller/erizoJS/adapt_schemes/schemeHelpers.js
@@ -1,9 +1,9 @@
 'use strict';
 const schemeHelpers = {};
 
-schemeHelpers.getBandwidthStat = (wrtc) => {
+schemeHelpers.getBandwidthStat = (mediaStream) => {
   return new Promise((resolve, reject) => {
-    wrtc.getStats( (statsString) => {
+    mediaStream.getStats( (statsString) => {
       if (!statsString) {
         reject('no stats');
       }

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -52,7 +52,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
             wrtc.metadata = options.metadata;
         }
 
-        if (wrtc.minVideoBW) {
+        if (wrtc.mediaStream.minVideoBW) {
             var monitorMinVideoBw = {};
             if (wrtc.scheme) {
                 try{
@@ -69,7 +69,8 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
             } else {
                 monitorMinVideoBw = require('./adapt_schemes/notify').MonitorSubscriber(log);
             }
-            monitorMinVideoBw(wrtc, callback, idPub, idSub, options, that);
+            wrtc.mediaStream.wrtcId = wrtc.wrtcId;
+            monitorMinVideoBw(wrtc.mediaStream, callback, idPub, idSub, options, that);
         }
 
         if (global.config.erizoController.report.rtcp_stats) {  // jshint ignore:line
@@ -397,9 +398,9 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
       var publisher = publishers[from];
         if (publisher !== undefined) {
             log.info('message: Removing publisher, id: ' + from);
-            if (publisher.periodicPlis !== undefined) {
+            if (publisher.wrtc.mediaStream.periodicPlis !== undefined) {
                 log.debug('message: clearing periodic PLIs for publisher, id: ' + from);
-                clearInterval (publisher.periodicPlis);
+                clearInterval (publisher.wrc.mediaStream.periodicPlis);
             }
             for (var key in publisher.subscribers) {
                 var subscriber = publisher.getSubscriber(key);
@@ -444,16 +445,16 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
             publisher.removeSubscriber(from);
         }
 
-        if (publisher && publisher.wrtc.periodicPlis !== undefined) {
+        if (publisher && publisher.wrtc.mediaStream.periodicPlis !== undefined) {
             for (var i in publisher.subscribers) {
-                if (publisher.getSubscriber(i).slideShowMode === true) {
+                if (publisher.getSubscriber(i).mediaStream.slideShowMode === true) {
                     return;
                 }
             }
             log.debug('message: clearing Pli interval as no more ' +
                       'slideshows subscribers are present');
-            clearInterval(publisher.wrtc.periodicPlis);
-            publisher.wrtc.periodicPlis = undefined;
+            clearInterval(publisher.wrtc.mediaStream.periodicPlis);
+            publisher.wrtc.mediaStream.periodicPlis = undefined;
         }
     };
 
@@ -495,35 +496,35 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
         if (Number.isSafeInteger(period)) {
             period = period < MIN_SLIDESHOW_PERIOD ? MIN_SLIDESHOW_PERIOD : period;
             period = period > MAX_SLIDESHOW_PERIOD ? MAX_SLIDESHOW_PERIOD : period;
-            theWrtc.setSlideShowMode(true);
-            theWrtc.slideShowMode = true;
+            theWrtc.mediaStream.setSlideShowMode(true);
+            theWrtc.mediaStream.slideShowMode = true;
             wrtcPub = publisher.wrtc;
-            if (wrtcPub.periodicPlis) {
-                clearInterval(wrtcPub.periodicPlis);
-                wrtcPub.periodicPlis = undefined;
+            if (wrtcPub.mediaStream.periodicPlis) {
+                clearInterval(wrtcPub.mediaStream.periodicPlis);
+                wrtcPub.mediaStream.periodicPlis = undefined;
             }
-            wrtcPub.periodicPlis = setInterval(function () {
+            wrtcPub.mediaStream.periodicPlis = setInterval(function () {
                 if(wrtcPub)
-                    wrtcPub.generatePLIPacket();
+                    wrtcPub.mediaStream.generatePLIPacket();
             }, period);
         } else {
             wrtcPub = publisher.wrtc;
             for (var pliIndex = 0; pliIndex < PLIS_TO_RECOVER; pliIndex++) {
-              wrtcPub.generatePLIPacket();
+              wrtcPub.mediaStream.generatePLIPacket();
             }
 
-            theWrtc.setSlideShowMode(false);
-            theWrtc.slideShowMode = false;
-            if (publisher.wrtc.periodicPlis !== undefined) {
+            theWrtc.mediaStream.setSlideShowMode(false);
+            theWrtc.mediaStream.slideShowMode = false;
+            if (publisher.wrtc.mediaStream.periodicPlis !== undefined) {
                 for (var i in publisher.subscribers) {
-                    if (publisher.getSubscriber(i).slideShowMode === true) {
+                    if (publisher.getSubscriber(i).mediaStream.slideShowMode === true) {
                         return;
                     }
                 }
                 log.debug('message: clearing PLI interval for publisher slideShow, ' +
                           'id: ' + publisher.wrtc.wrtcId);
-                clearInterval(publisher.wrtc.periodicPlis);
-                publisher.wrtc.periodicPlis = undefined;
+                clearInterval(publisher.wrtc.mediaStream.periodicPlis);
+                publisher.wrtc.mediaStream.periodicPlis = undefined;
             }
         }
 
@@ -561,7 +562,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
 
     const getWrtcStats = (label, stats, wrtc) => {
       const promise = new Promise((resolve) => {
-        wrtc.getStats((statsString) => {
+        wrtc.mediaStream.getStats((statsString) => {
           const unfilteredStats = JSON.parse(statsString);
           unfilteredStats.metadata = wrtc.metadata;
           stats[label] = unfilteredStats;

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -75,7 +75,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
 
         if (global.config.erizoController.report.rtcp_stats) {  // jshint ignore:line
             log.debug('message: RTCP Stat collection is active');
-            wrtc.getPeriodicStats(function (newStats) {
+            wrtc.mediaStream.getPeriodicStats(function (newStats) {
                 var timeStamp = new Date();
                 amqper.broadcast('stats', {pub: idPub,
                                            subs: idSub,
@@ -276,7 +276,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
                             that.setSlideShow(msg.config.slideShowMode, peerId, streamId);
                         }
                         if (msg.config.muteStream !== undefined) {
-                            that.muteStream (msg.config.muteStream, peerId, streamId);
+                            that.muteStream(msg.config.muteStream, peerId, streamId);
                         }
                         if (msg.config.qualityLayer !== undefined) {
                             that.setQualityLayer (msg.config.qualityLayer, peerId, streamId);
@@ -400,7 +400,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
             log.info('message: Removing publisher, id: ' + from);
             if (publisher.wrtc.mediaStream.periodicPlis !== undefined) {
                 log.debug('message: clearing periodic PLIs for publisher, id: ' + from);
-                clearInterval (publisher.wrc.mediaStream.periodicPlis);
+                clearInterval (publisher.wrtc.mediaStream.periodicPlis);
             }
             for (var key in publisher.subscribers) {
                 var subscriber = publisher.getSubscriber(key);
@@ -445,7 +445,8 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
             publisher.removeSubscriber(from);
         }
 
-        if (publisher && publisher.wrtc.mediaStream.periodicPlis !== undefined) {
+        if (publisher && publisher.wrtc && publisher.wrtc.mediaStream &&
+           publisher.wrtc.mediaStream.periodicPlis !== undefined) {
             for (var i in publisher.subscribers) {
                 if (publisher.getSubscriber(i).mediaStream.slideShowMode === true) {
                     return;

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -155,6 +155,10 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
           clearInterval(wrtc.monitorInterval);
         }
         wrtc.close();
+        if (wrtc.mediaStream !== undefined) {
+          wrtc.mediaStream.close();
+          delete wrtc.mediaStream;
+        }
         log.info('message: WebRtcConnection status update, ' +
             'id: ' + wrtc.wrtcId + ', status: ' + CONN_FINISHED + ', ' +
                 logger.objectToLog(associatedMetadata));

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -72,7 +72,7 @@ class Source {
     wrtc.addMediaStream(wrtc.mediaStream);
     this.subscribers[id] = wrtc;
     this.muxer.addSubscriber(wrtc.mediaStream, id);
-    wrtc.minVideoBW = this.minVideoBW;
+    wrtc.mediaStream.minVideoBW = this.minVideoBW;
     log.debug('message: Setting scheme from publisher to subscriber, ' +
               'id: ' + wrtcId + ', scheme: ' + this.scheme+
                ', ' + logger.objectToLog(options.metadata));
@@ -140,7 +140,7 @@ class Source {
     var subscriber = this.getSubscriber(id);
     log.info('message: setQualityLayer, spatialLayer: ', spatialLayer,
                                      ', temporalLayer: ', temporalLayer);
-    subscriber.setQualityLayer(spatialLayer, temporalLayer);
+    subscriber.mediaStream.setQualityLayer(spatialLayer, temporalLayer);
   }
 
   muteSubscriberStream(id, muteVideo, muteAudio) {
@@ -149,7 +149,7 @@ class Source {
     subscriber.muteAudio = muteAudio;
     log.info('message: Mute Stream, video: ', this.muteVideo || muteVideo,
                                  ', audio: ', this.muteAudio || muteAudio);
-    subscriber.muteStream(this.muteVideo || muteVideo,
+    subscriber.mediaStream.muteStream(this.muteVideo || muteVideo,
                           this.muteAudio || muteAudio);
   }
 
@@ -158,7 +158,7 @@ class Source {
     var maxWidth = (width && width.max !== undefined) ? width.max : -1;
     var maxHeight = (height && height.max !== undefined) ? height.max : -1;
     var maxFrameRate = (frameRate && frameRate.max !== undefined) ? frameRate.max : -1;
-    subscriber.setVideoConstraints(maxWidth, maxHeight, maxFrameRate);
+    subscriber.mediaStream.setVideoConstraints(maxWidth, maxHeight, maxFrameRate);
   }
 
   enableHandlers(id, handlers) {
@@ -168,7 +168,7 @@ class Source {
     }
     if (wrtc) {
       for (var index in handlers) {
-        wrtc.enableHandler(handlers[index]);
+        wrtc.mediaStream.enableHandler(handlers[index]);
       }
     }
   }
@@ -180,7 +180,7 @@ class Source {
     }
     if (wrtc) {
       for (var index in handlers) {
-        wrtc.disableHandler(handlers[index]);
+        wrtc.mediaStream.disableHandler(handlers[index]);
       }
     }
   }
@@ -204,7 +204,7 @@ class Publisher extends Source {
     this.muxer.setPublisher(this.wrtc.mediaStream);
     const muteVideo = (options.muteStream && options.muteStream.video) || false;
     const muteAudio = (options.muteStream && options.muteStream.audio) || false;
-    this.muteStream(muteVideo, muteAudio);
+    this.wrtc.mediaStream.muteStream(muteVideo, muteAudio);
   }
 
   resetWrtc() {

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -204,7 +204,7 @@ class Publisher extends Source {
     this.muxer.setPublisher(this.wrtc.mediaStream);
     const muteVideo = (options.muteStream && options.muteStream.video) || false;
     const muteAudio = (options.muteStream && options.muteStream.audio) || false;
-    this.wrtc.mediaStream.muteStream(muteVideo, muteAudio);
+    this.muteStream(muteVideo, muteAudio);
   }
 
   resetWrtc() {

--- a/erizo_controller/test/erizoJS/erizoJSController.js
+++ b/erizo_controller/test/erizoJS/erizoJSController.js
@@ -161,10 +161,10 @@ describe('Erizo JS Controller', function() {
       expect(erizoApiMock.WebRtcConnection.args[0][2]).to.equal(kArbitraryId);
       expect(erizoApiMock.WebRtcConnection.callCount).to.equal(1);
       expect(mocks.WebRtcConnection.wrtcId).to.equal(kArbitraryId);
-      expect(mocks.WebRtcConnection.setAudioReceiver.args[0][0]).to.equal(mocks.OneToManyProcessor);
-      expect(mocks.WebRtcConnection.setVideoReceiver.args[0][0]).to.equal(mocks.OneToManyProcessor);
+      expect(mocks.MediaStream.setAudioReceiver.args[0][0]).to.equal(mocks.OneToManyProcessor);
+      expect(mocks.MediaStream.setVideoReceiver.args[0][0]).to.equal(mocks.OneToManyProcessor);
       expect(mocks.OneToManyProcessor.setPublisher.args[0][0]).to.
-                                                      equal(mocks.WebRtcConnection);
+                                                      equal(mocks.MediaStream);
       expect(callback.callCount).to.equal(1);
       expect(callback.args[0]).to.deep.equal(['callback', {type: 'initializing'}]);
     });
@@ -178,10 +178,10 @@ describe('Erizo JS Controller', function() {
       expect(erizoApiMock.WebRtcConnection.args[0][2]).to.equal(kArbitraryId);
       expect(erizoApiMock.WebRtcConnection.callCount).to.equal(2);
       expect(mocks.WebRtcConnection.wrtcId).to.equal(kArbitraryId);
-      expect(mocks.WebRtcConnection.setAudioReceiver.args[1][0]).to.equal(mocks.OneToManyProcessor);
-      expect(mocks.WebRtcConnection.setVideoReceiver.args[1][0]).to.equal(mocks.OneToManyProcessor);
+      expect(mocks.MediaStream.setAudioReceiver.args[1][0]).to.equal(mocks.OneToManyProcessor);
+      expect(mocks.MediaStream.setVideoReceiver.args[1][0]).to.equal(mocks.OneToManyProcessor);
       expect(mocks.OneToManyProcessor.setPublisher.args[1][0]).to.
-                                                      equal(mocks.WebRtcConnection);
+                                                      equal(mocks.MediaStream);
       expect(callback.callCount).to.equal(2);
       expect(callback.args[1]).to.deep.equal(['callback', {type: 'initializing'}]);
     });
@@ -338,7 +338,7 @@ describe('Erizo JS Controller', function() {
         expect(subCallback.callCount).to.equal(2);
         expect(subCallback.args[1]).to.deep.equal(['callback', {type: 'initializing'}]);
         expect(subCallback.args[0]).to.deep.equal(['callback', {type: 'ready'}]);
-        expect(mocks.WebRtcConnection.setSlideShowMode.callCount).to.equal(1);
+        expect(mocks.MediaStream.setSlideShowMode.callCount).to.equal(1);
       });
 
       describe('Process Signaling Message', function() {
@@ -389,9 +389,9 @@ describe('Erizo JS Controller', function() {
                         }
                       }});
 
-          expect(mocks.WebRtcConnection.muteStream.callCount).to.equal(3);
-          expect(mocks.WebRtcConnection.muteStream.args[1]).to.deep.equal([false, true]);
-          expect(mocks.WebRtcConnection.muteStream.args[2]).to.deep.equal([false, false]);
+          expect(mocks.MediaStream.muteStream.callCount).to.equal(3);
+          expect(mocks.MediaStream.muteStream.args[1]).to.deep.equal([false, true]);
+          expect(mocks.MediaStream.muteStream.args[2]).to.deep.equal([false, false]);
         });
 
         it('should mute and unmute publisher stream', function() {
@@ -413,9 +413,9 @@ describe('Erizo JS Controller', function() {
                         }
                       }});
 
-          expect(mocks.WebRtcConnection.muteStream.callCount).to.equal(3);
-          expect(mocks.WebRtcConnection.muteStream.args[1]).to.deep.equal([false, true]);
-          expect(mocks.WebRtcConnection.muteStream.args[2]).to.deep.equal([false, false]);
+          expect(mocks.MediaStream.muteStream.callCount).to.equal(3);
+          expect(mocks.MediaStream.muteStream.args[1]).to.deep.equal([false, true]);
+          expect(mocks.MediaStream.muteStream.args[2]).to.deep.equal([false, false]);
         });
 
         it('should set slide show mode to true', function() {
@@ -425,8 +425,8 @@ describe('Erizo JS Controller', function() {
                         slideShowMode: true
                       }});
 
-          expect(mocks.WebRtcConnection.setSlideShowMode.callCount).to.equal(1);
-          expect(mocks.WebRtcConnection.setSlideShowMode.args[0][0]).to.be.true;  // jshint ignore:line
+          expect(mocks.MediaStream.setSlideShowMode.callCount).to.equal(1);
+          expect(mocks.MediaStream.setSlideShowMode.args[0][0]).to.be.true;  // jshint ignore:line
         });
 
         it('should set slide show mode to false', function() {
@@ -436,7 +436,7 @@ describe('Erizo JS Controller', function() {
                         slideShowMode: false
                       }});
 
-          expect(mocks.WebRtcConnection.setSlideShowMode.args[0][0]).to.be.false;  // jshint ignore:line
+          expect(mocks.MediaStream.setSlideShowMode.args[0][0]).to.be.false;  // jshint ignore:line
         });
       });
 

--- a/erizo_controller/test/utils.js
+++ b/erizo_controller/test/utils.js
@@ -138,21 +138,26 @@ var reset = module.exports.reset = function() {
 
   module.exports.WebRtcConnection = {
     wrtcId: '',
-    minVideoBW: '',
-    scheme:'',
-    periodicPlis:'',
     init: sinon.stub(),
-    setAudioReceiver: sinon.stub(),
-    setVideoReceiver: sinon.stub(),
     close: sinon.stub(),
-    getStats: sinon.stub(),
-    getPeriodicStats: sinon.stub(),
-    generatePLIPacket: sinon.stub(),
     createOffer: sinon.stub(),
     setRemoteSdp: sinon.stub(),
     addRemoteCandidate: sinon.stub(),
+    addMediaStream: sinon.stub(),
+  };
+
+  module.exports.MediaStream = {
+    minVideoBW: '',
+    scheme: '',
+    periodicPlis: '',
+    close: sinon.stub(),
+    setAudioReceiver: sinon.stub(),
+    setVideoReceiver: sinon.stub(),
+    getStats: sinon.stub(),
+    getPeriodicStats: sinon.stub(),
+    generatePLIPacket: sinon.stub(),
     setSlideShowMode: sinon.stub(),
-    muteStream: sinon.stub()
+    muteStream: sinon.stub(),
   };
 
   module.exports.ExternalInput = {
@@ -171,6 +176,7 @@ var reset = module.exports.reset = function() {
   module.exports.erizoAPI = createMock('../../erizoAPI/build/Release/addon', {
     OneToManyProcessor: sinon.stub().returns(module.exports.OneToManyProcessor),
     WebRtcConnection: sinon.stub().returns(module.exports.WebRtcConnection),
+    MediaStream: sinon.stub().returns(module.exports.MediaStream),
     ExternalInput: sinon.stub().returns(module.exports.ExternalInput),
     ExternalOutput: sinon.stub().returns(module.exports.ExternalOutput)
   });


### PR DESCRIPTION
**Description**
This PR separates media from the connection as opposed to having both bundled in a WebRTCConnection.
The new MediaStream hosts the pipeline and the handlers while the Transport management is still done in WebRTCConnection. SDP is also mostly managed via the WebRTCConnection but it is now a shared pointer with MediaStream.

This also updates ErizoJS to properly manage the new objects.
[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.