### PR TITLE
Remove double quotes in the release description

### DIFF
--- a/utils/release.sh
+++ b/utils/release.sh
@@ -88,7 +88,7 @@ if [ "$MODE" = "PRERELEASE" ]; then
   docker push lynckia/licode:${NEXT_PRERELEASE_NAME}
   docker push lynckia/licode:staging
 
-  LOGS=`git log $PREVIOUS_VERSION..$COMMIT --oneline | perl -p -e 's/\n/\\\\n/'`
+  LOGS=`git log $PREVIOUS_VERSION..$COMMIT --oneline | perl -p -e 's/\n/\\\\n/'` | sed -e s/\"//g
   DESCRIPTION="### Detailed PR List:\\n$LOGS"
 
   if [ "$URL" = "null" ]; then


### PR DESCRIPTION
**Description**

We were having issues when creating a release. The issue was affected by commit with names that contain double quotes.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.