### PR TITLE
Fix calls to updateSpec function that caused failing ICE connections

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -47,7 +47,7 @@ WebRtcConnection::WebRtcConnection(std::shared_ptr<Worker> worker, std::shared_p
     ice_config_{ice_config}, rtp_mappings_{rtp_mappings}, extension_processor_{ext_mappings},
     worker_{worker}, io_worker_{io_worker},
     remote_sdp_{std::make_shared<SdpInfo>(rtp_mappings)}, local_sdp_{std::make_shared<SdpInfo>(rtp_mappings)},
-    audio_muted_{false}, video_muted_{false}
+    audio_muted_{false}, video_muted_{false}, remote_sdp_processed_{false}
     {
   ELOG_INFO("%s message: constructor, stunserver: %s, stunPort: %d, minPort: %d, maxPort: %d",
       toLog(), ice_config.stun_server.c_str(), ice_config.stun_port, ice_config.min_port, ice_config.max_port);
@@ -186,6 +186,11 @@ bool WebRtcConnection::setRemoteSdp(const std::string &sdp) {
 
 bool WebRtcConnection::processRemoteSdp() {
   ELOG_DEBUG("%s message: processing remote SDP", toLog());
+  if (remote_sdp_processed_) {
+    media_stream_->setRemoteSdp(remote_sdp_);
+    return true;
+  }
+
   bundle_ = remote_sdp_->isBundle;
   local_sdp_->setOfferSdp(remote_sdp_);
   extension_processor_.setSdpInfo(local_sdp_);
@@ -261,6 +266,7 @@ bool WebRtcConnection::processRemoteSdp() {
 
   media_stream_->setRemoteSdp(remote_sdp_);
   media_stream_->setLocalSdp(local_sdp_);
+  remote_sdp_processed_ = true;
   return true;
 }
 

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -182,6 +182,7 @@ class WebRtcConnection: public TransportListener, public LogContext,
   std::shared_ptr<SdpInfo> local_sdp_;
   bool audio_muted_;
   bool video_muted_;
+  bool remote_sdp_processed_;
 };
 
 }  // namespace erizo


### PR DESCRIPTION
**Description**

We were having ICE fail connections after having been successfully established. The issue was that we were setting again ICE credentials when Erizo received a new SDP, and the underlying ICE library set that status to fail.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

[] It includes documentation for these changes in `/doc`.