### PR TITLE
Add full simulcast support to recordings

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -143,7 +143,9 @@ bool MediaStream::setLocalSdp(std::shared_ptr<SdpInfo> sdp) {
 }
 
 void MediaStream::initializePipeline() {
+  handler_manager_ = std::make_shared<HandlerManager>(shared_from_this());
   pipeline_->addService(shared_from_this());
+  pipeline_->addService(handler_manager_);
   pipeline_->addService(rtcp_processor_);
   pipeline_->addService(stats_);
   pipeline_->addService(quality_manager_);

--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -20,6 +20,7 @@
 #include "rtp/RtpExtensionProcessor.h"
 #include "lib/Clock.h"
 #include "pipeline/Handler.h"
+#include "pipeline/HandlerManager.h"
 #include "pipeline/Service.h"
 #include "rtp/QualityManager.h"
 #include "rtp/PacketBufferService.h"
@@ -37,7 +38,7 @@ class MediaStreamStatsListener {
  * A MediaStream. This class represents a Media Stream that can be established with other peers via a SDP negotiation
  */
 class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
-                        public FeedbackSource, public LogContext,
+                        public FeedbackSource, public LogContext, public HandlerManagerListener,
                         public std::enable_shared_from_this<MediaStream>, public Service {
   DECLARE_LOGGER();
 
@@ -98,7 +99,7 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
 
   void enableHandler(const std::string &name);
   void disableHandler(const std::string &name);
-  void notifyUpdateToHandlers();
+  void notifyUpdateToHandlers() override;
 
   void notifyToEventSink(MediaEventPtr event);
 
@@ -156,6 +157,7 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   std::shared_ptr<Stats> stats_;
   std::shared_ptr<QualityManager> quality_manager_;
   std::shared_ptr<PacketBufferService> packet_buffer_;
+  std::shared_ptr<HandlerManager> handler_manager_;
 
   Pipeline::Ptr pipeline_;
 

--- a/erizo/src/erizo/media/ExternalOutput.cpp
+++ b/erizo/src/erizo/media/ExternalOutput.cpp
@@ -93,7 +93,7 @@ void ExternalOutput::close() {
 }
 
 void ExternalOutput::syncClose() {
-  if (!recording_.exchange(false)) {
+  if (!recording_) {
     return;
   }
   // Stop our thread so we can safely nuke libav stuff and close our
@@ -120,6 +120,7 @@ void ExternalOutput::syncClose() {
   }
 
   pipeline_initialized_ = false;
+  recording_ = false;
 
   ELOG_DEBUG("Closed Successfully");
 }

--- a/erizo/src/erizo/media/ExternalOutput.cpp
+++ b/erizo/src/erizo/media/ExternalOutput.cpp
@@ -11,18 +11,23 @@
 #include "rtp/RtpHeaders.h"
 #include "rtp/RtpVP8Parser.h"
 
+#include "rtp/QualityFilterHandler.h"
+#include "rtp/LayerBitrateCalculationHandler.h"
+
 using std::memcpy;
 
 namespace erizo {
 
 DEFINE_LOGGER(ExternalOutput, "media.ExternalOutput");
-ExternalOutput::ExternalOutput(const std::string& output_url, const std::vector<RtpMap> rtp_mappings)
-  : audio_queue_{5.0, 10.0}, video_queue_{5.0, 10.0}, inited_{false}, video_stream_{nullptr},
+ExternalOutput::ExternalOutput(std::shared_ptr<Worker> worker, const std::string& output_url,
+                               const std::vector<RtpMap> rtp_mappings)
+  : worker_{worker}, pipeline_{Pipeline::create()}, audio_queue_{5.0, 10.0}, video_queue_{5.0, 10.0},
+    inited_{false}, video_stream_{nullptr},
     audio_stream_{nullptr}, video_source_ssrc_{0},
     first_video_timestamp_{-1}, first_audio_timestamp_{-1},
     first_data_received_{}, video_offset_ms_{-1}, audio_offset_ms_{-1},
     need_to_send_fir_{true}, rtp_mappings_{rtp_mappings}, video_codec_{AV_CODEC_ID_NONE},
-    audio_codec_{AV_CODEC_ID_NONE} {
+    audio_codec_{AV_CODEC_ID_NONE}, pipeline_initialized_{false} {
   ELOG_DEBUG("Creating output to %s", output_url.c_str());
 
   fb_sink_ = nullptr;
@@ -33,6 +38,8 @@ ExternalOutput::ExternalOutput(const std::string& output_url, const std::vector<
   avcodec_register_all();
 
   fec_receiver_.reset(webrtc::UlpfecReceiver::Create(this));
+  stats_ = std::make_shared<Stats>();
+  quality_manager_ = std::make_shared<QualityManager>();
 
   for (auto rtp_map : rtp_mappings_) {
     switch (rtp_map.media_type) {
@@ -64,8 +71,11 @@ bool ExternalOutput::init() {
   MediaInfo m;
   m.hasVideo = false;
   m.hasAudio = false;
-  thread_ = boost::thread(&ExternalOutput::sendLoop, this);
   recording_ = true;
+  asyncTask([] (std::shared_ptr<ExternalOutput> output) {
+    output->initializePipeline();
+  });
+  thread_ = boost::thread(&ExternalOutput::sendLoop, this);
   ELOG_DEBUG("Initialized successfully");
   return true;
 }
@@ -105,6 +115,15 @@ void ExternalOutput::close() {
   }
 
   ELOG_DEBUG("Closed Successfully");
+}
+
+void ExternalOutput::asyncTask(std::function<void(std::shared_ptr<ExternalOutput>)> f) {
+  std::weak_ptr<ExternalOutput> weak_this = shared_from_this();
+  worker_->task([weak_this, f] {
+    if (auto this_ptr = weak_this.lock()) {
+      f(this_ptr);
+    }
+  });
 }
 
 void ExternalOutput::receiveRawData(const RawDataPacket& /*packet*/) {
@@ -265,28 +284,70 @@ void ExternalOutput::maybeWriteVideoPacket(char* buf, int len) {
   }
 }
 
+void ExternalOutput::notifyUpdateToHandlers() {
+  asyncTask([] (std::shared_ptr<ExternalOutput> output) {
+    output->pipeline_->notifyUpdate();
+  });
+}
+
+void ExternalOutput::initializePipeline() {
+  stats_->getNode()["total"].insertStat("senderBitrateEstimation",
+      CumulativeStat{static_cast<uint64_t>(kExternalOutputMaxBitrate)});
+
+  handler_manager_ = std::make_shared<HandlerManager>(shared_from_this());
+  pipeline_->addService(handler_manager_);
+  pipeline_->addService(quality_manager_);
+  pipeline_->addService(stats_);
+
+  pipeline_->addFront(LayerBitrateCalculationHandler());
+  pipeline_->addFront(QualityFilterHandler());
+
+  pipeline_->addFront(ExternalOuputWriter(shared_from_this()));
+  pipeline_->finalize();
+  pipeline_initialized_ = true;
+}
+
+void ExternalOutput::write(std::shared_ptr<DataPacket> packet) {
+  queueData(packet->data, packet->length, packet->type);
+}
+
+void ExternalOutput::queueDataAsync(std::shared_ptr<DataPacket> copied_packet) {
+  asyncTask([copied_packet] (std::shared_ptr<ExternalOutput> this_ptr) {
+    if (!this_ptr->pipeline_initialized_) {
+      return;
+    }
+    this_ptr->pipeline_->write(std::move(copied_packet));
+  });
+}
+
 int ExternalOutput::deliverAudioData_(std::shared_ptr<DataPacket> audio_packet) {
   std::shared_ptr<DataPacket> copied_packet = std::make_shared<DataPacket>(*audio_packet);
-  queueData(copied_packet->data, copied_packet->length, AUDIO_PACKET);
+  copied_packet->type = AUDIO_PACKET;
+  queueDataAsync(copied_packet);
   return 0;
 }
 
 int ExternalOutput::deliverVideoData_(std::shared_ptr<DataPacket> video_packet) {
-  std::shared_ptr<DataPacket> copied_packet = std::make_shared<DataPacket>(*video_packet);
-  // TODO(javierc): We should support higher layers, but it requires having an entire pipeline at this point
-  if (!video_packet->belongsToSpatialLayer(0)) {
-    return 0;
-  }
   if (video_source_ssrc_ == 0) {
-    RtpHeader* h = reinterpret_cast<RtpHeader*>(copied_packet->data);
+    RtpHeader* h = reinterpret_cast<RtpHeader*>(video_packet->data);
     video_source_ssrc_ = h->getSSRC();
   }
-  queueData(copied_packet->data, copied_packet->length, VIDEO_PACKET);
+
+  std::shared_ptr<DataPacket> copied_packet = std::make_shared<DataPacket>(*video_packet);
+  copied_packet->type = VIDEO_PACKET;
+  queueDataAsync(copied_packet);
   return 0;
 }
 
 int ExternalOutput::deliverEvent_(MediaEventPtr event) {
-  return 0;
+  auto output_ptr = shared_from_this();
+  worker_->task([output_ptr, event]{
+    if (!output_ptr->pipeline_initialized_) {
+      return;
+    }
+    output_ptr->pipeline_->notifyEvent(event);
+  });
+  return 1;
 }
 
 bool ExternalOutput::initContext() {

--- a/erizo/src/erizo/media/ExternalOutput.h
+++ b/erizo/src/erizo/media/ExternalOutput.h
@@ -59,12 +59,14 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
 
   void notifyUpdateToHandlers() override;
 
+  bool isRecording() { return recording_; }
+
  private:
   std::shared_ptr<Worker> worker_;
   Pipeline::Ptr pipeline_;
   std::unique_ptr<webrtc::UlpfecReceiver> fec_receiver_;
   RtpPacketQueue audio_queue_, video_queue_;
-  bool recording_, inited_;
+  std::atomic<bool> recording_, inited_;
   boost::mutex mtx_;  // a mutex we use to signal our writer thread that data is waiting.
   boost::thread thread_;
   boost::condition_variable cond_;
@@ -136,6 +138,7 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
   void updateAudioCodec(RtpMap map);
   void maybeWriteVideoPacket(char* buf, int len);
   void initializePipeline();
+  void syncClose();
 };
 
 class ExternalOuputWriter : public OutboundHandler {

--- a/erizo/src/erizo/media/ExternalOutput.h
+++ b/erizo/src/erizo/media/ExternalOutput.h
@@ -27,12 +27,6 @@ extern "C" {
 
 namespace erizo {
 
-// Our search state for VP8 frames.
-enum vp8SearchState {
-    kLookingForStart,
-    kLookingForEnd
-};
-
 static constexpr uint64_t kExternalOutputMaxBitrate = 1000000000;
 
 class ExternalOutput : public MediaSink, public RawDataReceiver, public FeedbackSource,
@@ -109,7 +103,6 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
   // Note: VP8 purportedly has two packetization schemes; per-frame and per-partition.  A frame is
   // composed of one or more partitions.  However, we don't seem to be sent anything but partition 0
   // so the second scheme seems not applicable.  Too bad.
-  // vp8SearchState video_search_state_;
   bool need_to_send_fir_;
   std::vector<RtpMap> rtp_mappings_;
   enum AVCodecID video_codec_;

--- a/erizo/src/erizo/media/ExternalOutput.h
+++ b/erizo/src/erizo/media/ExternalOutput.h
@@ -11,18 +11,21 @@ extern "C" {
 #include <string>
 
 #include "./MediaDefinitions.h"
+#include "thread/Worker.h"
 #include "rtp/RtpPacketQueue.h"
 #include "webrtc/modules/rtp_rtcp/source/ulpfec_receiver_impl.h"
 #include "media/MediaProcessor.h"
 #include "media/Depacketizer.h"
+#include "./Stats.h"
 #include "lib/Clock.h"
 #include "SdpInfo.h"
+#include "rtp/QualityManager.h"
+#include "pipeline/Handler.h"
+#include "pipeline/HandlerManager.h"
 
 #include "./logger.h"
 
 namespace erizo {
-
-class MediaStream;
 
 // Our search state for VP8 frames.
 enum vp8SearchState {
@@ -30,11 +33,16 @@ enum vp8SearchState {
     kLookingForEnd
 };
 
-class ExternalOutput : public MediaSink, public RawDataReceiver, public FeedbackSource, public webrtc::RtpData {
+static constexpr uint64_t kExternalOutputMaxBitrate = 1000000000;
+
+class ExternalOutput : public MediaSink, public RawDataReceiver, public FeedbackSource,
+                       public webrtc::RtpData, public HandlerManagerListener,
+                       public std::enable_shared_from_this<ExternalOutput> {
   DECLARE_LOGGER();
 
  public:
-  explicit ExternalOutput(const std::string& output_url, const std::vector<RtpMap> rtp_mappings);
+  explicit ExternalOutput(std::shared_ptr<Worker> worker, const std::string& output_url,
+                          const std::vector<RtpMap> rtp_mappings);
   virtual ~ExternalOutput();
   bool init();
   void receiveRawData(const RawDataPacket& packet) override;
@@ -47,7 +55,13 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
 
   void close() override;
 
+  void write(std::shared_ptr<DataPacket> packet);
+
+  void notifyUpdateToHandlers() override;
+
  private:
+  std::shared_ptr<Worker> worker_;
+  Pipeline::Ptr pipeline_;
   std::unique_ptr<webrtc::UlpfecReceiver> fec_receiver_;
   RtpPacketQueue audio_queue_, video_queue_;
   bool recording_, inited_;
@@ -93,7 +107,7 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
   // Note: VP8 purportedly has two packetization schemes; per-frame and per-partition.  A frame is
   // composed of one or more partitions.  However, we don't seem to be sent anything but partition 0
   // so the second scheme seems not applicable.  Too bad.
-  vp8SearchState video_search_state_;
+  // vp8SearchState video_search_state_;
   bool need_to_send_fir_;
   std::vector<RtpMap> rtp_mappings_;
   enum AVCodecID video_codec_;
@@ -102,10 +116,16 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
   std::map<uint, RtpMap> audio_maps_;
   RtpMap video_map_;
   RtpMap audio_map_;
+  bool pipeline_initialized_;
+  std::shared_ptr<Stats> stats_;
+  std::shared_ptr<QualityManager> quality_manager_;
+  std::shared_ptr<HandlerManager> handler_manager_;
 
   bool initContext();
   int sendFirPacket();
+  void asyncTask(std::function<void(std::shared_ptr<ExternalOutput>)> f);
   void queueData(char* buffer, int length, packetType type);
+  void queueDataAsync(std::shared_ptr<DataPacket> copied_packet);
   void sendLoop();
   int deliverAudioData_(std::shared_ptr<DataPacket> audio_packet) override;
   int deliverVideoData_(std::shared_ptr<DataPacket> video_packet) override;
@@ -115,6 +135,32 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
   void updateVideoCodec(RtpMap map);
   void updateAudioCodec(RtpMap map);
   void maybeWriteVideoPacket(char* buf, int len);
+  void initializePipeline();
 };
+
+class ExternalOuputWriter : public OutboundHandler {
+ public:
+  explicit ExternalOuputWriter(std::shared_ptr<ExternalOutput> output) : output_{output} {}
+
+  void enable() override {}
+  void disable() override {}
+
+  std::string getName() override {
+    return "writer";
+  }
+
+  void write(Context *ctx, std::shared_ptr<DataPacket> packet) override {
+    if (auto output = output_.lock()) {
+      output->write(std::move(packet));
+    }
+  }
+
+  void notifyUpdate() override {
+  }
+
+ private:
+  std::weak_ptr<ExternalOutput> output_;
+};
+
 }  // namespace erizo
 #endif  // ERIZO_SRC_ERIZO_MEDIA_EXTERNALOUTPUT_H_

--- a/erizo/src/erizo/pipeline/HandlerManager.h
+++ b/erizo/src/erizo/pipeline/HandlerManager.h
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2016, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+#ifndef ERIZO_SRC_ERIZO_PIPELINE_HANDLERMANAGER_H_
+#define ERIZO_SRC_ERIZO_PIPELINE_HANDLERMANAGER_H_
+
+#include "pipeline/Service.h"
+
+namespace erizo {
+
+class HandlerManagerListener {
+ public:
+  virtual ~HandlerManagerListener() = default;
+
+  virtual void notifyUpdateToHandlers() = 0;
+};
+
+class HandlerManager : public Service {
+ public:
+  explicit HandlerManager(std::weak_ptr<HandlerManagerListener> listener) : listener_{listener} {}
+  virtual ~HandlerManager() = default;
+
+  void notifyUpdateToHandlers() {
+    if (auto listener = listener_.lock()) {
+      listener->notifyUpdateToHandlers();
+    }
+  }
+ private:
+  std::weak_ptr<HandlerManagerListener> listener_;
+};
+}  // namespace erizo
+
+#endif  // ERIZO_SRC_ERIZO_PIPELINE_HANDLERMANAGER_H_

--- a/erizo/src/erizo/pipeline/HandlerManager.h
+++ b/erizo/src/erizo/pipeline/HandlerManager.h
@@ -1,12 +1,3 @@
-/*
- *  Copyright (c) 2016, Facebook, Inc.
- *  All rights reserved.
- *
- *  This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree. An additional grant
- *  of patent rights can be found in the PATENTS file in the same directory.
- *
- */
 #ifndef ERIZO_SRC_ERIZO_PIPELINE_HANDLERMANAGER_H_
 #define ERIZO_SRC_ERIZO_PIPELINE_HANDLERMANAGER_H_
 

--- a/erizo/src/erizo/rtp/QualityFilterHandler.cpp
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.cpp
@@ -192,19 +192,18 @@ void QualityFilterHandler::notifyUpdate() {
     max_video_bw_ = processor->getMaxVideoBW();
   }
 
-  if (initialized_) {
-    return;
+  stream_ = pipeline->getService<MediaStream>().get();
+  if (stream_) {
+    video_sink_ssrc_ = stream_->getVideoSinkSSRC();
+    video_source_ssrc_ = stream_->getVideoSourceSSRC();
   }
 
-  stream_ = pipeline->getService<MediaStream>().get();
-  if (!stream_) {
+  if (initialized_) {
     return;
   }
 
   quality_manager_ = pipeline->getService<QualityManager>();
 
-  video_sink_ssrc_ = stream_->getVideoSinkSSRC();
-  video_source_ssrc_ = stream_->getVideoSourceSSRC();
   initialized_ = true;
 }
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -1,7 +1,7 @@
 #include "rtp/QualityManager.h"
 #include <memory>
 
-#include "MediaStream.h"
+#include "pipeline/HandlerManager.h"
 #include "rtp/LayerDetectorHandler.h"
 
 namespace erizo {
@@ -157,9 +157,9 @@ void QualityManager::selectLayer(bool try_higher_layers) {
     if (below_min_layer || try_higher_layers) {
       slideshow_mode_active_ = below_min_layer;
       ELOG_DEBUG("Slideshow fallback mode %d", slideshow_mode_active_);
-      MediaStream *media_stream = getContext()->getPipelineShared()->getService<MediaStream>().get();
-      if (media_stream) {
-        media_stream->notifyUpdateToHandlers();
+      HandlerManager *manager = getContext()->getPipelineShared()->getService<HandlerManager>().get();
+      if (manager) {
+        manager->notifyUpdateToHandlers();
       }
     }
   }
@@ -258,7 +258,10 @@ void QualityManager::setTemporalLayer(int temporal_layer) {
 void QualityManager::setPadding(bool enabled) {
   if (padding_enabled_ != enabled) {
     padding_enabled_ = enabled;
-    getContext()->getPipelineShared()->getService<MediaStream>()->notifyUpdateToHandlers();
+    HandlerManager *manager = getContext()->getPipelineShared()->getService<HandlerManager>().get();
+    if (manager) {
+      manager->notifyUpdateToHandlers();
+    }
   }
 }
 

--- a/erizoAPI/ExternalOutput.cc
+++ b/erizoAPI/ExternalOutput.cc
@@ -23,6 +23,9 @@ class AsyncCloser : public Nan::AsyncWorker {
     ~AsyncCloser() {}
     void Execute() {
       external_output_->close();
+      while (external_output_->isRecording()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }
     }
     void HandleOKCallback() {
       Nan::HandleScope scope;

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -416,27 +416,25 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
                 log.info('message: Removing subscriber, id: ' + subscriber.wrtcId);
                 closeWebRtcConnection(subscriber);
             }
-            for (let externalOutputKey in publisher.externalOutputs) {
-                log.info('message: Removing externalOutput, id ' + externalOutputKey);
-                publisher.removeExternalOutput(externalOutputKey);
-            }
-            closeWebRtcConnection(publisher.wrtc);
-            publisher.muxer.close(function(message) {
-                log.info('message: muxer closed succesfully, ' +
-                         'id: ' + from + ', ' +
-                         logger.objectToLog(message));
-                delete publishers[from];
-                var count = 0;
-                for (var k in publishers) {
-                    if (publishers.hasOwnProperty(k)) {
-                        ++count;
-                    }
-                }
-                log.debug('message: remaining publishers, publisherCount: ' + count);
-                if (count === 0)  {
-                    log.info('message: Removed all publishers. Killing process.');
-                    process.exit(0);
-                }
+            publisher.removeExternalOutputs().then(function() {
+              closeWebRtcConnection(publisher.wrtc);
+              publisher.muxer.close(function(message) {
+                  log.info('message: muxer closed succesfully, ' +
+                           'id: ' + from + ', ' +
+                           logger.objectToLog(message));
+                  delete publishers[from];
+                  var count = 0;
+                  for (var k in publishers) {
+                      if (publishers.hasOwnProperty(k)) {
+                          ++count;
+                      }
+                  }
+                  log.debug('message: remaining publishers, publisherCount: ' + count);
+                  if (count === 0)  {
+                      log.info('message: Removed all publishers. Killing process.');
+                      process.exit(0);
+                  }
+              });
             });
 
         } else {

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -87,7 +87,7 @@ class Source {
   addExternalOutput(url, options) {
     var eoId = url + '_' + this.id;
     log.info('message: Adding ExternalOutput, id: ' + eoId);
-    var externalOutput = new addon.ExternalOutput(url,
+    var externalOutput = new addon.ExternalOutput(this.threadPool, url,
       Helpers.getMediaConfiguration(options.mediaConfiguration));
     externalOutput.wrtcId = eoId;
     externalOutput.init();

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -96,12 +96,23 @@ class Source {
   }
 
   removeExternalOutput(url) {
-    var self = this;
-    this.muxer.removeSubscriber(url);
-    this.externalOutputs[url].close(function() {
-      log.info('message: ExternalOutput closed');
-      delete self.externalOutputs[url];
-    });
+    return new Promise(function(resolve, reject) {
+      this.muxer.removeSubscriber(url);
+      this.externalOutputs[url].close(function() {
+        log.info('message: ExternalOutput closed');
+        delete this.externalOutputs[url];
+        resolve();
+      });
+    }.bind(this));
+  }
+
+  removeExternalOutputs() {
+    const promises = [];
+    for (let externalOutputKey in this.externalOutputs) {
+        log.info('message: Removing externalOutput, id ' + externalOutputKey);
+        promises.push(this.removeExternalOutput(externalOutputKey));
+    }
+    return Promise.all(promises);
   }
 
   hasExternalOutput(url) {

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -96,7 +96,7 @@ class Source {
   }
 
   removeExternalOutput(url) {
-    return new Promise(function(resolve, reject) {
+    return new Promise(function(resolve) {
       this.muxer.removeSubscriber(url);
       this.externalOutputs[url].close(function() {
         log.info('message: ExternalOutput closed');

--- a/erizo_controller/test/erizoJS/erizoJSController.js
+++ b/erizo_controller/test/erizoJS/erizoJSController.js
@@ -488,19 +488,19 @@ describe('Erizo JS Controller', function() {
       });
 
       it('should succeed closing WebRtcConnection and OneToManyProcessor', function() {
-        controller.removePublisher(kArbitraryId);
-
-        expect(mocks.WebRtcConnection.close.callCount).to.equal(1);
-        expect(mocks.OneToManyProcessor.close.callCount).to.equal(1);
+        controller.removePublisher(kArbitraryId).then(function() {
+          expect(mocks.WebRtcConnection.close.callCount).to.equal(1);
+          expect(mocks.OneToManyProcessor.close.callCount).to.equal(1);
+        });
       });
 
       it('should fail closing an unknown Publisher', function() {
         var kArbitraryUnknownId = 'unknownId';
 
-        controller.removePublisher(kArbitraryUnknownId);
-
-        expect(mocks.WebRtcConnection.close.callCount).to.equal(0);
-        expect(mocks.OneToManyProcessor.close.callCount).to.equal(0);
+        controller.removePublisher(kArbitraryUnknownId).then(function() {
+          expect(mocks.WebRtcConnection.close.callCount).to.equal(0);
+          expect(mocks.OneToManyProcessor.close.callCount).to.equal(0);
+        });
       });
 
       it('should succeed closing also Subscribers', function() {
@@ -509,10 +509,10 @@ describe('Erizo JS Controller', function() {
         var subCallback = sinon.stub();
         controller.addSubscriber(kArbitraryId2, kArbitraryId, {}, subCallback);
 
-        controller.removePublisher(kArbitraryId);
-
-        expect(mocks.WebRtcConnection.close.callCount).to.equal(2);
-        expect(mocks.OneToManyProcessor.close.callCount).to.equal(1);
+        controller.removePublisher(kArbitraryId).then(function() {
+          expect(mocks.WebRtcConnection.close.callCount).to.equal(2);
+          expect(mocks.OneToManyProcessor.close.callCount).to.equal(1);
+        });
       });
     });
   });

--- a/erizo_controller/test/erizoJS/erizoJSController.js
+++ b/erizo_controller/test/erizoJS/erizoJSController.js
@@ -105,7 +105,7 @@ describe('Erizo JS Controller', function() {
 
     it('should succeed creating ExternalOutput', function() {
       controller.addExternalOutput(kArbitraryEiId, kArbitraryEoUrl, kArbitraryEoOptions);
-      expect(erizoApiMock.ExternalOutput.args[0][0]).to.equal(kArbitraryEoUrl);
+      expect(erizoApiMock.ExternalOutput.args[0][1]).to.equal(kArbitraryEoUrl);
       expect(erizoApiMock.ExternalOutput.callCount).to.equal(1);
       expect(mocks.ExternalOutput.wrtcId).to.equal(kArbitraryEoUrl + '_' + kArbitraryEiId);
       expect(mocks.OneToManyProcessor.addExternalOutput.args[0]).to.deep.


### PR DESCRIPTION
**Description**

It adds a new worker + pipeline to ExternalOutput, so that we can handle simulcast layers and filter them. Now we record the higher available layer, but we might want to create an API in the future to record the lower or any intermediate layers instead.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.