### PR TITLE
Make licode work on gcc 7 and clang 3.9

### DIFF
--- a/erizo/src/erizo/NicerConnection.h
+++ b/erizo/src/erizo/NicerConnection.h
@@ -5,6 +5,9 @@
 #ifndef ERIZO_SRC_ERIZO_NICERCONNECTION_H_
 #define ERIZO_SRC_ERIZO_NICERCONNECTION_H_
 
+// Need at least one std header before nicer to explicitly define std namespace
+#include <string>
+
 // nICEr includes
 extern "C" {
 #include <r_types.h>
@@ -12,7 +15,6 @@ extern "C" {
 }
 
 #include <boost/thread.hpp>
-#include <string>
 #include <vector>
 #include <queue>
 #include <map>

--- a/erizo/src/erizo/media/ExternalInput.h
+++ b/erizo/src/erizo/media/ExternalInput.h
@@ -4,12 +4,17 @@
 #include <boost/scoped_ptr.hpp>
 #include <boost/thread.hpp>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libavutil/mathematics.h>
 #include <libavutil/time.h>
 }
+
+#pragma GCC diagnostic pop
 
 #include <string>
 #include <map>
@@ -59,4 +64,5 @@ class ExternalInput : public MediaSource, public RTPDataReceiver {
   void encodeLoop();
 };
 }  // namespace erizo
+
 #endif  // ERIZO_SRC_ERIZO_MEDIA_EXTERNALINPUT_H_

--- a/erizo/src/erizo/rtp/RtcpRrGenerator.h
+++ b/erizo/src/erizo/rtp/RtcpRrGenerator.h
@@ -61,7 +61,6 @@ class RtcpRrGenerator {
   };
 
   uint8_t packet_[128];
-  bool enabled_, initialized_;
   RrPacketInfo rr_info_;
   uint32_t ssrc_;
   packetType type_;

--- a/erizo/src/erizo/stats/StatNode.h
+++ b/erizo/src/erizo/stats/StatNode.h
@@ -43,7 +43,7 @@ class StatNode {
   virtual std::string toString();
 
  private:
-  bool is_node_;
+  bool is_node_{false};
   std::map<std::string, std::shared_ptr<StatNode>> node_map_;
 };
 

--- a/erizo/src/test/NicerConnectionTest.cpp
+++ b/erizo/src/test/NicerConnectionTest.cpp
@@ -3,7 +3,6 @@
 
 #include <NicerConnection.h>
 #include <lib/NicerInterface.h>
-#include <nice/nice.h>
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

This PR addresses the few build errors that precluded licode's compilation on gcc 7 and clang 3.9 (linux)

<!--
Add a short description here, please.
If the contribution needs and includes Unit Tests check the box below.
-->

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.