### PR TITLE
Firefox Simulcast parser

### DIFF
--- a/erizo_controller/common/semanticSdp/MediaInfo.js
+++ b/erizo_controller/common/semanticSdp/MediaInfo.js
@@ -12,6 +12,7 @@ class MediaInfo {
     this.codecs = new Map();
     this.rids = new Map();
     this.simulcast = null;
+    this.simulcast_03 = null;
     this.bitrate = 0;
     this.ice = null;
     this.dtls = null;
@@ -272,6 +273,14 @@ class MediaInfo {
 
   setSimulcast(simulcast) {
     this.simulcast = simulcast;
+  }
+
+  getSimulcast03() {
+    return this.simulcast_03;
+  }
+
+  setSimulcast03(simulcast) {
+    this.simulcast_03 = simulcast;
   }
 }
 

--- a/erizo_controller/common/semanticSdp/SDPInfo.js
+++ b/erizo_controller/common/semanticSdp/SDPInfo.js
@@ -374,6 +374,8 @@ class SDPInfo {
       });
 
       const simulcast = media.getSimulcast();
+      const simulcast03 = media.getSimulcast03();
+
       if (simulcast) {
         let index = 1;
         md.simulcast = {};
@@ -409,6 +411,12 @@ class SDPInfo {
           md.simulcast[`list${index}`] = list;
           index += 1;
         }
+      }
+
+      if (simulcast03) {
+        md.simulcast_03 = {
+          value: simulcast03.getSimulcastPlainString(),
+        };
       }
 
       sdp.media.push(md);
@@ -580,19 +588,7 @@ function getSimulcastDir(index, md, simulcast) {
 }
 
 function getSimulcast3Dir(md, simulcast) {
-  const simulcastDir = md.simulcast_03.value.match(/\s*(send|recv)/)[0];
-  const simulcastList = md.simulcast_03.value.match(/rid=([\S]+)/)[0];
-  if (simulcastDir) {
-    const direction = DirectionWay.byValue(simulcastDir);
-    const list = SDPTransform.parseSimulcastStreamList(simulcastList);
-    list.forEach((stream) => {
-      const alternatives = [];
-      stream.forEach((entry) => {
-        alternatives.push(new SimulcastStreamInfo(entry.scid, entry.paused));
-      });
-      simulcast.addSimulcastAlternativeStreams(direction, alternatives);
-    });
-  }
+  simulcast.setSimulcastPlainString(md.simulcast_03.value);
 }
 
 function getSimulcast(mediaInfo, md) {
@@ -629,7 +625,7 @@ function getSimulcast(mediaInfo, md) {
   if (md.simulcast_03) {
     const simulcast = new SimulcastInfo();
     getSimulcast3Dir(md, simulcast);
-    mediaInfo.setSimulcast(simulcast);
+    mediaInfo.setSimulcast03(simulcast);
   }
   return encodings;
 }

--- a/erizo_controller/common/semanticSdp/SimulcastInfo.js
+++ b/erizo_controller/common/semanticSdp/SimulcastInfo.js
@@ -4,6 +4,7 @@ class SimulcastInfo {
   constructor() {
     this.send = [];
     this.recv = [];
+    this.plainString = null;
   }
 
   clone() {
@@ -66,6 +67,14 @@ class SimulcastInfo {
       return this.send;
     }
     return this.recv;
+  }
+
+  setSimulcastPlainString(string) {
+    this.plainString = string;
+  }
+
+  getSimulcastPlainString() {
+    return this.plainString;
   }
 }
 


### PR DESCRIPTION
Implemented a proper parser for the old implementation of Simulcast (such the one in Firefox).
Simulcast on Firefox was working only thanks to a coincidence.

Fix simulcast not working on https://github.com/lynckia/licode/pull/1098

[] It needs and includes Unit Tests
[] It includes documentation for these changes in `/doc`.