### PR TITLE
check if targetClient is undefined

### DIFF
--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -91,8 +91,10 @@ class Client extends events.EventEmitter {
     }
     if (this.room.p2p) {
       const targetClient = this.room.getClientById(message.peerSocket);
-      targetClient.sendMessage('signaling_message_peer',
-                {streamId: message.streamId, peerSocket: this.id, msg: message.msg});
+      if (targetClient) {
+        targetClient.sendMessage('signaling_message_peer',
+                  {streamId: message.streamId, peerSocket: this.id, msg: message.msg});
+      }
     } else {
         const isControlMessage = message.msg.type === 'control';
         if (!isControlMessage ||


### PR DESCRIPTION
Sometimes happens that targetClient is undefined and the whole thing crashes because can't find sendMessage of undefined;

[] It needs and includes Unit Tests
[] It includes documentation for these changes in `/doc`.