### PR TITLE
fix unprotected access to task_queue_.begin()->first in Scheduler

### DIFF
--- a/erizo/src/erizo/thread/Scheduler.h
+++ b/erizo/src/erizo/thread/Scheduler.h
@@ -37,6 +37,7 @@ class Scheduler {
 
  private:
   std::multimap<std::chrono::system_clock::time_point, Function> task_queue_;
+  std::chrono::system_clock::time_point current_timeout_;
   std::condition_variable new_task_scheduled_;
   mutable std::mutex new_task_mutex_;
   std::atomic<int> n_threads_servicing_queue_;


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR fixes a concurrency issue in the Scheduler component. Passing a reference to task_queue_.begin()->first to wait_until is problematic because the timeout's reads aren't synchronized with writes happening in Scheduler::schedule. 

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.