### PR TITLE
Use private variables to save the codec type of the output format.

### DIFF
--- a/erizo/src/erizo/media/ExternalOutput.h
+++ b/erizo/src/erizo/media/ExternalOutput.h
@@ -99,6 +99,8 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
   vp8SearchState video_search_state_;
   bool need_to_send_fir_;
   std::vector<RtpMap> rtp_mappings_;
+  enum AVCodecID video_codec_;
+  enum AVCodecID audio_codec_;
   std::map<uint, RtpMap> video_maps_;
   std::map<uint, RtpMap> audio_maps_;
   RtpMap video_map_;


### PR DESCRIPTION
- Because the return value of `av_guess_format()` is a pointer to a
  global object, we can not use it to save the codec type for each
  `ExternalOutput`.

<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

<!--
Add a short description here, please.
If the contribution needs and includes Unit Tests check the box below.
-->

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.