### PR TITLE
Move offer creation logic out of Erizo

### DIFF
--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -1089,6 +1089,16 @@ namespace erizo {
     return payloadVector;
   }
 
+  std::vector<ExtMap> SdpInfo::getExtensionMap(MediaType media) {
+    std::vector<ExtMap> valid_extensions;
+    for (const ExtMap& extension : extMapVector) {
+      if (isValidExtension(extension.uri) && extension.mediaType == media) {
+        valid_extensions.push_back(extension);
+      }
+    }
+    return valid_extensions;
+  }
+
   unsigned int SdpInfo::getAudioInternalPT(unsigned int externalPT) {
     // should use separate mapping for video and audio at the very least
     // standard requires separate mappings for each media, even!

--- a/erizo/src/erizo/SdpInfo.h
+++ b/erizo/src/erizo/SdpInfo.h
@@ -192,6 +192,7 @@ class SdpInfo {
   * @return A vector containing the PT-codec information
   */
   std::vector<RtpMap>& getPayloadInfos();
+  std::vector<ExtMap> getExtensionMap(MediaType media);
   /**
    * Gets the actual SDP.
    * @return The SDP in string format.

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -175,6 +175,11 @@ bool WebRtcConnection::setRemoteSdpInfo(std::shared_ptr<SdpInfo> sdp) {
   return processRemoteSdp();
 }
 
+std::shared_ptr<SdpInfo> WebRtcConnection::getLocalSdpInfo() {
+  ELOG_DEBUG("%s message: getting local SDPInfo", toLog());
+  return local_sdp_;
+}
+
 bool WebRtcConnection::setRemoteSdp(const std::string &sdp) {
   ELOG_DEBUG("%s message: setting remote SDP", toLog());
 

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -98,6 +98,11 @@ class WebRtcConnection: public TransportListener, public LogContext,
   bool addRemoteCandidate(const std::string &mid, int mLineIndex, const std::string &sdp);
   /**
    * Obtains the local SDP.
+   * @return The SDP as a SdpInfo.
+   */
+  std::shared_ptr<SdpInfo> getLocalSdpInfo();
+  /**
+   * Obtains the local SDP.
    * @return The SDP as a string.
    */
   std::string getLocalSdp();

--- a/erizoAPI/ConnectionDescription.h
+++ b/erizoAPI/ConnectionDescription.h
@@ -12,6 +12,7 @@
 class ConnectionDescription : public Nan::ObjectWrap {
  public:
     static NAN_MODULE_INIT(Init);
+    static v8::Local<v8::Object> NewInstance();
 
     std::shared_ptr<erizo::SdpInfo> me;
 
@@ -36,25 +37,45 @@ class ConnectionDescription : public Nan::ObjectWrap {
     static NAN_METHOD(setRtcpMux);
     static NAN_METHOD(setAudioAndVideo);
 
+    static NAN_METHOD(getProfile);
+    static NAN_METHOD(isBundle);
+    static NAN_METHOD(getMediaId);
+    static NAN_METHOD(isRtcpMux);
+    static NAN_METHOD(hasAudio);
+    static NAN_METHOD(hasVideo);
+
     static NAN_METHOD(setAudioSsrc);
     static NAN_METHOD(setVideoSsrcList);
+    static NAN_METHOD(getAudioSsrc);
+    static NAN_METHOD(getVideoSsrcList);
 
     static NAN_METHOD(setDirection);
+    static NAN_METHOD(getDirection);
 
     static NAN_METHOD(setFingerprint);
+    static NAN_METHOD(getFingerprint);
     static NAN_METHOD(setDtlsRole);
+    static NAN_METHOD(getDtlsRole);
 
     static NAN_METHOD(setVideoBandwidth);
+    static NAN_METHOD(getVideoBandwidth);
 
     static NAN_METHOD(addCandidate);
     static NAN_METHOD(addCryptoInfo);
     static NAN_METHOD(setICECredentials);
+    static NAN_METHOD(getICECredentials);
+
+    static NAN_METHOD(getCandidates);
+    static NAN_METHOD(getCodecs);
+    static NAN_METHOD(getExtensions);
 
     static NAN_METHOD(addRid);
     static NAN_METHOD(addPt);
     static NAN_METHOD(addExtension);
     static NAN_METHOD(addFeedback);
     static NAN_METHOD(addParameter);
+
+    static NAN_METHOD(getRids);
 
     static NAN_METHOD(postProcessInfo);
 

--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -3,6 +3,7 @@
 #endif
 
 #include "WebRtcConnection.h"
+#include "ConnectionDescription.h"
 #include "MediaStream.h"
 
 #include <future>  // NOLINT
@@ -41,6 +42,7 @@ NAN_MODULE_INIT(WebRtcConnection::Init) {
   Nan::SetPrototypeMethod(tpl, "close", close);
   Nan::SetPrototypeMethod(tpl, "init", init);
   Nan::SetPrototypeMethod(tpl, "setRemoteDescription", setRemoteDescription);
+  Nan::SetPrototypeMethod(tpl, "getLocalDescription", getLocalDescription);
   Nan::SetPrototypeMethod(tpl, "setRemoteSdp", setRemoteSdp);
   Nan::SetPrototypeMethod(tpl, "addRemoteCandidate", addRemoteCandidate);
   Nan::SetPrototypeMethod(tpl, "getLocalSdp", getLocalSdp);
@@ -262,6 +264,18 @@ NAN_METHOD(WebRtcConnection::setRemoteDescription) {
 
   bool r = me->setRemoteSdpInfo(sdp);
   info.GetReturnValue().Set(Nan::New(r));
+}
+
+NAN_METHOD(WebRtcConnection::getLocalDescription) {
+  WebRtcConnection* obj = Nan::ObjectWrap::Unwrap<WebRtcConnection>(info.Holder());
+  std::shared_ptr<erizo::WebRtcConnection> me = obj->me;
+
+  std::shared_ptr<erizo::SdpInfo> sdp_info = me->getLocalSdpInfo();
+
+  v8::Local<v8::Object> instance = ConnectionDescription::NewInstance();
+  ConnectionDescription* description = ObjectWrap::Unwrap<ConnectionDescription>(instance);
+  description->me = sdp_info;
+  info.GetReturnValue().Set(instance);
 }
 
 NAN_METHOD(WebRtcConnection::addRemoteCandidate) {

--- a/erizoAPI/WebRtcConnection.h
+++ b/erizoAPI/WebRtcConnection.h
@@ -65,6 +65,12 @@ class WebRtcConnection : public erizo::WebRtcConnectionEventListener,
      */
     static NAN_METHOD(setRemoteDescription);
     /*
+     * Gets the SDP of the local peer.
+     * Param: the SDP.
+     * Returns true if the SDP was received correctly.
+     */
+    static NAN_METHOD(getLocalDescription);
+    /*
      * Sets the SDP of the remote peer.
      * Param: the SDP.
      * Returns true if the SDP was received correctly.

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -108,6 +108,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
                     wrtc.localDescription = new SessionDescription(wrtc.getLocalDescription());
                     const sdp = wrtc.localDescription.getSdp();
                     mess = sdp.toString();
+                    mess = mess.replace(that.privateRegexp, that.publicIP);
                     if (options.createOffer)
                         callback('callback', {type: 'offer', sdp: mess});
                     else

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -105,8 +105,8 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
 
                 case CONN_SDP:
                 case CONN_GATHERED:
-                    mess = mess.replace(that.privateRegexp, that.publicIP);
-                    const sdp = SemanticSdp.SDPInfo.processString(mess);
+                    wrtc.localDescription = new SessionDescription(wrtc.getLocalDescription());
+                    const sdp = wrtc.localDescription.getSdp();
                     mess = sdp.toString();
                     if (options.createOffer)
                         callback('callback', {type: 'offer', sdp: mess});

--- a/erizo_controller/erizoJS/models/Helpers.js
+++ b/erizo_controller/erizoJS/models/Helpers.js
@@ -1,9 +1,5 @@
-/*global require, exports*/
+/*global exports*/
 'use strict';
-var logger = require('./../../common/logger').logger;
-
-// Logger
-var log = logger.getLogger('Helpers');
 
 exports.getMediaConfiguration = (mediaConfiguration = 'default') => {
   if (global.mediaConfig && global.mediaConfig.codecConfigurations) {
@@ -12,11 +8,9 @@ exports.getMediaConfiguration = (mediaConfiguration = 'default') => {
     } else if (global.mediaConfig.codecConfigurations.default) {
       return JSON.stringify(global.mediaConfig.codecConfigurations.default);
     } else {
-      log.warn('message: Bad media config file. You need to specify a default codecConfiguration.');
       return JSON.stringify({});
     }
   } else {
-    log.warn('message: Bad media config file. You need to specify a default codecConfiguration.');
     return JSON.stringify({});
   }
 };

--- a/erizo_controller/erizoJS/models/SessionDescription.js
+++ b/erizo_controller/erizoJS/models/SessionDescription.js
@@ -1,6 +1,5 @@
 /*global require*/
 'use strict';
-const SDPTransform = require('sdp-transform');  // eslint-disable-line
 var ConnectionDescription = require('./../../../erizoAPI/build/Release/addon')
                                                           .ConnectionDescription;
 var SdpInfo = require('./../../common/semanticSdp/SdpInfo');
@@ -24,7 +23,7 @@ function getRandomArbitrary(min, max) {
 }
 
 function generateRandom(length) {
-  const alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  const alphanum = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
   const lastChar = alphanum.length - 1;
   let value = '';
 
@@ -82,8 +81,8 @@ function getMediaInfoFromDescription(info, sdp, mediaType) {
   if (candidates) {
     candidates.forEach((candidate) => {
       media.addCandidate(new CandidateInfo(candidate.foundation, candidate.componentId,
-        candidate.protocol, candidate.priority, candidate.hostIp, candidate.hostPort, candidate.hostType,
-        0, candidate.relayIp, candidate.relayPort));
+        candidate.protocol, candidate.priority, candidate.hostIp, candidate.hostPort,
+        candidate.hostType, 0, candidate.relayIp, candidate.relayPort));
     });
   }
 
@@ -154,11 +153,11 @@ function getMediaInfoFromDescription(info, sdp, mediaType) {
       direction = rids[id];
       ridsData.push(id);
       const ridInfo = new RIDInfo(id, DirectionWay.byValue(rids[id]));
-      let formats = [];
       media.addRID(ridInfo);
     });
 
     if (isSimulcast) {
+      /*jshint camelcase: false */
       simulcast.setSimulcastPlainString(direction + ' rid=' + ridsData.join(';'));
       media.simulcast_03 = simulcast;
     }

--- a/erizo_controller/erizoJS/models/SessionDescription.js
+++ b/erizo_controller/erizoJS/models/SessionDescription.js
@@ -2,7 +2,7 @@
 'use strict';
 var ConnectionDescription = require('./../../../erizoAPI/build/Release/addon')
                                                           .ConnectionDescription;
-var SdpInfo = require('./../../common/semanticSdp/SdpInfo');
+var SdpInfo = require('./../../common/semanticSdp/SDPInfo');
 var MediaInfo = require('./../../common/semanticSdp/MediaInfo');
 var ICEInfo = require('./../../common/semanticSdp/ICEInfo');
 var DTLSInfo = require('./../../common/semanticSdp/DTLSInfo');

--- a/erizo_controller/test/utils.js
+++ b/erizo_controller/test/utils.js
@@ -144,6 +144,8 @@ var reset = module.exports.reset = function() {
     setAudioAndVideo: sinon.stub(),
     setVideoSsrcList: sinon.stub(),
     postProcessInfo: sinon.stub(),
+    hasAudio: sinon.stub(),
+    hasVideo: sinon.stub(),
   };
 
   module.exports.WebRtcConnection = {
@@ -153,6 +155,7 @@ var reset = module.exports.reset = function() {
     createOffer: sinon.stub(),
     setRemoteSdp: sinon.stub(),
     setRemoteDescription: sinon.stub(),
+    getLocalDescription: sinon.stub().returns(module.exports.ConnectionDescription),
     addRemoteCandidate: sinon.stub(),
     addMediaStream: sinon.stub(),
   };

--- a/spine/nativeClient.js
+++ b/spine/nativeClient.js
@@ -2,8 +2,10 @@
 const addon = require('./../erizoAPI/build/Release/addon'); // eslint-disable-line import/no-unresolved
 const licodeConfig = require('./../licode_config');
 const mediaConfig = require('./../rtp_media_config');
-const SemanticSdp = require('./../erizo_controller/common/semanticSdp/SemanticSdp');
 const logger = require('./logger').logger;
+const SessionDescription = require('./../erizo_controller/erizoJS/models/SessionDescription');
+const SemanticSdp = require('./../erizo_controller/common/semanticSdp/SemanticSdp');
+
 
 const log = logger.getLogger('NativeClient');
 
@@ -66,8 +68,9 @@ exports.ErizoNativeConnection = (config) => {
         case CONN_SDP:
         case CONN_GATHERED:
           setTimeout(() => {
-            const sdp = SemanticSdp.SDPInfo.processString(mess);
-            initConnectionCallback('callback', { type: 'offer', sdp: sdp.toJSON() });
+            wrtc.localDescription = new SessionDescription(wrtc.getLocalDescription());
+            const sdp = wrtc.localDescription.getSdp();
+            initConnectionCallback('callback', { type: 'offer', sdp: sdp.toString() });
           }, 100);
           break;
 
@@ -184,7 +187,7 @@ exports.ErizoNativeConnection = (config) => {
     } else if (signalingMsg.type === 'answer') {
       setTimeout(() => {
         log.info('Passing delayed answer');
-        const sdp = SemanticSdp.SDPInfo.process(signalingMsg.sdp);
+        const sdp = SemanticSdp.SDPInfo.processString(signalingMsg.sdp);
         wrtc.setRemoteSdp(sdp.toString());
         that.onaddstream({ stream: { active: true } });
       }, 10);


### PR DESCRIPTION
**Description**
It moves the logic to create SDP offer from Erizo to ErizoJS.

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.