### PR TITLE
Fix a crash that still happens when closing NicerConnection

### DIFF
--- a/erizo/src/erizo/IceConnection.h
+++ b/erizo/src/erizo/IceConnection.h
@@ -91,7 +91,7 @@ class IceConnection : public LogContext {
   DECLARE_LOGGER();
 
  public:
-  IceConnection(IceConnectionListener* listener, const IceConfig& ice_config);
+  explicit IceConnection(const IceConfig& ice_config);
 
   virtual ~IceConnection();
 
@@ -107,8 +107,8 @@ class IceConnection : public LogContext {
 
   virtual void updateIceState(IceState state);
   virtual IceState checkIceState();
-  virtual void setIceListener(IceConnectionListener *listener);
-  virtual IceConnectionListener* getIceListener();
+  virtual void setIceListener(std::weak_ptr<IceConnectionListener> listener);
+  virtual std::weak_ptr<IceConnectionListener> getIceListener();
 
   virtual std::string getLocalUsername();
   virtual std::string getLocalPassword();
@@ -122,7 +122,7 @@ class IceConnection : public LogContext {
   }
 
  protected:
-  IceConnectionListener *listener_;
+  std::weak_ptr<IceConnectionListener> listener_;
   IceState ice_state_;
   IceConfig ice_config_;
 

--- a/erizo/src/erizo/LibNiceConnection.h
+++ b/erizo/src/erizo/LibNiceConnection.h
@@ -41,8 +41,7 @@ class LibNiceConnection : public IceConnection {
   DECLARE_LOGGER();
 
  public:
-  LibNiceConnection(boost::shared_ptr<LibNiceInterface> libnice, IceConnectionListener* listener,
-    const IceConfig& ice_config);
+  LibNiceConnection(boost::shared_ptr<LibNiceInterface> libnice, const IceConfig& ice_config);
 
   virtual ~LibNiceConnection();
   /**
@@ -61,7 +60,7 @@ class LibNiceConnection : public IceConnection {
   void setReceivedLastCandidate(bool hasReceived) override;
   void close() override;
 
-  static LibNiceConnection* create(IceConnectionListener *listener, const IceConfig& ice_config);
+  static LibNiceConnection* create(const IceConfig& ice_config);
 
  private:
   void mainLoop();

--- a/erizo/src/erizo/NicerConnection.h
+++ b/erizo/src/erizo/NicerConnection.h
@@ -41,7 +41,7 @@ class NicerConnection : public IceConnection, public std::enable_shared_from_thi
 
  public:
   explicit NicerConnection(std::shared_ptr<IOWorker> io_worker, std::shared_ptr<NicerInterface> interface,
-                           IceConnectionListener *listener, const IceConfig& ice_config);
+                           const IceConfig& ice_config);
 
   virtual ~NicerConnection();
 
@@ -57,8 +57,7 @@ class NicerConnection : public IceConnection, public std::enable_shared_from_thi
   void setReceivedLastCandidate(bool hasReceived) override;
   void close() override;
 
-  static std::shared_ptr<IceConnection> create(std::shared_ptr<IOWorker> io_worker, IceConnectionListener *listener,
-                               const IceConfig& ice_config);
+  static std::shared_ptr<IceConnection> create(std::shared_ptr<IOWorker> io_worker, const IceConfig& ice_config);
 
   static void initializeGlobals();
 

--- a/erizo/src/erizo/NicerConnection.h
+++ b/erizo/src/erizo/NicerConnection.h
@@ -56,6 +56,7 @@ class NicerConnection : public IceConnection, public std::enable_shared_from_thi
   CandidatePair getSelectedPair() override;
   void setReceivedLastCandidate(bool hasReceived) override;
   void close() override;
+  bool isClosed() { return closed_; }
 
   static std::shared_ptr<IceConnection> create(std::shared_ptr<IOWorker> io_worker, const IceConfig& ice_config);
 

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -62,9 +62,6 @@ WebRtcConnection::WebRtcConnection(std::shared_ptr<Worker> worker, std::shared_p
 
 WebRtcConnection::~WebRtcConnection() {
   ELOG_DEBUG("%s message:Destructor called", toLog());
-  if (sending_) {
-    syncClose();
-  }
   ELOG_DEBUG("%s message: Destructor ended", toLog());
 }
 
@@ -90,8 +87,9 @@ void WebRtcConnection::syncClose() {
 
 void WebRtcConnection::close() {
   ELOG_DEBUG("%s message: Async close called", toLog());
-  asyncTask([] (std::shared_ptr<WebRtcConnection> connection) {
-    connection->syncClose();
+  std::shared_ptr<WebRtcConnection> shared_this = shared_from_this();
+  asyncTask([shared_this] (std::shared_ptr<WebRtcConnection> connection) {
+    shared_this->syncClose();
   });
 }
 

--- a/erizo/src/test/LibNiceConnectionTest.cpp
+++ b/erizo/src/test/LibNiceConnectionTest.cpp
@@ -66,17 +66,16 @@ class LibNiceConnectionStartTest : public ::testing::Test {
   virtual void SetUp() {
     libnice = new MockLibNice;
     libnice_pointer.reset(libnice);
-    nice_listener = new MockLibNiceConnectionListener();
+    nice_listener = std::make_shared<MockLibNiceConnectionListener>();
     ice_config = new erizo::IceConfig();
   }
   virtual void TearDown() {
-    delete nice_listener;
     delete ice_config;
   }
 
   boost::shared_ptr<erizo::LibNiceInterface> libnice_pointer;
   MockLibNice* libnice;
-  MockLibNiceConnectionListener* nice_listener;
+  std::shared_ptr<MockLibNiceConnectionListener> nice_listener;
   erizo::IceConfig* ice_config;
 };
 
@@ -91,7 +90,7 @@ class LibNiceConnectionTest : public ::testing::Test {
 
     libnice = new MockLibNice;
     libnice_pointer.reset(libnice);
-    nice_listener = new MockLibNiceConnectionListener();
+    nice_listener = std::make_shared<MockLibNiceConnectionListener>();
     ice_config = new erizo::IceConfig();
     ufrag = strdup(kArbitraryLocalCredentialUsername.c_str());
     pass = strdup(kArbitraryLocalCredentialPassword.c_str());
@@ -113,21 +112,20 @@ class LibNiceConnectionTest : public ::testing::Test {
     EXPECT_CALL(*libnice, NiceAgentSetRelayInfo(_, _, _, _, _, _, _)).Times(0);
 
     nice_connection = new erizo::LibNiceConnection(libnice_pointer,
-        nice_listener,
         *ice_config);
+    nice_connection->setIceListener(nice_listener);
     nice_connection->start();
   }
 
   virtual void TearDown() {
     delete nice_connection;
-    delete nice_listener;
     delete ice_config;
     free(test_packet);
   }
 
   boost::shared_ptr<erizo::LibNiceInterface> libnice_pointer;
   MockLibNice* libnice;
-  MockLibNiceConnectionListener* nice_listener;
+  std::shared_ptr<MockLibNiceConnectionListener> nice_listener;
   erizo::IceConfig* ice_config;
   erizo::LibNiceConnection* nice_connection;
   char* ufrag, * pass, * test_packet;
@@ -143,7 +141,7 @@ class LibNiceConnectionTwoComponentsTest : public ::testing::Test {
 
     libnice = new MockLibNice;
     libnice_pointer.reset(libnice);
-    nice_listener = new MockLibNiceConnectionListener();
+    nice_listener = std::make_shared<MockLibNiceConnectionListener>();
     ice_config = new erizo::IceConfig();
     ufrag = strdup(kArbitraryLocalCredentialUsername.c_str());
     pass = strdup(kArbitraryLocalCredentialPassword.c_str());
@@ -163,20 +161,19 @@ class LibNiceConnectionTwoComponentsTest : public ::testing::Test {
     EXPECT_CALL(*libnice, NiceAgentSetRelayInfo(_, _, _, _, _, _, _)).Times(0);
 
     nice_connection = new erizo::LibNiceConnection(libnice_pointer,
-        nice_listener,
         *ice_config);
+    nice_connection->setIceListener(nice_listener);
     nice_connection->start();
   }
 
   virtual void TearDown() {
     delete nice_connection;
-    delete nice_listener;
     delete ice_config;
   }
 
   boost::shared_ptr<erizo::LibNiceInterface> libnice_pointer;
   MockLibNice* libnice;
-  MockLibNiceConnectionListener* nice_listener;
+  std::shared_ptr<MockLibNiceConnectionListener> nice_listener;
   erizo::IceConfig* ice_config;
   erizo::LibNiceConnection* nice_connection;
   char* ufrag, * pass;
@@ -207,8 +204,8 @@ TEST_F(LibNiceConnectionStartTest, start_Configures_Libnice_With_Default_Config)
   EXPECT_CALL(*libnice, NiceAgentSetRelayInfo(_, _, _, _, _, _, _)).Times(0);
 
   erizo::LibNiceConnection nice(libnice_pointer,
-      nice_listener,
       *ice_config);
+  nice.setIceListener(nice_listener);
   nice.start();
 }
 
@@ -243,8 +240,8 @@ TEST_F(LibNiceConnectionStartTest, start_Configures_Libnice_With_Remote_Credenti
   EXPECT_CALL(*libnice, NiceAgentSetRelayInfo(_, _, _, _, _, _, _)).Times(0);
 
   erizo::LibNiceConnection nice(libnice_pointer,
-      nice_listener,
       *ice_config);
+  nice.setIceListener(nice_listener);
   nice.start();
 }
 
@@ -278,8 +275,8 @@ TEST_F(LibNiceConnectionStartTest, start_Configures_Libnice_With_Port_Range) {
   EXPECT_CALL(*libnice, NiceAgentSetRelayInfo(_, _, _, _, _, _, _)).Times(0);
 
   erizo::LibNiceConnection nice(libnice_pointer,
-      nice_listener,
       *ice_config);
+  nice.setIceListener(nice_listener);
   nice.start();
 }
 
@@ -320,8 +317,8 @@ TEST_F(LibNiceConnectionStartTest, start_Configures_Libnice_With_Turn) {
         WillOnce(Return(true));
 
   erizo::LibNiceConnection nice(libnice_pointer,
-      nice_listener,
       *ice_config);
+  nice.setIceListener(nice_listener);
   nice.start();
 }
 


### PR DESCRIPTION
**Description**

There's still some cases where NicerConnection makes Erizo crash when closing a connection. This PR aims to solve them by destroying things in the correct threads.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.