### PR TITLE
Fix a JS error thrown by a wrong DOM access within the Resizer

### DIFF
--- a/erizo_controller/erizoClient/src/utils/L.Resizer.js
+++ b/erizo_controller/erizoClient/src/utils/L.Resizer.js
@@ -250,9 +250,13 @@ L.ElementQueries = function ElementQueries() {
   this.init = () => {
     const styleSheets = document.styleSheets || [];
     for (let i = 0, j = styleSheets.length; i < j; i += 1) {
-      readRules(styleSheets[i].cssText ||
-                        styleSheets[i].cssRules ||
-                        styleSheets[i].rules);
+      if (Object.prototype.hasOwnProperty.call(styleSheets[i], 'cssText')) {
+        readRules(styleSheets[i].cssText);
+      } else if (Object.prototype.hasOwnProperty.call(styleSheets[i], 'cssRules')) {
+        readRules(styleSheets[i].cssRules);
+      } else if (Object.prototype.hasOwnProperty.call(styleSheets[i], 'rules')) {
+        readRules(styleSheets[i].rules);
+      }
     }
   };
 };


### PR DESCRIPTION
Should fix https://github.com/lynckia/licode/issues/1154

<!--
Add a short description here, please.
If the contribution needs and includes Unit Tests check the box below.
-->

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.