### PR TITLE
Initial support for multiple MediaStreams in a single WebRtcConnection

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -402,7 +402,7 @@ void WebRtcConnection::onTransportData(std::shared_ptr<DataPacket> packet, Trans
   RtpHeader *head = reinterpret_cast<RtpHeader*> (buf);
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*> (buf);
   uint32_t ssrc = head->getSSRC();
-  if (chead->isRtcp()) {
+  if (chead->isRtcp() && chead->packettype != RTCP_Sender_PT) {  // Sender Report
     ssrc = chead->getSourceSSRC();
   }
   forEachMediaStream([packet, transport, ssrc] (const std::shared_ptr<MediaStream> &media_stream) {

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -137,18 +137,15 @@ class WebRtcConnection: public TransportListener, public LogContext,
   bool isAudioMuted() { return audio_muted_; }
   bool isVideoMuted() { return video_muted_; }
 
-  std::shared_ptr<MediaStream> getMediaStream() { return media_stream_; }
   void addMediaStream(std::shared_ptr<MediaStream> media_stream);
   void removeMediaStream(const std::string& stream_id);
+  void forEachMediaStream(std::function<void(const std::shared_ptr<MediaStream>&)> func);
 
   std::shared_ptr<Stats> getStatsService() { return stats_; }
 
   RtpExtensionProcessor& getRtpExtensionProcessor() { return extension_processor_; }
 
   std::shared_ptr<Worker> getWorker() { return worker_; }
-
-  bool isSourceSSRC(uint32_t ssrc);
-  bool isSinkSSRC(uint32_t ssrc);
 
   inline std::string toLog() {
     return "id: " + connection_id_ + ", " + printLogContext();
@@ -182,7 +179,7 @@ class WebRtcConnection: public TransportListener, public LogContext,
 
   std::shared_ptr<Worker> worker_;
   std::shared_ptr<IOWorker> io_worker_;
-  std::shared_ptr<MediaStream> media_stream_;
+  std::vector<std::shared_ptr<MediaStream>> media_streams_;
   std::shared_ptr<SdpInfo> remote_sdp_;
   std::shared_ptr<SdpInfo> local_sdp_;
   bool audio_muted_;


### PR DESCRIPTION
**Description**

This PR adds initial support for handling multiple streams in a single WebRtcConnection inside Erizo.
[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.