### PR TITLE
Fix screensharing when loading ErizoClient in an Electron App

### DIFF
--- a/erizo_controller/erizoClient/src/Connection.js
+++ b/erizo_controller/erizoClient/src/Connection.js
@@ -77,7 +77,8 @@ const GetUserMedia = (config, callback = () => {}, error = () => {}) => {
         screenConfig = {};
         screenConfig.video = config.video || {};
         screenConfig.video.mandatory = config.video.mandatory || {};
-        screenConfig.video.mandatory.chromeMediaSource = 'screen';
+        screenConfig.video.mandatory.chromeMediaSource = 'desktop';
+        screenConfig.video.mandatory.chromeMediaSourceId = config.desktopStreamId;
         getUserMedia(screenConfig, callback, error);
         break;
       case 'mozilla':


### PR DESCRIPTION
**Description**

We were not using the selected window/screen in Electron apps.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.