### PR TITLE
Fix random unit test failure

### DIFF
--- a/erizo/src/test/media/SyntheticInputTest.cpp
+++ b/erizo/src/test/media/SyntheticInputTest.cpp
@@ -176,7 +176,7 @@ TEST_F(SyntheticInputTest, firstVideoFrame_shouldBeAKeyframe) {
 }
 
 TEST_F(SyntheticInputTest, shouldWriteFragmentedKeyFrames_whenExpected) {
-  auto packet = erizo::PacketTools::createRembPacket(300000);
+  auto packet = erizo::PacketTools::createRembPacket(350000);
   input->deliverFeedback(packet);
   EXPECT_CALL(sink, deliverAudioDataInternal(_, _)).Times(4);
   EXPECT_CALL(sink, deliverVideoDataInternal(_, _)).With(Args<0>(erizo::IsKeyframeFirstPacket())).Times(1);

--- a/erizo/src/test/rtp/SenderBandwidthEstimationTest.cpp
+++ b/erizo/src/test/rtp/SenderBandwidthEstimationTest.cpp
@@ -120,7 +120,6 @@ TEST_F(SenderBandwidthEstimationHandlerTest, shouldProvideEstimateAfterkMinUpdat
 
     pipeline->write(packet);
     pipeline->read(remb_packet);
-    advanceClock(SenderBandwidthEstimationHandler::kMinUpdateEstimateInterval+std::chrono::milliseconds(1));
+    advanceClock(SenderBandwidthEstimationHandler::kMinUpdateEstimateInterval+std::chrono::milliseconds(500));
     pipeline->write(packet_2);
 }
-


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

We have been having few annoying failures on unit tests that break our CI process. I made two tweaks to constant values and it works much better for us, now we got 100% build success in several thousands test runs.

<!--
Add a short description here, please.
If the contribution needs and includes Unit Tests check the box below.
-->

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.