### PR TITLE
fix for unpublish/publish

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -38,16 +38,8 @@ const Room = (altIo, altConnection, specInput) => {
   let localStreams = that.localStreams;
 
   // Private functions
-  const removeStream = (streamInput) => {
+  const closePc = (streamInput) => {
     const stream = streamInput;
-    if (stream.stream) {
-      // Remove HTML element
-      stream.hide();
-
-      stream.stop();
-      stream.close();
-      delete stream.stream;
-    }
 
     // Close PC stream
     if (stream.pc) {
@@ -61,6 +53,20 @@ const Room = (altIo, altConnection, specInput) => {
         delete stream.pc;
       }
     }
+  };
+
+  const removeStream = (streamInput) => {
+    const stream = streamInput;
+    if (stream.stream) {
+      // Remove HTML element
+      stream.hide();
+
+      stream.stop();
+      stream.close();
+      delete stream.stream;
+    }
+
+    closePc(stream);
   };
 
   const onStreamFailed = (streamInput, message) => {
@@ -708,7 +714,7 @@ const Room = (altIo, altConnection, specInput) => {
       });
       stream.room = undefined;
       if (stream.hasMedia() && !stream.isExternal()) {
-        removeStream(stream);
+        closePc(stream);
       }
       localStreams.remove(stream.getID());
 


### PR DESCRIPTION
Thinking about the unpublish logic, I find unuseful to remove stream.stream.
This prevents us to republish a stream and this is a bug I think.

steps to reproduce the bug:
1) open basicexample on one chrome tab
2) open basicexample ?onlySubscribe=true in another tab
3) open console in first tab and execute 

> room.unpublish(localStream)
> room.publish(localStream)

It gives you an error.

This PR aims to resolve this behavior

[] It needs and includes Unit Tests
[] It includes documentation for these changes in `/doc`.