### PR TITLE
Use strings to send the SDP within signalling messages.

### DIFF
--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -97,7 +97,7 @@ const BaseStack = (specInput) => {
 
     specBase.callback({
       type: localDesc.type,
-      sdp: localSdp.toJSON(),
+      sdp: localDesc.sdp,
     });
   };
 
@@ -118,7 +118,7 @@ const BaseStack = (specInput) => {
   const processOffer = (message) => {
     // Its an offer, we assume its p2p
     const msg = message;
-    remoteSdp = SemanticSdp.SDPInfo.process(msg.sdp);
+    remoteSdp = SemanticSdp.SDPInfo.processString(msg.sdp);
     SdpHelpers.setMaxBW(remoteSdp, specBase);
     msg.sdp = remoteSdp.toString();
     that.peerConnection.setRemoteDescription(msg).then(() => {
@@ -134,7 +134,7 @@ const BaseStack = (specInput) => {
     Logger.debug('Remote Description', msg.sdp);
     Logger.debug('Local Description', localDesc.sdp);
 
-    remoteSdp = SemanticSdp.SDPInfo.process(msg.sdp);
+    remoteSdp = SemanticSdp.SDPInfo.processString(msg.sdp);
     SdpHelpers.setMaxBW(remoteSdp, specBase);
     msg.sdp = remoteSdp.toString();
 
@@ -242,19 +242,19 @@ const BaseStack = (specInput) => {
         Logger.debug('Updating with SDP renegotiation', specBase.maxVideoBW, specBase.maxAudioBW);
         that.peerConnection.setLocalDescription(localDesc)
           .then(() => {
-            remoteSdp = SemanticSdp.SDPInfo.process(remoteDesc.sdp);
+            remoteSdp = SemanticSdp.SDPInfo.processString(remoteDesc.sdp);
             SdpHelpers.setMaxBW(remoteSdp, specBase);
             remoteDesc.sdp = remoteSdp.toString();
             return that.peerConnection.setRemoteDescription(new RTCSessionDescription(remoteDesc));
           }).then(() => {
             specBase.remoteDescriptionSet = true;
-            specBase.callback({ type: 'updatestream', sdp: localSdp.toJSON() });
+            specBase.callback({ type: 'updatestream', sdp: localDesc.sdp });
           }).catch(errorCallback.bind(null, 'updateSpec', callback));
       } else {
         Logger.debug('Updating without SDP renegotiation, ' +
                      'newVideoBW:', specBase.maxVideoBW,
                      'newAudioBW:', specBase.maxAudioBW);
-        specBase.callback({ type: 'updatestream', sdp: localSdp.toJSON() });
+        specBase.callback({ type: 'updatestream', sdp: localDesc.sdp });
       }
     }
     if (config.minVideoBW || (config.slideShowMode !== undefined) ||

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -106,7 +106,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
                 case CONN_GATHERED:
                     mess = mess.replace(that.privateRegexp, that.publicIP);
                     const sdp = SemanticSdp.SDPInfo.processString(mess);
-                    mess = sdp.toJSON();
+                    mess = sdp.toString();
                     if (options.createOffer)
                         callback('callback', {type: 'offer', sdp: mess});
                     else
@@ -257,7 +257,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
             if (publisher.hasSubscriber(peerId)) {
                 var subscriber = publisher.getSubscriber(peerId);
                 if (msg.type === 'offer') {
-                    const sdp = SemanticSdp.SDPInfo.process(msg.sdp);
+                    const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
                     msg.sdp = sdp.toString();
                     subscriber.setRemoteSdp(msg.sdp);
                     disableDefaultHandlers(subscriber);
@@ -267,7 +267,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
                                                   msg.candidate.candidate);
                 } else if (msg.type === 'updatestream') {
                     if(msg.sdp) {
-                        const sdp = SemanticSdp.SDPInfo.process(msg.sdp);
+                        const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
                         msg.sdp = sdp.toString();
                         subscriber.setRemoteSdp(msg.sdp);
                       }
@@ -290,7 +290,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
                 }
             } else {
                 if (msg.type === 'offer') {
-                    const sdp = SemanticSdp.SDPInfo.process(msg.sdp);
+                    const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
                     msg.sdp = sdp.toString();
                     publisher.wrtc.setRemoteSdp(msg.sdp);
                     disableDefaultHandlers(publisher.wrtc);
@@ -300,8 +300,8 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
                                                                  msg.candidate.candidate);
                 } else if (msg.type === 'updatestream') {
                     if (msg.sdp) {
-                        const sdp = SemanticSdp.SDPInfo.process(msg.sdp);
-                        msg.sdp = sdp.toJSON();
+                        const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
+                        msg.sdp = sdp.toString();
                         publisher.wrtc.setRemoteSdp(msg.sdp);
                     }
                     if (msg.config) {

--- a/erizo_controller/test/erizoJS/erizoJSController.js
+++ b/erizo_controller/test/erizoJS/erizoJSController.js
@@ -276,7 +276,7 @@ describe('Erizo JS Controller', function() {
       });
 
       it('should set remote sdp when received', function() {
-        controller.processSignaling(kArbitraryId, undefined, {type: 'offer', sdp: {media: []}});
+        controller.processSignaling(kArbitraryId, undefined, {type: 'offer', sdp: ''});
 
         expect(mocks.WebRtcConnection.setRemoteSdp.callCount).to.equal(1);
       });
@@ -292,7 +292,7 @@ describe('Erizo JS Controller', function() {
       it('should update sdp', function() {
         controller.processSignaling(kArbitraryId, undefined, {
                     type: 'updatestream',
-                    sdp: {media: []}});
+                    sdp: 'sdp'});
 
         expect(mocks.WebRtcConnection.setRemoteSdp.callCount).to.equal(1);
       });
@@ -349,7 +349,7 @@ describe('Erizo JS Controller', function() {
 
         it('should set remote sdp when received', function() {
           controller.processSignaling(kArbitraryId, kArbitraryId2, {type: 'offer',
-            sdp: {media: []}});
+            sdp: ''});
 
           expect(mocks.WebRtcConnection.setRemoteSdp.callCount).to.equal(1);
         });
@@ -365,7 +365,7 @@ describe('Erizo JS Controller', function() {
         it('should update sdp', function() {
           controller.processSignaling(kArbitraryId, kArbitraryId2, {
                       type: 'updatestream',
-                      sdp: {media: []}});
+                      sdp: 'aaa'});
 
           expect(mocks.WebRtcConnection.setRemoteSdp.callCount).to.equal(1);
         });


### PR DESCRIPTION
**Description**

For v5 we'll still send SDPs as strings instead of format them in JSON objects. 

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.