### PR TITLE
Fix missing generated nack

### DIFF
--- a/erizo/src/erizo/rtp/RtcpNackGenerator.cpp
+++ b/erizo/src/erizo/rtp/RtcpNackGenerator.cpp
@@ -93,6 +93,7 @@ bool RtcpNackGenerator::addNackPacketToRr(std::shared_ptr<DataPacket> rr_packet)
       uint16_t distance = blp_nack_info.seq_num - pid -1;
       if (distance <= 15) {
         if (!isTimeToRetransmit(blp_nack_info, now_ms)) {
+          index++;
           continue;
         }
         if (blp_nack_info.retransmits >= kMaxRetransmits) {

--- a/erizo/src/erizo/rtp/RtcpNackGenerator.cpp
+++ b/erizo/src/erizo/rtp/RtcpNackGenerator.cpp
@@ -89,8 +89,7 @@ bool RtcpNackGenerator::addNackPacketToRr(std::shared_ptr<DataPacket> rr_packet)
     base_nack_info.sent_time = now_ms;
     base_nack_info.retransmits++;
     while (index + 1u < nack_info_list_.size()) {
-      index++;
-      NackInfo& blp_nack_info = nack_info_list_[index];
+      NackInfo& blp_nack_info = nack_info_list_[index + 1];
       uint16_t distance = blp_nack_info.seq_num - pid -1;
       if (distance <= 15) {
         if (!isTimeToRetransmit(blp_nack_info, now_ms)) {
@@ -99,13 +98,14 @@ bool RtcpNackGenerator::addNackPacketToRr(std::shared_ptr<DataPacket> rr_packet)
         if (blp_nack_info.retransmits >= kMaxRetransmits) {
           ELOG_DEBUG("message: Removing Nack in list too many retransmits, ssrc: %u, seq_num: %u",
               ssrc_, blp_nack_info.seq_num);
-          nack_info_list_.erase(nack_info_list_.begin() + index);
+          nack_info_list_.erase(nack_info_list_.begin() + index + 1);
           continue;
         }
         ELOG_DEBUG("message: Adding Nack to BLP, seq_num: %u", blp_nack_info.seq_num);
         blp |= (1 << distance);
         blp_nack_info.sent_time = now_ms;
         blp_nack_info.retransmits++;
+        index++;
       } else {
         break;
       }

--- a/erizo/src/test/rtp/RtcpNackGeneratorTest.cpp
+++ b/erizo/src/test/rtp/RtcpNackGeneratorTest.cpp
@@ -144,7 +144,10 @@ TEST_F(RtcpNackGeneratorTest, nackShouldContainLostPacketsInMoreThanOneBlock) {
   EXPECT_TRUE(nack_generator.handleRtpPacket(second_packet));
 
   receiver_report = generateRrWithNack();
-  EXPECT_TRUE(RtcpPacketContainsNackSeqNum(receiver_report, 35));
+
+  for (int i = erizo::kArbitrarySeqNumber + 1; i < erizo::kArbitrarySeqNumber + kArbitraryNumberOfPackets; ++i) {
+    EXPECT_TRUE(RtcpPacketContainsNackSeqNum(receiver_report, i)) << "i = " << i;
+  }
 }
 
 TEST_F(RtcpNackGeneratorTest, shouldNotRetransmitNacksInmediately) {


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
I run into this bug while looking at the nack generator (related to pr #1096 ). Something was off in the sequence of nacks generated and then I found that the first nack of the second blp was always missing.

[X] It needs and includes Unit Tests
The for inside the test case works but maybe the form can be improved

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.