### PR TITLE
fix firefox sendrecv

### DIFF
--- a/erizo_controller/erizoClient/src/utils/SdpHelpers.js
+++ b/erizo_controller/erizoClient/src/utils/SdpHelpers.js
@@ -1,3 +1,5 @@
+import Direction from '../../../common/semanticSdp/Direction';
+
 const SdpHelpers = {};
 
 SdpHelpers.addSim = (spatialLayers) => {
@@ -47,6 +49,14 @@ SdpHelpers.enableOpusNacks = (sdpInput) => {
   }
 
   return sdp;
+};
+
+// Take an SdpInfo object and a direction ('sendrecv, sendonly, recvonly')
+SdpHelpers.forceDirection = (sdp, direction) => {
+  sdp.medias.forEach((media) => {
+    const thisMedia = media;
+    thisMedia.direction = Direction.byValue(direction);
+  });
 };
 
 export default SdpHelpers;

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -86,7 +86,7 @@ const BaseStack = (specInput) => {
     }
   };
 
-  const setLocalDescForOffer = (isSubscribe, sessionDescription) => {
+  that.setLocalDescForOffer = (isSubscribe, sessionDescription) => {
     localDesc = sessionDescription;
     if (!isSubscribe) {
       localDesc.sdp = that.enableSimulcast(localDesc.sdp);
@@ -101,7 +101,7 @@ const BaseStack = (specInput) => {
     });
   };
 
-  const setLocalDescForAnswerp2p = (sessionDescription) => {
+  that.setLocalDescForAnswerp2p = (sessionDescription) => {
     localDesc = sessionDescription;
     localSdp = SemanticSdp.SDPInfo.processString(localDesc.sdp);
     SdpHelpers.setMaxBW(localSdp, specBase);
@@ -123,7 +123,7 @@ const BaseStack = (specInput) => {
     msg.sdp = remoteSdp.toString();
     that.peerConnection.setRemoteDescription(msg).then(() => {
       that.peerConnection.createAnswer(that.mediaConstraints)
-      .then(setLocalDescForAnswerp2p).catch(errorCallback.bind(null, 'createAnswer p2p', undefined));
+      .then(that.setLocalDescForAnswerp2p).catch(errorCallback.bind(null, 'createAnswer p2p', undefined));
       specBase.remoteDescriptionSet = true;
     }).catch(errorCallback.bind(null, 'process Offer', undefined));
   };
@@ -277,7 +277,7 @@ const BaseStack = (specInput) => {
     }
     Logger.debug('Creating offer', that.mediaConstraints);
     that.peerConnection.createOffer(that.mediaConstraints)
-    .then(setLocalDescForOffer.bind(null, isSubscribe))
+    .then(that.setLocalDescForOffer.bind(null, isSubscribe))
     .catch(errorCallback.bind(null, 'Create Offer', undefined));
   };
 

--- a/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
@@ -1,5 +1,7 @@
 import Logger from '../utils/Logger';
 import BaseStack from './BaseStack';
+import SemanticSdp from '../../../common/semanticSdp/SemanticSdp';
+import SdpHelpers from '../utils/SdpHelpers';
 
 const FirefoxStack = (specInput) => {
   Logger.info('Starting Firefox stack');
@@ -47,6 +49,26 @@ const FirefoxStack = (specInput) => {
       enableSimulcast();
     }
     baseCreateOffer(isSubscribe);
+  };
+
+  const baseSetLocalDescForOffer = that.setLocalDescForOffer;
+
+  that.setLocalDescForOffer = (isSubscribe, sessionDescription) => {
+    const sdp = SemanticSdp.SDPInfo.processString(sessionDescription.sdp);
+    if (isSubscribe) {
+      SdpHelpers.forceDirection(sdp, 'recvonly');
+    } else {
+      SdpHelpers.forceDirection(sdp, 'sendonly');
+    }
+    baseSetLocalDescForOffer(isSubscribe, sdp.toString());
+  };
+
+  const baseSetLocalDescForAnswerp2p = that.setLocalDescForAnswerp2p;
+
+  that.setLocalDescForAnswerp2p = (sessionDescription) => {
+    const sdp = SemanticSdp.SDPInfo.processString(sessionDescription.sdp);
+    SdpHelpers.forceDirection(sdp, 'recvonly');
+    baseSetLocalDescForAnswerp2p(sdp.toString());
   };
 
   return that;

--- a/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
@@ -54,21 +54,25 @@ const FirefoxStack = (specInput) => {
   const baseSetLocalDescForOffer = that.setLocalDescForOffer;
 
   that.setLocalDescForOffer = (isSubscribe, sessionDescription) => {
-    const sdp = SemanticSdp.SDPInfo.processString(sessionDescription.sdp);
+    const thisSessionDescription = sessionDescription;
+    const sdp = SemanticSdp.SDPInfo.processString(thisSessionDescription.sdp);
     if (isSubscribe) {
       SdpHelpers.forceDirection(sdp, 'recvonly');
     } else {
       SdpHelpers.forceDirection(sdp, 'sendonly');
     }
-    baseSetLocalDescForOffer(isSubscribe, sdp.toString());
+    thisSessionDescription.sdp = sdp.toString();
+    baseSetLocalDescForOffer(isSubscribe, thisSessionDescription);
   };
 
   const baseSetLocalDescForAnswerp2p = that.setLocalDescForAnswerp2p;
 
   that.setLocalDescForAnswerp2p = (sessionDescription) => {
-    const sdp = SemanticSdp.SDPInfo.processString(sessionDescription.sdp);
+    const thisSessionDescription = sessionDescription;
+    const sdp = SemanticSdp.SDPInfo.processString(thisSessionDescription.sdp);
     SdpHelpers.forceDirection(sdp, 'recvonly');
-    baseSetLocalDescForAnswerp2p(sdp.toString());
+    thisSessionDescription.sdp = sdp.toString();
+    baseSetLocalDescForAnswerp2p(thisSessionDescription);
   };
 
   return that;


### PR DESCRIPTION
There's an open bug in firefox 59 that had to be landed in 59 but apparently it's still there, that causes the browser to ingore the offertoreceivevideo: false and offertoreceiveaudio: false, resulting in an sdp in sendrecv direction. (this because they now implemented transceivers)
also in simulcast, firefox generates audio in sendonly direction and video in sendrecv. this breaks the logic since licode can handle only one direction for every peerconnection.

this is a temporary fix, since Firefox or adapter have to handle this misbehavior.

you can follow these topics if interested in:
https://github.com/webrtc/adapter/issues/760
https://bugzilla.mozilla.org/show_bug.cgi?id=1433953 (from comment 3)

[] It needs and includes Unit Tests
[] It includes documentation for these changes in `/doc`.