### PR TITLE
Fix wrong max audio bandwidth setting

### DIFF
--- a/erizo_controller/erizoClient/src/utils/SdpHelpers.js
+++ b/erizo_controller/erizoClient/src/utils/SdpHelpers.js
@@ -33,7 +33,7 @@ SdpHelpers.setMaxBW = (sdp, spec) => {
   if (spec.audio && spec.maxAudioBW) {
     const audio = sdp.getMedia('audio');
     if (audio) {
-      audio.setBitrate(spec.maxVideoBW);
+      audio.setBitrate(spec.maxAudioBW);
     }
   }
 };


### PR DESCRIPTION
**Description**

This fixes audio bitrate when we limit the max audio bandwidth in the pub/sub options.
[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.
[] It includes documentation for these changes in `/doc`.