### PR TITLE
Fix Firefox 59

### DIFF
--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -52,7 +52,7 @@ namespace erizo {
 
 
   SdpInfo::SdpInfo(const std::vector<RtpMap> rtp_mappings) : internalPayloadVector_{rtp_mappings} {
-    session_counter = 0;
+    session_version = 0;
     isBundle = false;
     isRtcpMux = false;
     isFingerprint = false;
@@ -170,7 +170,7 @@ namespace erizo {
     ELOG_DEBUG("Getting SDP");
 
     std::ostringstream sdp;
-    sdp << "v=0\n" << "o=- 0 " << session_counter << " IN IP4 127.0.0.1\n";
+    sdp << "v=0\n" << "o=- 0 " << session_version << " IN IP4 127.0.0.1\n";
     sdp << "s=" << SDP_IDENTIFIER << "\n";
     sdp << "t=0 0\n";
 
@@ -1251,12 +1251,12 @@ namespace erizo {
     }
   }
 
-  int SdpInfo::getSessionCounter() const {
-    return session_counter;
+  int SdpInfo::getSessionVersion() const {
+    return session_version;
   }
 
-  void SdpInfo::setSessionCounter(int counter) {
-    session_counter = counter;
+  void SdpInfo::setSessionVersion(int counter) {
+    session_version = counter;
   }
 
   void SdpInfo::setFirstMediaReceived(MediaType media) {

--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -66,6 +66,7 @@ namespace erizo {
     videoSdpMLine = -1;
     audioSdpMLine = -1;
     videoBandwidth = 0;
+    first_media_received_ = MediaType::OTHER;
   }
 
   SdpInfo::~SdpInfo() {
@@ -190,279 +191,292 @@ namespace erizo {
     // candidates audio
     bool printedAudio = true, printedVideo = true;
 
-    if (printedAudio && this->hasAudio) {
-      sdp << "m=audio 1";
-      if (profile == SAVPF) {
-        sdp << " UDP/TLS/RTP/SAVPF ";
-      } else {
-        sdp << " RTP/AVPF ";  // << "103 104 0 8 106 105 13 126\n"
-      }
-
-      int codecCounter = 0;
-      for (unsigned int it = 0; it < payloadVector.size(); it++) {
-        const RtpMap& payload_info = payloadVector[it];
-        if (payload_info.media_type == AUDIO_TYPE) {
-          codecCounter++;
-          sdp << payload_info.payload_type << ((codecCounter < audioCodecs) ? " " : "");
-        }
-      }
-
-      sdp << "\n"
-          << "c=IN IP4 0.0.0.0" << endl;
-      if (isRtcpMux) {
-        sdp << "a=rtcp:1 IN IP4 0.0.0.0" << endl;
-      }
-      for (unsigned int it = 0; it < candidateVector_.size(); it++) {
-        if (candidateVector_[it].mediaType == AUDIO_TYPE || isBundle)
-          sdp << this->stringifyCandidate(candidateVector_[it]) << endl;
-      }
-      if (iceAudioUsername_.size() > 0) {
-        sdp << "a=ice-ufrag:" << iceAudioUsername_ << endl;
-        sdp << "a=ice-pwd:" << iceAudioPassword_ << endl;
-      } else {
-        sdp << "a=ice-ufrag:" << iceVideoUsername_ << endl;
-        sdp << "a=ice-pwd:" << iceVideoPassword_ << endl;
-      }
-      // sdp << "a=ice-options:google-ice" << endl;
-      if (isFingerprint) {
-        sdp << "a=fingerprint:sha-256 "<< fingerprint << endl;
-      }
-      switch (dtlsRole) {
-        case ACTPASS:
-          sdp << "a=setup:actpass"<< endl;
-          break;
-        case PASSIVE:
-          sdp << "a=setup:passive"<< endl;
-          break;
-        case ACTIVE:
-          sdp << "a=setup:active"<< endl;
-          break;
-      }
-      switch (this->audioDirection) {
-        case SENDONLY:
-          sdp << "a=sendonly" << endl;
-          break;
-        case SENDRECV:
-          sdp << "a=sendrecv" << endl;
-          break;
-        case RECVONLY:
-          sdp << "a=recvonly" << endl;
-          break;
-      }
-
-      ELOG_DEBUG("Writing Extmap for AUDIO %lu", extMapVector.size());
-      for (uint8_t i = 0; i < extMapVector.size(); i++) {
-        if (extMapVector[i].mediaType == AUDIO_TYPE && isValidExtension(std::string(extMapVector[i].uri))) {
-          sdp << "a=extmap:" << extMapVector[i].value << " " << extMapVector[i].uri << endl;
-        }
-      }
-
-      if (bundleTags.size() > 2) {
-        ELOG_WARN("More bundleTags than supported, expect unexpected behaviour");
-      }
-      for (uint8_t i = 0; i < bundleTags.size(); i++) {
-        if (bundleTags[i].mediaType == AUDIO_TYPE) {
-          sdp << "a=mid:" << bundleTags[i].id << endl;
-        }
-      }
-      if (isRtcpMux)
-        sdp << "a=rtcp-mux\n";
-      for (unsigned int it = 0; it < cryptoVector_.size(); it++) {
-        const CryptoInfo& cryp_info = cryptoVector_[it];
-        if (cryp_info.mediaType == AUDIO_TYPE) {
-          sdp << "a=crypto:" << cryp_info.tag << " "
-            << cryp_info.cipherSuite << " " << "inline:"
-            << cryp_info.keyParams << endl;
-        }
-      }
-
-      for (unsigned int it = 0; it < payloadVector.size(); it++) {
-        const RtpMap& rtp = payloadVector[it];
-        if (rtp.media_type == AUDIO_TYPE) {
-          int payload_type = rtp.payload_type;
-          if (rtp.channels > 1) {
-            sdp << "a=rtpmap:"<< payload_type << " " << rtp.encoding_name << "/"
-              << rtp.clock_rate << "/" << rtp.channels << endl;
-          } else {
-            sdp << "a=rtpmap:"<< payload_type << " " << rtp.encoding_name << "/"
-              << rtp.clock_rate << endl;
-          }
-          if (!rtp.feedback_types.empty()) {
-            for (unsigned int itFb = 0; itFb < rtp.feedback_types.size(); itFb++) {
-              sdp << "a=rtcp-fb:" << payload_type << " " << rtp.feedback_types[itFb] << "\n";
-            }
-          }
-          if (!rtp.format_parameters.empty()) {
-            std::string fmtp_line;
-            for (std::map<std::string, std::string>::const_iterator theIt = rtp.format_parameters.begin();
-                theIt != rtp.format_parameters.end(); theIt++) {
-              if (theIt->first.compare("none")) {
-                fmtp_line += theIt->first + "=" + theIt->second + ';';
-              } else {
-                fmtp_line += theIt->second + ';';
-              }
-            }
-            fmtp_line.pop_back();
-            sdp << "a=fmtp:" << payload_type << " " << fmtp_line << std::endl;
-          }
-        }
-      }
-
-      if (audio_ssrc == 0) {
-        audio_ssrc = 44444;
-      }
-      if (audioDirection != RECVONLY) {
-        sdp << "a=ssrc:" << audio_ssrc << " cname:o/i14u9pJrxRKAsu" << endl <<
-          "a=ssrc:"<< audio_ssrc << " msid:"<< msidtemp << " a0"<< endl <<
-          "a=ssrc:"<< audio_ssrc << " mslabel:"<< msidtemp << endl <<
-          "a=ssrc:"<< audio_ssrc << " label:" << msidtemp << "a0" << endl;
-      }
+    if (first_media_received_ == MediaType::AUDIO_TYPE) {
+      printAudio(sdp, msidtemp, printedAudio);
+      printVideo(sdp, msidtemp, printedVideo);
+    } else if (first_media_received_ == MediaType::VIDEO_TYPE) {
+      printVideo(sdp, msidtemp, printedVideo);
+      printAudio(sdp, msidtemp, printedAudio);
     }
 
-    if (printedVideo && this->hasVideo) {
-      sdp << "m=video 1";
-      if (profile == SAVPF) {
-        sdp << " UDP/TLS/RTP/SAVPF ";
-      } else {
-        sdp << " RTP/AVPF ";
-      }
-
-      int codecCounter = 0;
-      for (unsigned int it = 0; it < payloadVector.size(); it++) {
-        const RtpMap& payload_info = payloadVector[it];
-        if (payload_info.media_type == VIDEO_TYPE) {
-          codecCounter++;
-          sdp << payload_info.payload_type << ((codecCounter < videoCodecs) ? " " : "");
-        }
-      }
-
-      sdp << "\n" << "c=IN IP4 0.0.0.0" << endl;
-      if (isRtcpMux) {
-        sdp << "a=rtcp:1 IN IP4 0.0.0.0" << endl;
-      }
-      for (unsigned int it = 0; it < candidateVector_.size(); it++) {
-        if (candidateVector_[it].mediaType == VIDEO_TYPE)
-          sdp << this->stringifyCandidate(candidateVector_[it]) << endl;
-      }
-
-      sdp << "a=ice-ufrag:" << iceVideoUsername_ << endl;
-      sdp << "a=ice-pwd:" << iceVideoPassword_ << endl;
-      // sdp << "a=ice-options:google-ice" << endl;
-
-      ELOG_DEBUG("Writing Extmap for VIDEO %lu", extMapVector.size());
-      for (uint8_t i = 0; i < extMapVector.size(); i++) {
-        if (extMapVector[i].mediaType == VIDEO_TYPE && isValidExtension(std::string(extMapVector[i].uri))) {
-          sdp << "a=extmap:" << extMapVector[i].value << " " << extMapVector[i].uri << endl;
-        }
-      }
-
-      if (isFingerprint) {
-        sdp << "a=fingerprint:sha-256 "<< fingerprint << endl;
-      }
-      switch (dtlsRole) {
-        case ACTPASS:
-          sdp << "a=setup:actpass"<< endl;
-          break;
-        case PASSIVE:
-          sdp << "a=setup:passive"<< endl;
-          break;
-        case ACTIVE:
-          sdp << "a=setup:active"<< endl;
-          break;
-      }
-      switch (this->videoDirection) {
-        case SENDONLY:
-          sdp << "a=sendonly" << endl;
-          break;
-        case SENDRECV:
-          sdp << "a=sendrecv" << endl;
-          break;
-        case RECVONLY:
-          sdp << "a=recvonly" << endl;
-          break;
-      }
-      for (uint8_t i = 0; i < bundleTags.size(); i++) {
-        if (bundleTags[i].mediaType == VIDEO_TYPE) {
-          sdp << "a=mid:" << bundleTags[i].id << endl;
-        }
-      }
-      if (isRtcpMux)
-        sdp << "a=rtcp-mux\n";
-      for (unsigned int it = 0; it < cryptoVector_.size(); it++) {
-        const CryptoInfo& cryp_info = cryptoVector_[it];
-        if (cryp_info.mediaType == VIDEO_TYPE) {
-          sdp << "a=crypto:" << cryp_info.tag << " "
-            << cryp_info.cipherSuite << " " << "inline:"
-            << cryp_info.keyParams << endl;
-        }
-      }
-
-      for (const auto rid : rids()) {
-        sdp << "a=rid:" << rid.id << " " << rid.direction << "\n";
-      }
-
-      for (unsigned int it = 0; it < payloadVector.size(); it++) {
-        const RtpMap& rtp = payloadVector[it];
-        if (rtp.media_type == VIDEO_TYPE) {
-          int payload_type = rtp.payload_type;
-          sdp << "a=rtpmap:" << payload_type << " " << rtp.encoding_name << "/"
-              << rtp.clock_rate <<"\n";
-          if (!rtp.feedback_types.empty()) {
-            for (unsigned int itFb = 0; itFb < rtp.feedback_types.size(); itFb++) {
-              sdp << "a=rtcp-fb:" << payload_type << " " << rtp.feedback_types[itFb] << "\n";
-            }
-          }
-          if (!rtp.format_parameters.empty()) {
-            std::string fmtp_line;
-            for (std::map<std::string, std::string>::const_iterator theIt = rtp.format_parameters.begin();
-                theIt != rtp.format_parameters.end(); theIt++) {
-              if (theIt->first.compare("none")) {
-                fmtp_line += theIt->first + "=" + theIt->second + ';';
-              } else {
-                fmtp_line += theIt->second + ';';
-              }
-            }
-            fmtp_line.pop_back();
-            sdp << "a=fmtp:" << payload_type << " " << fmtp_line << std::endl;
-          }
-        }
-      }
-      if (video_ssrc_list.empty()) {
-        video_ssrc_list.push_back(55543);
-      }
-
-      if (!rids().empty()) {
-        sdp << "a=simulcast: " << rids()[0].direction << " rid=";
-        for (unsigned i = 0; i < rids().size(); ++i) {
-          sdp << rids()[i].id;
-          if (i < rids().size() - 1) {
-            sdp << ';';
-          }
-        }
-        sdp << '\n';
-      }
-
-      if (videoDirection != RECVONLY) {
-        std::for_each(video_ssrc_list.begin(), video_ssrc_list.end(),
-            [&sdp, &msidtemp](uint32_t &video_ssrc){
-            sdp << "a=ssrc:" << video_ssrc << " cname:o/i14u9pJrxRKAsu" << endl <<
-            "a=ssrc:" << video_ssrc << " msid:"<< msidtemp << " v0"<< endl <<
-            "a=ssrc:" << video_ssrc << " mslabel:"<< msidtemp << endl <<
-            "a=ssrc:" << video_ssrc << " label:" << msidtemp << "v0" << endl;
-            });
-        /* TODO(pedro)  properly encode FID groups in sdp when supported
-        std::for_each(video_rtx_ssrc_map.begin(), video_rtx_ssrc_map.end(),
-            [&sdp, &msidtemp](uint32_t &video_rtx_ssrc){
-            sdp << "a=ssrc:" << video_rtx_ssrc << " cname:o/i14u9pJrxRKAsu" << endl <<
-            "a=ssrc:" << video_rtx_ssrc << " msid:"<< msidtemp << " v0"<< endl <<
-            "a=ssrc:" << video_rtx_ssrc << " mslabel:"<< msidtemp << endl <<
-            "a=ssrc:" << video_rtx_ssrc << " label:" << msidtemp << "v0" << endl;
-            });
-        */
-      }
-    }
     ELOG_DEBUG("sdp local \n %s", sdp.str().c_str());
     return sdp.str();
+  }
+
+  void SdpInfo::printAudio(std::ostringstream& sdp, char (&msidtemp)[11], bool printedAudio) {
+      if (printedAudio && this->hasAudio) {
+        sdp << "m=audio 1";
+        if (profile == SAVPF) {
+          sdp << " UDP/TLS/RTP/SAVPF ";
+        } else {
+          sdp << " RTP/AVPF ";  // << "103 104 0 8 106 105 13 126\n"
+        }
+
+        int codecCounter = 0;
+        for (unsigned int it = 0; it < payloadVector.size(); it++) {
+          const RtpMap& payload_info = payloadVector[it];
+          if (payload_info.media_type == AUDIO_TYPE) {
+            codecCounter++;
+            sdp << payload_info.payload_type << ((codecCounter < audioCodecs) ? " " : "");
+          }
+        }
+
+        sdp << "\n"
+            << "c=IN IP4 0.0.0.0" << endl;
+        if (isRtcpMux) {
+          sdp << "a=rtcp:1 IN IP4 0.0.0.0" << endl;
+        }
+        for (unsigned int it = 0; it < candidateVector_.size(); it++) {
+          if (candidateVector_[it].mediaType == AUDIO_TYPE || isBundle)
+            sdp << this->stringifyCandidate(candidateVector_[it]) << endl;
+        }
+        if (iceAudioUsername_.size() > 0) {
+          sdp << "a=ice-ufrag:" << iceAudioUsername_ << endl;
+          sdp << "a=ice-pwd:" << iceAudioPassword_ << endl;
+        } else {
+          sdp << "a=ice-ufrag:" << iceVideoUsername_ << endl;
+          sdp << "a=ice-pwd:" << iceVideoPassword_ << endl;
+        }
+        // sdp << "a=ice-options:google-ice" << endl;
+        if (isFingerprint) {
+          sdp << "a=fingerprint:sha-256 "<< fingerprint << endl;
+        }
+        switch (dtlsRole) {
+          case ACTPASS:
+            sdp << "a=setup:actpass"<< endl;
+            break;
+          case PASSIVE:
+            sdp << "a=setup:passive"<< endl;
+            break;
+          case ACTIVE:
+            sdp << "a=setup:active"<< endl;
+            break;
+        }
+        switch (this->audioDirection) {
+          case SENDONLY:
+            sdp << "a=sendonly" << endl;
+            break;
+          case SENDRECV:
+            sdp << "a=sendrecv" << endl;
+            break;
+          case RECVONLY:
+            sdp << "a=recvonly" << endl;
+            break;
+        }
+
+        ELOG_DEBUG("Writing Extmap for AUDIO %lu", extMapVector.size());
+        for (uint8_t i = 0; i < extMapVector.size(); i++) {
+          if (extMapVector[i].mediaType == AUDIO_TYPE && isValidExtension(std::string(extMapVector[i].uri))) {
+            sdp << "a=extmap:" << extMapVector[i].value << " " << extMapVector[i].uri << endl;
+          }
+        }
+
+        if (bundleTags.size() > 2) {
+          ELOG_WARN("More bundleTags than supported, expect unexpected behaviour");
+        }
+        for (uint8_t i = 0; i < bundleTags.size(); i++) {
+          if (bundleTags[i].mediaType == AUDIO_TYPE) {
+            sdp << "a=mid:" << bundleTags[i].id << endl;
+          }
+        }
+        if (isRtcpMux)
+          sdp << "a=rtcp-mux\n";
+        for (unsigned int it = 0; it < cryptoVector_.size(); it++) {
+          const CryptoInfo& cryp_info = cryptoVector_[it];
+          if (cryp_info.mediaType == AUDIO_TYPE) {
+            sdp << "a=crypto:" << cryp_info.tag << " "
+              << cryp_info.cipherSuite << " " << "inline:"
+              << cryp_info.keyParams << endl;
+          }
+        }
+
+        for (unsigned int it = 0; it < payloadVector.size(); it++) {
+          const RtpMap& rtp = payloadVector[it];
+          if (rtp.media_type == AUDIO_TYPE) {
+            int payload_type = rtp.payload_type;
+            if (rtp.channels > 1) {
+              sdp << "a=rtpmap:"<< payload_type << " " << rtp.encoding_name << "/"
+                << rtp.clock_rate << "/" << rtp.channels << endl;
+            } else {
+              sdp << "a=rtpmap:"<< payload_type << " " << rtp.encoding_name << "/"
+                << rtp.clock_rate << endl;
+            }
+            if (!rtp.feedback_types.empty()) {
+              for (unsigned int itFb = 0; itFb < rtp.feedback_types.size(); itFb++) {
+                sdp << "a=rtcp-fb:" << payload_type << " " << rtp.feedback_types[itFb] << "\n";
+              }
+            }
+            if (!rtp.format_parameters.empty()) {
+              std::string fmtp_line;
+              for (std::map<std::string, std::string>::const_iterator theIt = rtp.format_parameters.begin();
+                  theIt != rtp.format_parameters.end(); theIt++) {
+                if (theIt->first.compare("none")) {
+                  fmtp_line += theIt->first + "=" + theIt->second + ';';
+                } else {
+                  fmtp_line += theIt->second + ';';
+                }
+              }
+              fmtp_line.pop_back();
+              sdp << "a=fmtp:" << payload_type << " " << fmtp_line << std::endl;
+            }
+          }
+        }
+
+        if (audio_ssrc == 0) {
+          audio_ssrc = 44444;
+        }
+        if (audioDirection != RECVONLY) {
+          sdp << "a=ssrc:" << audio_ssrc << " cname:o/i14u9pJrxRKAsu" << endl <<
+            "a=ssrc:"<< audio_ssrc << " msid:"<< msidtemp << " a0"<< endl <<
+            "a=ssrc:"<< audio_ssrc << " mslabel:"<< msidtemp << endl <<
+            "a=ssrc:"<< audio_ssrc << " label:" << msidtemp << "a0" << endl;
+        }
+      }
+  }
+
+  void SdpInfo::printVideo(std::ostringstream& sdp, char (&msidtemp)[11], bool printedVideo) {
+      if (printedVideo && this->hasVideo) {
+        sdp << "m=video 1";
+        if (profile == SAVPF) {
+          sdp << " UDP/TLS/RTP/SAVPF ";
+        } else {
+          sdp << " RTP/AVPF ";
+        }
+
+        int codecCounter = 0;
+        for (unsigned int it = 0; it < payloadVector.size(); it++) {
+          const RtpMap& payload_info = payloadVector[it];
+          if (payload_info.media_type == VIDEO_TYPE) {
+            codecCounter++;
+            sdp << payload_info.payload_type << ((codecCounter < videoCodecs) ? " " : "");
+          }
+        }
+
+        sdp << "\n" << "c=IN IP4 0.0.0.0" << endl;
+        if (isRtcpMux) {
+          sdp << "a=rtcp:1 IN IP4 0.0.0.0" << endl;
+        }
+        for (unsigned int it = 0; it < candidateVector_.size(); it++) {
+          if (candidateVector_[it].mediaType == VIDEO_TYPE)
+            sdp << this->stringifyCandidate(candidateVector_[it]) << endl;
+        }
+
+        sdp << "a=ice-ufrag:" << iceVideoUsername_ << endl;
+        sdp << "a=ice-pwd:" << iceVideoPassword_ << endl;
+        // sdp << "a=ice-options:google-ice" << endl;
+
+        ELOG_DEBUG("Writing Extmap for VIDEO %lu", extMapVector.size());
+        for (uint8_t i = 0; i < extMapVector.size(); i++) {
+          if (extMapVector[i].mediaType == VIDEO_TYPE && isValidExtension(std::string(extMapVector[i].uri))) {
+            sdp << "a=extmap:" << extMapVector[i].value << " " << extMapVector[i].uri << endl;
+          }
+        }
+
+        if (isFingerprint) {
+          sdp << "a=fingerprint:sha-256 "<< fingerprint << endl;
+        }
+        switch (dtlsRole) {
+          case ACTPASS:
+            sdp << "a=setup:actpass"<< endl;
+            break;
+          case PASSIVE:
+            sdp << "a=setup:passive"<< endl;
+            break;
+          case ACTIVE:
+            sdp << "a=setup:active"<< endl;
+            break;
+        }
+        switch (this->videoDirection) {
+          case SENDONLY:
+            sdp << "a=sendonly" << endl;
+            break;
+          case SENDRECV:
+            sdp << "a=sendrecv" << endl;
+            break;
+          case RECVONLY:
+            sdp << "a=recvonly" << endl;
+            break;
+        }
+        for (uint8_t i = 0; i < bundleTags.size(); i++) {
+          if (bundleTags[i].mediaType == VIDEO_TYPE) {
+            sdp << "a=mid:" << bundleTags[i].id << endl;
+          }
+        }
+        if (isRtcpMux)
+          sdp << "a=rtcp-mux\n";
+        for (unsigned int it = 0; it < cryptoVector_.size(); it++) {
+          const CryptoInfo& cryp_info = cryptoVector_[it];
+          if (cryp_info.mediaType == VIDEO_TYPE) {
+            sdp << "a=crypto:" << cryp_info.tag << " "
+              << cryp_info.cipherSuite << " " << "inline:"
+              << cryp_info.keyParams << endl;
+          }
+        }
+
+        for (const auto rid : rids()) {
+          sdp << "a=rid:" << rid.id << " " << rid.direction << "\n";
+        }
+
+        for (unsigned int it = 0; it < payloadVector.size(); it++) {
+          const RtpMap& rtp = payloadVector[it];
+          if (rtp.media_type == VIDEO_TYPE) {
+            int payload_type = rtp.payload_type;
+            sdp << "a=rtpmap:" << payload_type << " " << rtp.encoding_name << "/"
+                << rtp.clock_rate <<"\n";
+            if (!rtp.feedback_types.empty()) {
+              for (unsigned int itFb = 0; itFb < rtp.feedback_types.size(); itFb++) {
+                sdp << "a=rtcp-fb:" << payload_type << " " << rtp.feedback_types[itFb] << "\n";
+              }
+            }
+            if (!rtp.format_parameters.empty()) {
+              std::string fmtp_line;
+              for (std::map<std::string, std::string>::const_iterator theIt = rtp.format_parameters.begin();
+                  theIt != rtp.format_parameters.end(); theIt++) {
+                if (theIt->first.compare("none")) {
+                  fmtp_line += theIt->first + "=" + theIt->second + ';';
+                } else {
+                  fmtp_line += theIt->second + ';';
+                }
+              }
+              fmtp_line.pop_back();
+              sdp << "a=fmtp:" << payload_type << " " << fmtp_line << std::endl;
+            }
+          }
+        }
+        if (video_ssrc_list.empty()) {
+          video_ssrc_list.push_back(55543);
+        }
+
+        if (!rids().empty()) {
+          sdp << "a=simulcast: " << rids()[0].direction << " rid=";
+          for (unsigned i = 0; i < rids().size(); ++i) {
+            sdp << rids()[i].id;
+            if (i < rids().size() - 1) {
+              sdp << ';';
+            }
+          }
+          sdp << '\n';
+        }
+
+        if (videoDirection != RECVONLY) {
+          std::for_each(video_ssrc_list.begin(), video_ssrc_list.end(),
+              [&sdp, &msidtemp](uint32_t &video_ssrc){
+              sdp << "a=ssrc:" << video_ssrc << " cname:o/i14u9pJrxRKAsu" << endl <<
+              "a=ssrc:" << video_ssrc << " msid:"<< msidtemp << " v0"<< endl <<
+              "a=ssrc:" << video_ssrc << " mslabel:"<< msidtemp << endl <<
+              "a=ssrc:" << video_ssrc << " label:" << msidtemp << "v0" << endl;
+              });
+          /* TODO(pedro)  properly encode FID groups in sdp when supported
+          std::for_each(video_rtx_ssrc_map.begin(), video_rtx_ssrc_map.end(),
+              [&sdp, &msidtemp](uint32_t &video_rtx_ssrc){
+              sdp << "a=ssrc:" << video_rtx_ssrc << " cname:o/i14u9pJrxRKAsu" << endl <<
+              "a=ssrc:" << video_rtx_ssrc << " msid:"<< msidtemp << " v0"<< endl <<
+              "a=ssrc:" << video_rtx_ssrc << " mslabel:"<< msidtemp << endl <<
+              "a=ssrc:" << video_rtx_ssrc << " label:" << msidtemp << "v0" << endl;
+              });
+          */
+        }
+      }
   }
 
   RtpMap* SdpInfo::getCodecByExternalPayloadType(const unsigned int payload_type) {
@@ -548,6 +562,7 @@ namespace erizo {
     this->hasAudio = offerSdp->hasAudio;
     this->bundleTags = offerSdp->bundleTags;
     this->extMapVector = offerSdp->extMapVector;
+    this->first_media_received_ = offerSdp->first_media_received_;
     this->rids_ = offerSdp->rids();
     for (auto& rid : rids_) {
       rid.direction = reverse(rid.direction);
@@ -701,12 +716,18 @@ namespace erizo {
         ELOG_DEBUG("sdp has video, mline = %d", videoSdpMLine);
         mtype = VIDEO_TYPE;
         hasVideo = true;
+        if (first_media_received_ == MediaType::OTHER) {
+          first_media_received_ = MediaType::VIDEO_TYPE;
+        }
       }
       if (isAudio != std::string::npos) {
         audioSdpMLine = ++mlineNum;
         ELOG_DEBUG("sdp has audio, mline = %d", audioSdpMLine);
         mtype = AUDIO_TYPE;
         hasAudio = true;
+        if (first_media_received_ == MediaType::OTHER) {
+          first_media_received_ = MediaType::AUDIO_TYPE;
+        }
       }
       if (isCand != std::string::npos) {
         std::vector<std::string> pieces = stringutil::splitOneOf(line, " :");
@@ -1236,6 +1257,14 @@ namespace erizo {
 
   void SdpInfo::setSessionCounter(int counter) {
     session_counter = counter;
+  }
+
+  void SdpInfo::setFirstMediaReceived(MediaType media) {
+    first_media_received_ = media;
+  }
+
+  MediaType SdpInfo::getFirstMediaReceived() const {
+    return first_media_received_;
   }
 
   bool operator==(const Rid& lhs, const Rid& rhs) {

--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -52,6 +52,7 @@ namespace erizo {
 
 
   SdpInfo::SdpInfo(const std::vector<RtpMap> rtp_mappings) : internalPayloadVector_{rtp_mappings} {
+    session_counter = 0;
     isBundle = false;
     isRtcpMux = false;
     isFingerprint = false;
@@ -168,7 +169,7 @@ namespace erizo {
     ELOG_DEBUG("Getting SDP");
 
     std::ostringstream sdp;
-    sdp << "v=0\n" << "o=- 0 0 IN IP4 127.0.0.1\n";
+    sdp << "v=0\n" << "o=- 0 " << session_counter << " IN IP4 127.0.0.1\n";
     sdp << "s=" << SDP_IDENTIFIER << "\n";
     sdp << "t=0 0\n";
 
@@ -1229,8 +1230,16 @@ namespace erizo {
     }
   }
 
+  int SdpInfo::getSessionCounter() const {
+    return session_counter;
+  }
+
+  void SdpInfo::setSessionCounter(int counter) {
+    session_counter = counter;
+  }
+
   bool operator==(const Rid& lhs, const Rid& rhs) {
-  return lhs.id == rhs.id && lhs.direction == rhs.direction;
+    return lhs.id == rhs.id && lhs.direction == rhs.direction;
   }
 
   std::ostream& operator<<(std::ostream& os, RidDirection dir) {

--- a/erizo/src/erizo/SdpInfo.h
+++ b/erizo/src/erizo/SdpInfo.h
@@ -258,11 +258,11 @@ class SdpInfo {
   */
   const std::vector<Rid>& rids() const { return rids_; }
 
-  int getSessionCounter() const;
+  int getSessionVersion() const;
 
-  void setSessionCounter(int counter);
+  void setSessionVersion(int counter);
 
-  int session_counter;
+  int session_version;
   /**
    * The audio and video SSRCs for this particular SDP.
    */

--- a/erizo/src/erizo/SdpInfo.h
+++ b/erizo/src/erizo/SdpInfo.h
@@ -238,6 +238,10 @@ class SdpInfo {
   bool supportPayloadType(const unsigned int payloadType);
 
   void createOfferSdp(bool videoEnabled, bool audioEnabled, bool bundle);
+
+  void setFirstMediaReceived(MediaType media);
+
+  MediaType getFirstMediaReceived() const;
   /**
    * @brief copies relevant information from the offer sdp for which this will be an answer sdp
    * @param offerSdp The offer SDP as received via signaling and parsed
@@ -322,6 +326,7 @@ class SdpInfo {
   int audioSdpMLine;
   int videoCodecs, audioCodecs;
   unsigned int videoBandwidth;
+  MediaType first_media_received_;
   std::vector<CandidateInfo> candidateVector_;
   std::vector<CryptoInfo> cryptoVector_;
   std::vector<RtpMap> internalPayloadVector_;
@@ -337,6 +342,8 @@ class SdpInfo {
   std::string stringifyCandidate(const CandidateInfo & candidate);
   void gen_random(char* s, int len);
   void maybeAddSsrcToList(uint32_t ssrc);
+  void printAudio(std::ostringstream& sdp, char (&msidtemp)[11], bool printedAudio);
+  void printVideo(std::ostringstream& sdp, char (&msidtemp)[11], bool printedVideo);
 };
 }  // namespace erizo
 #endif  // ERIZO_SRC_ERIZO_SDPINFO_H_

--- a/erizo/src/erizo/SdpInfo.h
+++ b/erizo/src/erizo/SdpInfo.h
@@ -254,6 +254,11 @@ class SdpInfo {
   */
   const std::vector<Rid>& rids() const { return rids_; }
 
+  int getSessionCounter() const;
+
+  void setSessionCounter(int counter);
+
+  int session_counter;
   /**
    * The audio and video SSRCs for this particular SDP.
    */

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -47,8 +47,7 @@ WebRtcConnection::WebRtcConnection(std::shared_ptr<Worker> worker, std::shared_p
     ice_config_{ice_config}, rtp_mappings_{rtp_mappings}, extension_processor_{ext_mappings},
     worker_{worker}, io_worker_{io_worker},
     remote_sdp_{std::make_shared<SdpInfo>(rtp_mappings)}, local_sdp_{std::make_shared<SdpInfo>(rtp_mappings)},
-    audio_muted_{false}, video_muted_{false}, remote_sdp_processed_{false}
-    {
+    audio_muted_{false}, video_muted_{false}, remote_sdp_processed_{false}, session_counter_(0) {
   ELOG_INFO("%s message: constructor, stunserver: %s, stunPort: %d, minPort: %d, maxPort: %d",
       toLog(), ice_config.stun_server.c_str(), ice_config.stun_port, ice_config.min_port, ice_config.max_port);
   stats_ = std::make_shared<Stats>();

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -47,7 +47,7 @@ WebRtcConnection::WebRtcConnection(std::shared_ptr<Worker> worker, std::shared_p
     ice_config_{ice_config}, rtp_mappings_{rtp_mappings}, extension_processor_{ext_mappings},
     worker_{worker}, io_worker_{io_worker},
     remote_sdp_{std::make_shared<SdpInfo>(rtp_mappings)}, local_sdp_{std::make_shared<SdpInfo>(rtp_mappings)},
-    audio_muted_{false}, video_muted_{false}, remote_sdp_processed_{false}, session_counter_(0) {
+    audio_muted_{false}, video_muted_{false}, remote_sdp_processed_{false}, session_version_(0) {
   ELOG_INFO("%s message: constructor, stunserver: %s, stunPort: %d, minPort: %d, maxPort: %d",
       toLog(), ice_config.stun_server.c_str(), ice_config.stun_port, ice_config.min_port, ice_config.max_port);
   stats_ = std::make_shared<Stats>();

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -188,6 +188,7 @@ class WebRtcConnection: public TransportListener, public LogContext,
   bool audio_muted_;
   bool video_muted_;
   bool remote_sdp_processed_;
+  int session_counter_;  // keeps track of how many sdp offer/answer cycles have been done
 };
 
 }  // namespace erizo

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -188,7 +188,7 @@ class WebRtcConnection: public TransportListener, public LogContext,
   bool audio_muted_;
   bool video_muted_;
   bool remote_sdp_processed_;
-  int session_version_;  // keeps track of how many sdp offer/answer cycles have been done
+  __attribute__((unused)) int session_version_;  // keeps track of how many sdp offer/answer cycles have been done (to be used in iceRestart)
 };
 
 }  // namespace erizo

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -188,7 +188,7 @@ class WebRtcConnection: public TransportListener, public LogContext,
   bool audio_muted_;
   bool video_muted_;
   bool remote_sdp_processed_;
-  int session_counter_;  // keeps track of how many sdp offer/answer cycles have been done
+  int session_version_;  // keeps track of how many sdp offer/answer cycles have been done
 };
 
 }  // namespace erizo

--- a/erizoAPI/ConnectionDescription.cc
+++ b/erizoAPI/ConnectionDescription.cc
@@ -101,6 +101,10 @@ NAN_MODULE_INIT(ConnectionDescription::Init) {
 
   Nan::SetPrototypeMethod(tpl, "postProcessInfo", postProcessInfo);
 
+  Nan::SetPrototypeMethod(tpl, "getSessionVersion", getSessionVersion);
+  Nan::SetPrototypeMethod(tpl, "getFirstMediaReceived", getFirstMediaReceived);
+  Nan::SetPrototypeMethod(tpl, "setFirstMediaReceived", setFirstMediaReceived);
+
   constructor.Reset(tpl->GetFunction());
   Nan::Set(target, Nan::New("ConnectionDescription").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
 }
@@ -710,6 +714,39 @@ NAN_METHOD(ConnectionDescription::postProcessInfo) {
   GET_SDP();
   bool success = sdp->postProcessInfo();
   info.GetReturnValue().Set(Nan::New(success));
+}
+
+NAN_METHOD(ConnectionDescription::getSessionVersion) {
+  GET_SDP();
+  info.GetReturnValue().Set(Nan::New(sdp->session_version));
+}
+
+NAN_METHOD(ConnectionDescription::getFirstMediaReceived) {
+  GET_SDP();
+  std::string media_type = "audio";
+  switch (sdp->first_media_received_) {
+    case erizo::VIDEO_TYPE:
+      media_type = "video";
+      break;
+    case erizo::AUDIO_TYPE:
+    default:
+      media_type = "audio";
+      break;
+  }
+  info.GetReturnValue().Set(Nan::New(media_type.c_str()).ToLocalChecked());
+}
+
+NAN_METHOD(ConnectionDescription::setFirstMediaReceived) {
+  GET_SDP();
+  std::string media = getString(info[0]);
+
+  if (media == "audio") {
+    sdp->first_media_received_ = erizo::AUDIO_TYPE;
+  } else if (media == "video") {
+    sdp->first_media_received_ = erizo::VIDEO_TYPE;
+  } else {
+    sdp->first_media_received_ = erizo::OTHER;
+  }
 }
 
 NAN_METHOD(ConnectionDescription::close) {

--- a/erizoAPI/ConnectionDescription.h
+++ b/erizoAPI/ConnectionDescription.h
@@ -79,6 +79,10 @@ class ConnectionDescription : public Nan::ObjectWrap {
 
     static NAN_METHOD(postProcessInfo);
 
+    static NAN_METHOD(getSessionVersion);
+    static NAN_METHOD(getFirstMediaReceived);
+    static NAN_METHOD(setFirstMediaReceived);
+
     static Nan::Persistent<v8::Function> constructor;
 };
 

--- a/erizo_controller/erizoClient/src/utils/SdpHelpers.js
+++ b/erizo_controller/erizoClient/src/utils/SdpHelpers.js
@@ -1,3 +1,5 @@
+import Direction from '../../../common/semanticSdp/Direction';
+
 const SdpHelpers = {};
 
 SdpHelpers.addSim = (spatialLayers) => {
@@ -47,6 +49,17 @@ SdpHelpers.enableOpusNacks = (sdpInput) => {
   }
 
   return sdp;
+};
+
+SdpHelpers.forceDirection = (sdp, isSubscribe) => {
+  const direction = isSubscribe ? 'recvonly' : 'sendonly';
+  // TODO this is a temporary fix for Firefox >= 59 where sdp generated are sendrecv
+  // instead of sendonly
+  // Bug associated: https://bugzilla.mozilla.org/show_bug.cgi?id=1433953 comment#3
+  sdp.medias.forEach((media) => {
+    const thisMedia = media;
+    thisMedia.direction = Direction.byValue(direction);
+  });
 };
 
 export default SdpHelpers;

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -92,6 +92,7 @@ const BaseStack = (specInput) => {
       localDesc.sdp = that.enableSimulcast(localDesc.sdp);
     }
     localSdp = SemanticSdp.SDPInfo.processString(localDesc.sdp);
+    SdpHelpers.forceDirection(localSdp, isSubscribe);
     SdpHelpers.setMaxBW(localSdp, specBase);
     localDesc.sdp = localSdp.toString();
 
@@ -104,6 +105,7 @@ const BaseStack = (specInput) => {
   const setLocalDescForAnswerp2p = (sessionDescription) => {
     localDesc = sessionDescription;
     localSdp = SemanticSdp.SDPInfo.processString(localDesc.sdp);
+    SdpHelpers.forceDirection(localSdp, true);
     SdpHelpers.setMaxBW(localSdp, specBase);
     localDesc.sdp = localSdp.toString();
     specBase.callback({

--- a/erizo_controller/erizoJS/models/SessionDescription.js
+++ b/erizo_controller/erizoJS/models/SessionDescription.js
@@ -205,7 +205,7 @@ class SessionDescription {
     sdp.setOrigin({
       username: '-',
       sessionId: 0,
-      sessionVersion: 0,
+      sessionVersion: info.getSessionVersion(),
       netType: 'IN',
       ipVer: 4,
       address: '127.0.0.1' });
@@ -213,15 +213,26 @@ class SessionDescription {
 
     sdp.msidSemantic = { semantic: 'WMS', token: generateRandom(10) };
 
-    if (info.hasAudio()) {
-      const media = getMediaInfoFromDescription(info, sdp, 'audio');
-      sdp.addMedia(media);
+    if (info.getFirstMediaReceived() === 'audio') {
+      if (info.hasAudio()) {
+        const media = getMediaInfoFromDescription(info, sdp, 'audio');
+        sdp.addMedia(media);
+      }
+      if (info.hasVideo()) {
+        const media = getMediaInfoFromDescription(info, sdp, 'video');
+        sdp.addMedia(media);
+      }
+    } else {
+      if (info.hasVideo()) {
+        const media = getMediaInfoFromDescription(info, sdp, 'video');
+        sdp.addMedia(media);
+      }
+      if (info.hasAudio()) {
+        const media = getMediaInfoFromDescription(info, sdp, 'audio');
+        sdp.addMedia(media);
+      }
     }
 
-    if (info.hasVideo()) {
-      const media = getMediaInfoFromDescription(info, sdp, 'video');
-      sdp.addMedia(media);
-    }
 
     this.sdp = sdp;
 
@@ -251,7 +262,7 @@ class SessionDescription {
       info.setDtlsRole(Setup.toString(dtls.getSetup()));
     }
 
-    sdp.medias.forEach((media) => {
+    sdp.medias.forEach((media, index) => {
       const dtls = media.getDTLS();
       if (dtls) {
         info.setFingerprint(dtls.getFingerprint());
@@ -261,6 +272,9 @@ class SessionDescription {
         audio = media;
       } else if (media.getType() === 'video') {
         video = media;
+      }
+      if (index == 0) {
+        info.setFirstMediaReceived(media.getType());
       }
       info.addBundleTag(media.getId(), media.getType());
 


### PR DESCRIPTION
Ok so,
With Firefox 59 (now in beta) there are lots of problems.

1) It generates offer with m line video before audio. this caused an "error" when generating the answer.
For more information see issue: https://github.com/lynckia/licode/issues/1141

2) Apparently when creating offer, even passing offertoreceiveaudio: false and offertoreceivevideo: false, it creates offer with 2 media in sendrecv. 
I don't know if it's a bug or not but you can follow the discussion from comment 3 [HERE (Bugzilla)](https://bugzilla.mozilla.org/show_bug.cgi?id=1433953)
you can try the example I posted on comment 3 with Firefox 59.
This caused problem with firefox simulcast publisher because the offer generated was audio in sendonly and video in sendrecv. we were generating an answer with both medias in recvonly (the first stream parsed) and when setting answer Firefox throwed an error.
Since licode can't handle multiple direction in one peerconnection my solution was to munge sdp object and set sendonly and recv only in the appropriate places.


Everything's seems to be working fine now, I haven't done any class test so maybe I need help with that.
Also obviously thanks @Trisfald  who helped me with c++ part

ps. there is also a new variable getSessionVersion that we use to increment at every ice restart. maybe you can keep it so when multiple sdp negotiation will be supported, you will increment that.
