### PR TITLE
set a default mediaConfiguration to avoid addon crash

### DIFF
--- a/nuve/nuveAPI/resource/tokensResource.js
+++ b/nuve/nuveAPI/resource/tokensResource.js
@@ -64,6 +64,7 @@ var generateToken = function (req, callback) {
     token.role = role;
     token.service = currentService._id;
     token.creationDate = new Date();
+    token.mediaConfiguration = 'default';
     if (typeof currentRoom.mediaConfiguration === 'string') {
       token.mediaConfiguration = currentRoom.mediaConfiguration;
     }


### PR DESCRIPTION
I think we need to set a default mediaConfiguration in case is not passed when creating token

[] It needs and includes Unit Tests
[] It includes documentation for these changes in `/doc`.