### PR TITLE
Update the media port in the SDP parser

### DIFF
--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -750,7 +750,9 @@ namespace erizo {
         if (mtype == VIDEO_TYPE) {
           uint32_t parsed_ssrc = strtoul(parts[1].c_str(), nullptr, 10);
           ELOG_DEBUG("message: maybeAdd video in isSsrc, ssrc: %u", parsed_ssrc);
-          maybeAddSsrcToList(parsed_ssrc);
+          if (video_ssrc_list.size() == 0) {
+            maybeAddSsrcToList(parsed_ssrc);
+          }
         } else if ((mtype == AUDIO_TYPE) && (audio_ssrc == 0)) {
           audio_ssrc = strtoul(parts[1].c_str(), nullptr, 10);
           ELOG_DEBUG("audio ssrc: %u", audio_ssrc);

--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -750,9 +750,7 @@ namespace erizo {
         if (mtype == VIDEO_TYPE) {
           uint32_t parsed_ssrc = strtoul(parts[1].c_str(), nullptr, 10);
           ELOG_DEBUG("message: maybeAdd video in isSsrc, ssrc: %u", parsed_ssrc);
-          if (video_ssrc_list.size() == 0) {
-            maybeAddSsrcToList(parsed_ssrc);
-          }
+          maybeAddSsrcToList(parsed_ssrc);
         } else if ((mtype == AUDIO_TYPE) && (audio_ssrc == 0)) {
           audio_ssrc = strtoul(parts[1].c_str(), nullptr, 10);
           ELOG_DEBUG("audio ssrc: %u", audio_ssrc);
@@ -769,12 +767,19 @@ namespace erizo {
         }
         if (parts[1] == kSimulcastGroup) {
           ELOG_DEBUG("Detected SIM group, size: %lu", parts.size());
+          std::vector<uint32_t> old_video_ssrc_list;
+          if (video_ssrc_list.size() > 0) {
+            old_video_ssrc_list = video_ssrc_list;
+            video_ssrc_list.clear();
+          }
           std::for_each(parts.begin() + 2, parts.end(), [this] (std::string &part){
-              uint32_t parsed_ssrc = strtoul(part.c_str(), nullptr, 10);
-              ELOG_DEBUG("maybeAddSsrc video SIM, ssrc %u", parsed_ssrc);
-              maybeAddSsrcToList(parsed_ssrc);
-              });
-
+            uint32_t parsed_ssrc = strtoul(part.c_str(), nullptr, 10);
+            ELOG_DEBUG("maybeAddSsrc video SIM, ssrc %u", parsed_ssrc);
+            maybeAddSsrcToList(parsed_ssrc);
+          });
+          for (uint32_t ssrc : old_video_ssrc_list) {
+            maybeAddSsrcToList(ssrc);
+          }
         } else if (parts[1] == kFidGroup) {
           int number_of_ssrcs = parts.size() - 2;
           if (number_of_ssrcs != 2) {

--- a/erizo_controller/common/semanticSdp/MediaInfo.js
+++ b/erizo_controller/common/semanticSdp/MediaInfo.js
@@ -3,9 +3,10 @@ const Direction = require('./Direction');
 const DirectionWay = require('./DirectionWay');
 
 class MediaInfo {
-  constructor(id, type) {
+  constructor(id, port, type) {
     this.id = id;
     this.type = type;
+    this.port = port;
     this.direction = Direction.SENDRECV;
     this.extensions = new Map();
     this.codecs = new Map();
@@ -19,7 +20,7 @@ class MediaInfo {
   }
 
   clone() {
-    const cloned = new MediaInfo(this.id, this.type);
+    const cloned = new MediaInfo(this.id, this.port, this.type);
     cloned.setDirection(this.direction);
     cloned.setBitrate(this.bitrate);
     cloned.setConnection(this.connection);
@@ -53,6 +54,7 @@ class MediaInfo {
   plain() {
     const plain = {
       id: this.id,
+      port: this.port,
       type: this.type,
       connection: this.connection,
       direction: Direction.toString(this.direction),
@@ -87,6 +89,10 @@ class MediaInfo {
 
   getType() {
     return this.type;
+  }
+
+  getPort() {
+    return this.port;
   }
 
   getId() {
@@ -202,7 +208,7 @@ class MediaInfo {
   }
 
   answer(supported) {
-    const answer = new MediaInfo(this.id, this.type);
+    const answer = new MediaInfo(this.id, this.port, this.type);
 
     answer.setDirection(Direction.reverse(this.direction));
 

--- a/erizo_controller/common/semanticSdp/SDPInfo.js
+++ b/erizo_controller/common/semanticSdp/SDPInfo.js
@@ -235,7 +235,7 @@ class SDPInfo {
     this.medias.forEach((media) => {
       const md = {
         type: media.getType(),
-        port: 9,
+        port: media.getPort(),
         protocol: 'UDP/TLS/RTP/SAVPF',
         fmtp: [],
         rtp: [],
@@ -751,7 +751,8 @@ SDPInfo.process = (sdp) => {
   sdp.media.forEach((md) => {
     const media = md.type;
     const mid = md.mid;
-    const mediaInfo = new MediaInfo(mid, media);
+    const port = md.port;
+    const mediaInfo = new MediaInfo(mid, port, media);
     mediaInfo.setXGoogleFlag(md.xGoogleFlag);
     mediaInfo.rtcp = md.rtcp;
     mediaInfo.setConnection(md.connection);


### PR DESCRIPTION
**Description**

There is something wrong in the current SDP parser that is affecting Simulcast and some feedback mechanisms. I've compared the SDPs generated by the previous solution and the current one and this is the only thing that is different, and that could be causing those issues. Not sure 100% if there is any other cause.

There was another issue caused by sending a=ssrc and a=ssrc-group in a different order compared with the previous SDPs. SdpInfo.cpp is not perfect and expected to receive a=ssrc-group first, which is not happening now. I added a temporal fix given that we'll eventually get rid of SdpInfo.cpp with the new parser.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.