### PR TITLE
Improved nack generator

### DIFF
--- a/erizo/src/erizo/rtp/RtcpFeedbackGenerationHandler.h
+++ b/erizo/src/erizo/rtp/RtcpFeedbackGenerationHandler.h
@@ -8,7 +8,7 @@
 #include "./logger.h"
 #include "pipeline/Handler.h"
 #include "rtp/RtcpRrGenerator.h"
-#include "rtp/RtcpNackGenerator.h"
+#include "rtp/RtcpNewNackGenerator.h"
 #include "lib/ClockUtils.h"
 
 #define MAX_DELAY 450000
@@ -20,7 +20,7 @@ class MediaStream;
 class RtcpGeneratorPair {
  public:
   std::shared_ptr<RtcpRrGenerator> rr_generator;
-  std::shared_ptr<RtcpNackGenerator> nack_generator;
+  std::shared_ptr<RtcpNewNackGenerator> nack_generator;
 };
 
 
@@ -29,7 +29,7 @@ class RtcpFeedbackGenerationHandler: public Handler {
 
 
  public:
-  explicit RtcpFeedbackGenerationHandler(bool nacks_enabled = true,
+  explicit RtcpFeedbackGenerationHandler(bool nacks_enabled = true, bool pli_enabled = true,
       std::shared_ptr<Clock> the_clock = std::make_shared<SteadyClock>());
 
 
@@ -50,7 +50,11 @@ class RtcpFeedbackGenerationHandler: public Handler {
 
   bool enabled_, initialized_;
   bool nacks_enabled_;
+  bool pli_enabled_;
   std::shared_ptr<Clock> clock_;
+
+  uint32_t video_sink_ssrc_ = 0;
+  uint32_t audio_sink_ssrc_ = 0;
 };
 }  // namespace erizo
 

--- a/erizo/src/erizo/rtp/RtcpNewNackGenerator.cpp
+++ b/erizo/src/erizo/rtp/RtcpNewNackGenerator.cpp
@@ -1,0 +1,189 @@
+#include "rtp/RtcpNewNackGenerator.h"
+
+#include <algorithm>
+#include "rtp/RtpUtils.h"
+
+namespace erizo {
+namespace {
+constexpr int max_nack_blocks = 10;
+constexpr int kNackCommonHeaderLengthRtcp = kNackCommonHeaderLengthBytes / 4 - 1;
+constexpr int nack_interval = 50;
+
+/**
+ * Drops from the set all packets older than the given sequence_number
+ */
+void drop_packets_from_set(Seq_number_set& set, uint16_t sequence_number) {  // NOLINT
+  set.erase(set.begin(), set.upper_bound(sequence_number));
+}
+
+void attach_nack_to_rr(uint32_t ssrc,
+    std::shared_ptr<DataPacket>& rr_packet,  // NOLINT
+    const std::vector<NackBlock>& nack_blocks);
+
+std::vector<NackBlock> build_nack_blocks(const Seq_number_set& set);
+}  // namespace
+
+DEFINE_LOGGER(RtcpNewNackGenerator, "rtp.RtcpNewNackGenerator");
+
+std::pair<bool, bool> RtcpNewNackGenerator::handleRtpPacket(const std::shared_ptr<DataPacket>& packet) {
+  if (packet->type != VIDEO_PACKET) {
+    return {false, false};
+  }
+  RtpHeader *head = reinterpret_cast<RtpHeader*>(packet->data);
+  if (head->getSSRC() != ssrc_) {
+    ELOG_DEBUG("message: handleRtpPacket Unknown SSRC, ssrc: %u", head->getSSRC());
+    return {false, false};
+  }
+  const uint16_t seq_num = head->getSeqNumber();
+  // Save when we got a key frame
+  if (packet->is_keyframe) {
+    keyframe_sequence_numbers_.insert(keyframe_sequence_numbers_.cend(), seq_num);
+  }
+  if (!latest_received_sequence_number_) {
+    latest_received_sequence_number_ = seq_num;
+    return {false, false};
+  }
+  // Purge old keyframes
+  const auto newest_received_sequence_number = latest_sequence_number(*latest_received_sequence_number_, seq_num);
+  drop_packets_from_set(keyframe_sequence_numbers_,
+      newest_received_sequence_number - constants::max_packet_age_to_nack);
+  const auto should_ask_pli = !update_nack_list(seq_num);
+  latest_received_sequence_number_ = newest_received_sequence_number;
+  return {!missing_sequence_numbers_.empty() && is_time_to_send(clock_->now()), should_ask_pli};
+}
+
+bool RtcpNewNackGenerator::missing_too_old_packet(const uint16_t latest_sequence_number) {
+  if (missing_sequence_numbers_.empty()) {
+    return false;
+  }
+  const uint16_t age_of_oldest_missing_packet = latest_sequence_number - *missing_sequence_numbers_.cbegin();
+  return age_of_oldest_missing_packet > constants::max_packet_age_to_nack;
+}
+
+bool RtcpNewNackGenerator::handle_too_large_nack_list() {
+  ELOG_DEBUG("NACK list has grown too large");
+  bool key_frame_found = false;
+  while (too_large_nack_list()) {
+    key_frame_found = recycle_frames_until_key_frame();
+  }
+  return key_frame_found;
+}
+
+bool RtcpNewNackGenerator::handle_too_old_packets(const uint16_t latest_sequence_number) {
+  ELOG_DEBUG("NACK list contains too old sequence numbers");
+  bool key_frame_found = false;
+  while (missing_too_old_packet(latest_sequence_number)) {
+    key_frame_found = recycle_frames_until_key_frame();
+  }
+  return key_frame_found;
+}
+
+bool RtcpNewNackGenerator::recycle_frames_until_key_frame() {
+  // should use a frame buffer strategy, for now approximate by seeking the starting packet of the next key frame
+  std::pair<bool, int16_t> key_frame = extract_oldest_keyframe();
+  if (key_frame.first) {
+    drop_packets_from_set(missing_sequence_numbers_, key_frame.second);
+    ELOG_DEBUG("recycling frames... found keyframe at seq: %u", key_frame.second);
+  } else {
+    ELOG_DEBUG("recycling frames... dropping all");
+    missing_sequence_numbers_.clear();
+  }
+  return key_frame.first;
+}
+
+bool RtcpNewNackGenerator::update_nack_list(const uint16_t seq) {
+  if (is_newer_sequence_number(seq, *latest_received_sequence_number_)) {
+    for (uint16_t i = *latest_received_sequence_number_ + 1; is_newer_sequence_number(seq, i); ++i) {
+      missing_sequence_numbers_.insert(missing_sequence_numbers_.cend(), i);
+      ELOG_DEBUG("added sequence number to NACK list: %u", i);
+    }
+    if (too_large_nack_list() && !handle_too_large_nack_list()) {
+      return false;
+    }
+    if (missing_too_old_packet(seq) && !handle_too_old_packets(seq)) {
+      return false;
+    }
+  } else {
+    missing_sequence_numbers_.erase(seq);
+    ELOG_DEBUG("recovered packet: %u", seq);
+  }
+  return true;
+}
+
+std::pair<bool, uint16_t> RtcpNewNackGenerator::extract_oldest_keyframe() {
+  if (keyframe_sequence_numbers_.empty()) {
+    return {false, 0};
+  }
+  auto seq = *keyframe_sequence_numbers_.cbegin();
+  keyframe_sequence_numbers_.erase(keyframe_sequence_numbers_.cbegin());
+  return {true, seq};
+}
+
+bool RtcpNewNackGenerator::addNackPacketToRr(std::shared_ptr<DataPacket>& rr_packet) {
+  const auto now = clock_->now();
+  if (!is_time_to_send(now)) {
+    return false;
+  }
+  rtcp_send_time_ = now;
+  const auto nack_blocks = build_nack_blocks(missing_sequence_numbers_);
+  attach_nack_to_rr(ssrc_, rr_packet, nack_blocks);
+  return true;
+}
+
+std::chrono::milliseconds RtcpNewNackGenerator::rtcp_min_interval() const {
+  return std::chrono::milliseconds(nack_interval);
+}
+
+bool RtcpNewNackGenerator::is_time_to_send(clock::time_point tp) const {
+  return (rtcp_send_time_ + rtcp_min_interval() <= tp);
+}
+
+namespace {
+std::vector<NackBlock> build_nack_blocks(const Seq_number_set& set) {
+  std::vector<NackBlock> nack_blocks;
+  for (auto it = set.cbegin(); it != set.cend(); ++it) {
+    if (nack_blocks.size() >= max_nack_blocks) {
+      break;
+    }
+    const uint16_t pid = *it;
+    ELOG_TRACE2(RtcpNewNackGenerator::logger, "added NACK PID, seq_num %u", pid);
+    uint16_t blp = 0;
+    for (++it; it != set.cend(); ++it) {
+      uint16_t distance = *it - pid;
+      if (distance > 16) {
+        break;
+      }
+      ELOG_TRACE2(RtcpNewNackGenerator::logger, "added Nack to BLP, seq_num: %u", *it);
+      blp |= (1 << (distance - 1));
+    }
+    --it;
+    NackBlock block;
+    block.setNackPid(pid);
+    block.setNackBlp(blp);
+    nack_blocks.push_back(block);
+  }
+  return nack_blocks;
+}
+
+void attach_nack_to_rr(const uint32_t ssrc,
+    std::shared_ptr<DataPacket>& rr_packet,  // NOLINT
+    const std::vector<NackBlock>& nack_blocks) {
+  char* buffer = rr_packet->data;
+  buffer += rr_packet->length;
+
+  RtcpHeader nack_packet;
+  nack_packet.setPacketType(RTCP_RTP_Feedback_PT);
+  nack_packet.setBlockCount(1);
+  nack_packet.setSSRC(ssrc);
+  nack_packet.setSourceSSRC(ssrc);
+  nack_packet.setLength(kNackCommonHeaderLengthRtcp + nack_blocks.size());
+  memcpy(buffer, reinterpret_cast<char *>(&nack_packet), kNackCommonHeaderLengthBytes);
+  buffer += kNackCommonHeaderLengthBytes;
+
+  memcpy(buffer, nack_blocks.data(), nack_blocks.size()*4);
+  int nack_length = (nack_packet.getLength()+1)*4;
+
+  rr_packet->length += nack_length;
+}
+}  // namespace
+}  // namespace erizo

--- a/erizo/src/erizo/rtp/RtcpNewNackGenerator.h
+++ b/erizo/src/erizo/rtp/RtcpNewNackGenerator.h
@@ -1,0 +1,93 @@
+#ifndef ERIZO_SRC_ERIZO_RTP_RTCPNEWNACKGENERATOR_H_
+#define ERIZO_SRC_ERIZO_RTP_RTCPNEWNACKGENERATOR_H_
+
+#include "./logger.h"
+#include "MediaDefinitions.h"
+#include <boost/optional.hpp>
+#include <set>
+#include <memory>
+#include <utility>
+#include <chrono>  // NOLINT
+
+namespace erizo {
+namespace constants {
+  constexpr int max_nack_list_size = 200;  // chrome default 250
+  constexpr int max_packet_age_to_nack = 300;  // chrome default 450
+}
+
+inline bool is_newer_sequence_number(uint16_t sequence_number, uint16_t prev_sequence_number) {
+  return sequence_number != prev_sequence_number &&
+    static_cast<uint16_t>(sequence_number - prev_sequence_number) < 0x8000;
+}
+
+inline uint16_t latest_sequence_number(uint16_t sequence_number1, uint16_t sequence_number2) {
+  return is_newer_sequence_number(sequence_number1, sequence_number2)
+      ? sequence_number1
+      : sequence_number2;
+}
+
+/// Comparator for seq_number_set
+struct Seq_number_less_than {
+  bool operator()(uint16_t lhs, uint16_t rhs) const { return is_newer_sequence_number(rhs, lhs); }
+};
+
+/// Set storing sequence numbers in ascending order (iff close numbers get inserted)
+using Seq_number_set = std::set<uint16_t, Seq_number_less_than>;
+
+class RtcpNewNackGenerator {
+ public:
+  DECLARE_LOGGER();
+
+  explicit RtcpNewNackGenerator(uint32_t ssrc, const std::shared_ptr<Clock>& clock = std::make_shared<SteadyClock>())
+  : ssrc_(ssrc), clock_(clock) {}
+
+  /**
+   * Handles an incoming rtp packet. Compatible with RtcpFeedbackGenerationHandler.
+   *
+   * @return A pair where first indicates if there's a NACK request and second if there's a PLI request
+   */
+  std::pair<bool, bool> handleRtpPacket(const std::shared_ptr<DataPacket>& packet);
+
+  /**
+   * Builds a nack and attaches it to an rtcp rr. Compatible with RtcpFeedbackGenerationHandler.
+   */
+  bool addNackPacketToRr(std::shared_ptr<DataPacket>& rr_packet);  // NOLINT
+
+ private:
+  inline bool too_large_nack_list() const;
+
+  bool missing_too_old_packet(const uint16_t latest_sequence_number);
+
+  bool handle_too_large_nack_list();
+
+  bool handle_too_old_packets(const uint16_t latest_sequence_number);
+
+  bool recycle_frames_until_key_frame();
+
+  bool update_nack_list(const uint16_t seq);
+
+  bool is_time_to_send(clock::time_point) const;
+
+  std::chrono::milliseconds rtcp_min_interval() const;
+
+  /**
+   * Find and remove the oldest key frame from the set
+   * @returns {true, sequence_number} if one key frame has been found, otherwise {false, undefined}
+   */
+  std::pair<bool, uint16_t> extract_oldest_keyframe();
+
+  uint32_t ssrc_;
+  boost::optional<uint16_t> latest_received_sequence_number_;
+  Seq_number_set missing_sequence_numbers_;
+  Seq_number_set keyframe_sequence_numbers_;
+
+  std::shared_ptr<Clock> clock_;
+  clock::time_point rtcp_send_time_;
+};
+
+bool RtcpNewNackGenerator::too_large_nack_list() const {
+  return missing_sequence_numbers_.size() > constants::max_nack_list_size;
+}
+}  // namespace erizo
+
+#endif  // ERIZO_SRC_ERIZO_RTP_RTCPNEWNACKGENERATOR_H_

--- a/erizo/src/test/rtp/RtcpFeedbackGenerationHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtcpFeedbackGenerationHandlerTest.cpp
@@ -40,7 +40,7 @@ class RtcpFeedbackRrGenerationTest : public erizo::HandlerTest {
 
  protected:
   void setHandler() {
-    rr_handler = std::make_shared<RtcpFeedbackGenerationHandler>(false, clock);
+    rr_handler = std::make_shared<RtcpFeedbackGenerationHandler>(false, false, clock);
     pipeline->addBack(rr_handler);
   }
 

--- a/erizo/src/test/rtp/RtcpNewNackGeneratorTest.cpp
+++ b/erizo/src/test/rtp/RtcpNewNackGeneratorTest.cpp
@@ -1,0 +1,229 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <rtp/RtcpNewNackGenerator.h>
+#include <rtp/RtpUtils.h>
+#include <lib/Clock.h>
+#include <rtp/RtpHeaders.h>
+#include <MediaDefinitions.h>
+#include <WebRtcConnection.h>
+
+#include <string>
+#include <vector>
+
+#include <boost/mpl/for_each.hpp>
+#include <boost/mpl/range_c.hpp>
+
+#include "../utils/Mocks.h"
+#include "../utils/Tools.h"
+#include "../utils/Matchers.h"
+
+using ::testing::_;
+using ::testing::IsNull;
+using ::testing::Args;
+using ::testing::Return;
+using ::testing::AllOf;
+using erizo::DataPacket;
+using erizo::packetType;
+using erizo::AUDIO_PACKET;
+using erizo::VIDEO_PACKET;
+using erizo::RtcpNewNackGenerator;
+using erizo::RtcpHeader;
+using erizo::WebRtcConnection;
+using erizo::SimulatedClock;
+
+class RtcpNewNackGeneratorTest :public ::testing::Test {
+ public:
+  RtcpNewNackGeneratorTest(): clock{std::make_shared<SimulatedClock>()},
+      nack_generator{erizo::kVideoSsrc, clock} {}
+
+ protected:
+  void advanceClockMs(int time_ms) {
+    clock->advanceTime(std::chrono::milliseconds(time_ms));
+  }
+
+  std::shared_ptr<DataPacket> generateRrWithNack() {
+    std::shared_ptr<DataPacket> new_receiver_report = erizo::PacketTools::createReceiverReport(erizo::kVideoSsrc,
+      erizo::kVideoSsrc, 0, VIDEO_PACKET);
+    nack_generator.addNackPacketToRr(new_receiver_report);
+    return new_receiver_report;
+  }
+
+  bool RtcpPacketContainsNackSeqNum(std::shared_ptr<DataPacket> rtcp_packet, uint16_t lost_seq_num) {
+    char* moving_buf = rtcp_packet->data;
+    int rtcp_length = 0;
+    int total_length = 0;
+    bool found_nack = false;
+    do {
+      moving_buf += rtcp_length;
+      RtcpHeader* chead = reinterpret_cast<RtcpHeader*>(moving_buf);
+      rtcp_length = (ntohs(chead->length) + 1) * 4;
+      total_length += rtcp_length;
+
+      if (chead->packettype == RTCP_RTP_Feedback_PT) {
+        erizo::RtpUtils::forEachNack(chead, [chead, lost_seq_num, &found_nack](uint16_t seq_num,
+          uint16_t plb, RtcpHeader* nack_head) {
+        uint16_t initial_seq_num = seq_num;
+        if (initial_seq_num == lost_seq_num) {
+          found_nack = true;
+          return;
+        }
+        uint16_t kNackBlpSize = 16;
+        for (int i = -1; i <= kNackBlpSize; i++) {
+          if ((plb >> i)  & 0x0001) {
+            uint16_t seq_num = initial_seq_num + i + 1;
+            if (seq_num == lost_seq_num) {
+              found_nack = true;
+              return;
+            }
+          }
+        }
+      });
+    }
+  } while (total_length < rtcp_packet->length);
+    return found_nack;
+  }
+
+  std::shared_ptr<SimulatedClock> clock;
+  std::shared_ptr<DataPacket> receiver_report;
+  RtcpNewNackGenerator nack_generator;
+  const uint16_t kMaxSeqnum = 65534;
+};
+
+TEST_F(RtcpNewNackGeneratorTest, shouldNotGenerateNackForConsecutivePackets) {
+  auto first_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
+  auto second_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber + 1,
+    VIDEO_PACKET);
+  nack_generator.handleRtpPacket(first_packet);
+  EXPECT_FALSE(nack_generator.handleRtpPacket(second_packet).first);
+}
+
+TEST_F(RtcpNewNackGeneratorTest, shouldNotGenerateNackForConsecutivePacketsWithRollOver) {
+  auto first_packet = erizo::PacketTools::createDataPacket(kMaxSeqnum, VIDEO_PACKET);
+  auto second_packet = erizo::PacketTools::createDataPacket(kMaxSeqnum + 1,
+    VIDEO_PACKET);
+  nack_generator.handleRtpPacket(first_packet);
+  EXPECT_FALSE(nack_generator.handleRtpPacket(second_packet).first);
+}
+
+TEST_F(RtcpNewNackGeneratorTest, shouldGenerateNackOnLostPacket) {
+  uint16_t kArbitraryNumberOfPackets = 4;
+  auto first_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
+  auto second_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber + kArbitraryNumberOfPackets,
+    VIDEO_PACKET);
+  nack_generator.handleRtpPacket(first_packet);
+  EXPECT_TRUE(nack_generator.handleRtpPacket(second_packet).first);
+}
+
+TEST_F(RtcpNewNackGeneratorTest, shouldGenerateNackOnLostPacketWithRollOver) {
+  uint16_t kArbitraryNumberOfPackets = 4;
+  auto first_packet = erizo::PacketTools::createDataPacket(kMaxSeqnum, VIDEO_PACKET);
+  auto second_packet = erizo::PacketTools::createDataPacket(kMaxSeqnum + kArbitraryNumberOfPackets,
+    VIDEO_PACKET);
+  nack_generator.handleRtpPacket(first_packet);
+  EXPECT_TRUE(nack_generator.handleRtpPacket(second_packet).first);
+}
+
+TEST_F(RtcpNewNackGeneratorTest, nackShouldContainLostPackets) {
+  uint16_t kArbitraryNumberOfPackets = 4;
+  auto first_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
+  auto second_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber + kArbitraryNumberOfPackets,
+    VIDEO_PACKET);
+  nack_generator.handleRtpPacket(first_packet);
+
+  EXPECT_TRUE(nack_generator.handleRtpPacket(second_packet).first);
+
+  receiver_report = generateRrWithNack();
+  EXPECT_TRUE(RtcpPacketContainsNackSeqNum(receiver_report, erizo::kArbitrarySeqNumber + 1));
+}
+
+TEST_F(RtcpNewNackGeneratorTest, nackShouldContainLostPacketsInMoreThanOneBlock) {
+  uint16_t kArbitraryNumberOfPackets = 30;  // Bigger than 16 - one block
+  auto first_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
+  auto second_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber + kArbitraryNumberOfPackets,
+    VIDEO_PACKET);
+  nack_generator.handleRtpPacket(first_packet);
+
+  EXPECT_TRUE(nack_generator.handleRtpPacket(second_packet).first);
+
+  receiver_report = generateRrWithNack();
+
+  for (int i = 13; i < 42; ++i) {
+    EXPECT_TRUE(RtcpPacketContainsNackSeqNum(receiver_report, i)) << "i = " << i;
+  }
+}
+
+TEST_F(RtcpNewNackGeneratorTest, shouldNotRetransmitNacksInmediately) {
+  uint16_t kArbitraryNumberOfPackets = 4;
+  auto first_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
+  auto second_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber + kArbitraryNumberOfPackets,
+    VIDEO_PACKET);
+  nack_generator.handleRtpPacket(first_packet);
+  nack_generator.handleRtpPacket(second_packet);
+
+  receiver_report = generateRrWithNack();
+
+  EXPECT_TRUE(RtcpPacketContainsNackSeqNum(receiver_report, erizo::kArbitrarySeqNumber + 1));
+
+  receiver_report = generateRrWithNack();
+
+  EXPECT_FALSE(RtcpPacketContainsNackSeqNum(receiver_report, erizo::kArbitrarySeqNumber + 1));
+}
+
+TEST_F(RtcpNewNackGeneratorTest, shouldRetransmitNacksAfterTime) {
+  uint16_t kArbitraryNumberOfPackets = 4;
+  auto first_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
+  auto second_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber + kArbitraryNumberOfPackets,
+    VIDEO_PACKET);
+  nack_generator.handleRtpPacket(first_packet);
+  nack_generator.handleRtpPacket(second_packet);
+
+  receiver_report = generateRrWithNack();
+
+  EXPECT_TRUE(RtcpPacketContainsNackSeqNum(receiver_report, erizo::kArbitrarySeqNumber + 1));
+
+  advanceClockMs(50);
+  receiver_report = generateRrWithNack();
+
+  EXPECT_TRUE(RtcpPacketContainsNackSeqNum(receiver_report, erizo::kArbitrarySeqNumber + 1));
+}
+
+TEST_F(RtcpNewNackGeneratorTest, cornerCase) {
+  auto first_packet = erizo::PacketTools::createDataPacket(65518, VIDEO_PACKET);
+  auto second_packet = erizo::PacketTools::createDataPacket(65520,
+    VIDEO_PACKET);
+  nack_generator.handleRtpPacket(first_packet);
+  EXPECT_TRUE(nack_generator.handleRtpPacket(second_packet).first);
+  receiver_report = generateRrWithNack();
+  EXPECT_TRUE(RtcpPacketContainsNackSeqNum(receiver_report, 65519));
+}
+
+TEST_F(RtcpNewNackGeneratorTest, shouldRetransmitNacksMoreThanTwice) {
+  uint16_t kArbitraryNumberOfPackets = 4;
+  auto first_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
+  auto second_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber + kArbitraryNumberOfPackets,
+    VIDEO_PACKET);
+  nack_generator.handleRtpPacket(first_packet);
+  nack_generator.handleRtpPacket(second_packet);
+
+  receiver_report = generateRrWithNack();
+
+  EXPECT_TRUE(RtcpPacketContainsNackSeqNum(receiver_report, erizo::kArbitrarySeqNumber + 1));
+
+  advanceClockMs(50);
+  receiver_report = generateRrWithNack();
+  EXPECT_TRUE(RtcpPacketContainsNackSeqNum(receiver_report, erizo::kArbitrarySeqNumber + 1));
+
+  advanceClockMs(50);
+  receiver_report = generateRrWithNack();
+  EXPECT_TRUE(RtcpPacketContainsNackSeqNum(receiver_report, erizo::kArbitrarySeqNumber + 1));
+}
+
+TEST_F(RtcpNewNackGeneratorTest, shouldAskPLI) {
+  uint16_t kArbitraryNumberOfPackets = 800;
+  auto first_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, VIDEO_PACKET);
+  auto second_packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber + kArbitraryNumberOfPackets,
+    VIDEO_PACKET);
+  nack_generator.handleRtpPacket(first_packet);
+  EXPECT_TRUE(nack_generator.handleRtpPacket(second_packet).second);
+}

--- a/erizo_controller/erizoAgent/log4cxx.properties
+++ b/erizo_controller/erizoAgent/log4cxx.properties
@@ -59,6 +59,7 @@ log4j.logger.rtp.RtcpFeedbackGenerationHandler=WARN
 log4j.logger.rtp.RtpPaddingRemovalHandler=WARN
 log4j.logger.rtp.RtcpRrGenerator=WARN
 log4j.logger.rtp.RtcpNackGenerator=WARN
+log4j.logger.rtp.RtcpNewNackGenerator=WARN
 log4j.logger.rtp.SRPacketHandler=WARN
 log4j.logger.rtp.BandwidthEstimationHandler=WARN
 log4j.logger.rtp.SenderBandwidthEstimationHandler=WARN

--- a/spine/log4cxx.properties
+++ b/spine/log4cxx.properties
@@ -58,6 +58,7 @@ log4j.logger.rtp.RtcpFeedbackGenerationHandler=WARN
 log4j.logger.rtp.RtpPaddingRemovalHandler=WARN
 log4j.logger.rtp.RtcpRrGenerator=WARN
 log4j.logger.rtp.RtcpNackGenerator=WARN
+log4j.logger.rtp.RtcpNewNackGenerator=WARN
 log4j.logger.rtp.SRPacketHandler=WARN
 log4j.logger.rtp.BandwidthEstimationHandler=WARN
 log4j.logger.rtp.SenderBandwidthEstimationHandler=WARN


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

<!--
Add a short description here, please.
If the contribution needs and includes Unit Tests check the box below.
-->
This PR adds a new nack generator using an algorithm very similar to the one implemented Chrome. Tthe only difference is that Chrome leverages the decoder to have a more consistent PLI generation. RtcpFeedbackGenerationHandler has been slightly modified, because there are some changes between the old and the new interface; for example it sends a PLI when it fails to recover a packet.

We have deployed this new generator few months ago and got very good results.

[X] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.