### PR TITLE
 Decouple Connection logic in ErizoJS

### DIFF
--- a/erizo_controller/erizoJS/adapt_schemes/notify-slideshow.js
+++ b/erizo_controller/erizoJS/adapt_schemes/notify-slideshow.js
@@ -25,8 +25,7 @@ exports.MonitorSubscriber = function (log) {
   };
 
 
-  that.monitorMinVideoBw = function(mediaStream, callback, idPub,
-     idSub, options, erizoJsController) {
+  that.monitorMinVideoBw = function(mediaStream, callback) {
     mediaStream.bwValues = [];
     var ticks = 0;
     var retries = 0;
@@ -87,10 +86,10 @@ exports.MonitorSubscriber = function (log) {
             average = 0;
             lastAverage = 0;
             mediaStream.minVideoBW = false;
-            erizoJsController.setSlideShow(true, idSub, idPub);
+            callback('scheme-slideshow-change', {enabled: true});
             callback('callback', {type: 'bandwidthAlert',
-            message: 'slideshow',
-            bandwidth: average});
+                                  message: 'slideshow',
+                                  bandwidth: average});
             clearInterval(mediaStream.monitorInterval);
             break;
           default:

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -215,7 +215,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
      * Removes a publisher from the room. This also deletes the associated OneToManyProcessor.
      */
     that.removePublisher = function (clientId, streamId) {
-      return new Promise(function(resolve, reject) {
+      return new Promise(function(resolve) {
         var publisher = publishers[streamId];
           if (publisher !== undefined) {
               log.info(`message: Removing publisher, id: ${clientId}, streamId: ${streamId}`);

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -5,14 +5,12 @@ var amqper = require('./../common/amqper');
 var Client = require('./models/Client').Client;
 var Publisher = require('./models/Publisher').Publisher;
 var ExternalInput = require('./models/Publisher').ExternalInput;
-var SessionDescription = require('./models/SessionDescription');
-var SemanticSdp = require('./../common/semanticSdp/SemanticSdp');
 
 // Logger
 var log = logger.getLogger('ErizoJSController');
 
 exports.ErizoJSController = function (threadPool, ioThreadPool) {
-    var that = {},
+    let that = {},
         // {streamId1: Publisher, streamId2: Publisher}
         publishers = {},
         // {clientId: Client}
@@ -20,31 +18,18 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
         io = ioThreadPool,
         // {streamId: {timeout: timeout, interval: interval}}
         statsSubscriptions = {},
-        MIN_SLIDESHOW_PERIOD = 2000,
-        MAX_SLIDESHOW_PERIOD = 10000,
-        PLIS_TO_RECOVER = 3,
-        initWebRtcConnection,
-        closeWebRtcConnection,
+        onAdaptSchemeNotify,
+        onPeriodicStats,
+        addListenerToConnection,
+        onConnectionStatusEvent,
+        closeNode,
         getOrCreateClient,
-        getSdp,
-        getRoap,
-
-        CONN_INITIAL        = 101,
-        // CONN_STARTED        = 102,
-        CONN_GATHERED       = 103,
-        CONN_READY          = 104,
-        CONN_FINISHED       = 105,
-        CONN_CANDIDATE      = 201,
-        CONN_SDP            = 202,
-        CONN_FAILED         = 500,
         WARN_NOT_FOUND      = 404,
-        WARN_CONFLICT       = 409,
-        WARN_PRECOND_FAILED = 412,
-        WARN_BAD_CONNECTION = 502;
+        WARN_CONFLICT       = 409;
 
     that.publishers = publishers;
     that.ioThreadPool = io;
-    
+
     getOrCreateClient = (clientId) => {
       log.debug(`getOrCreateClient with id ${clientId}`);
       let client = clients.get(clientId);
@@ -54,140 +39,53 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
       }
       return client;
     };
-    /*
-     * Given a WebRtcConnection waits for the state CANDIDATES_GATHERED for set remote SDP.
-     */
-    initWebRtcConnection = function (node, callback, idPub, idSub, options) {
-        const connection = node.connection;
-        const mediaStream = node.mediaStream;
-        const wrtc = connection.wrtc;
-        log.debug(`message: Init WebRtcConnection, node ClientId: ${node.clientId}, ` +
-          `node StreamId: ${node.streamId}, connectionId: ${node.connection.id}, ` +
-          `scheme: ${mediaStream.scheme} ${logger.objectToLog(options)}`);
 
-
-        if (options.metadata) {
-            wrtc.setMetadata(JSON.stringify(options.metadata));
-            node.connection.metadata = options.metadata;
-        }
-
-        if (mediaStream.minVideoBW) {
-            var monitorMinVideoBw = {};
-            if (mediaStream.scheme) {
-                try{
-                    monitorMinVideoBw = require('./adapt_schemes/' + mediaStream.scheme)
-                                          .MonitorSubscriber(log);
-                } catch (e) {
-                    log.warn('message: could not find custom adapt scheme, ' +
-                             'code: ' + WARN_PRECOND_FAILED + ', ' +
-                             'id:' + node.clientId + ', ' +
-                             'scheme: ' + mediaStream.scheme + ', ' +
-                             logger.objectToLog(options.metadata));
-                }
-            } else {
-                monitorMinVideoBw = require('./adapt_schemes/notify').MonitorSubscriber(log);
-            }
-            monitorMinVideoBw(mediaStream, callback, idPub, idSub, options, that);
-        }
-
-        if (global.config.erizoController.report.rtcp_stats) {  // jshint ignore:line
-            log.debug('message: RTCP Stat collection is active');
-            mediaStream.getPeriodicStats(function (newStats) {
-                var timeStamp = new Date();
-                amqper.broadcast('stats', {pub: idPub,
-                                           subs: idSub,
-                                           stats: JSON.parse(newStats),
-                                           timestamp:timeStamp.getTime()});
-            });
-        }
-
-        wrtc.init(function (newStatus, mess) {
-            log.info('message: WebRtcConnection status update, ' +
-                     'id: ' + connection.id + ', status: ' + newStatus +
-                      ', ' + logger.objectToLog(options.metadata));
-            if (global.config.erizoController.report.connection_events) {  //jshint ignore:line
-                var timeStamp = new Date();
-                amqper.broadcast('event', {pub: idPub,
-                                           subs: idSub,
-                                           type: 'connection_status',
-                                           status: newStatus,
-                                           timestamp:timeStamp.getTime()});
-            }
-
-            switch(newStatus) {
-                case CONN_INITIAL:
-                    callback('callback', {type: 'started'});
-                    break;
-
-                case CONN_SDP:
-                case CONN_GATHERED:
-                    wrtc.localDescription = new SessionDescription(wrtc.getLocalDescription());
-                    const sdp = wrtc.localDescription.getSdp();
-                    mess = sdp.toString();
-                    mess = mess.replace(that.privateRegexp, that.publicIP);
-                    if (options.createOffer)
-                        callback('callback', {type: 'offer', sdp: mess});
-                    else
-                        callback('callback', {type: 'answer', sdp: mess});
-                    break;
-
-                case CONN_CANDIDATE:
-                    mess = mess.replace(that.privateRegexp, that.publicIP);
-                    callback('callback', {type: 'candidate', candidate: mess});
-                    break;
-
-                case CONN_FAILED:
-                    log.warn('message: failed the ICE process, ' +
-                             'code: ' + WARN_BAD_CONNECTION + ', id: ' + connection.id);
-                    callback('callback', {type: 'failed', sdp: mess});
-                    break;
-
-                case CONN_READY:
-                    log.debug('message: connection ready, ' +
-                              'id: ' + connection.id + ', ' +
-                              'status: ' + newStatus);
-                    // If I'm a subscriber and I'm bowser, I ask for a PLI
-                    if (idSub && options.browser === 'bowser') {
-                        publishers[idPub].wrtc.generatePLIPacket();
-                    }
-                    if (options.slideShowMode === true || 
-                        Number.isSafeInteger(options.slideShowMode)) {
-                        that.setSlideShow(options.slideShowMode, idSub, idPub);
-                    }
-                    callback('callback', {type: 'ready'});
-                    break;
-            }
-        });
-        if (options.createOffer) {
-            log.debug('message: create offer requested, id:', connection);
-            var audioEnabled = options.createOffer.audio;
-            var videoEnabled = options.createOffer.video;
-            var bundle = options.createOffer.bundle;
-            wrtc.createOffer(videoEnabled, audioEnabled, bundle);
-        }
-        callback('callback', {type: 'initializing'});
+    onAdaptSchemeNotify = (callbackRpc, type, message) => {
+      callbackRpc(type, message);
     };
 
-    closeWebRtcConnection = function (node) {
+    onPeriodicStats = (streamId, clientId, newStats) => {
+      var timeStamp = new Date();
+      amqper.broadcast('stats', {pub: streamId,
+                                 subs: clientId,
+                                 stats: JSON.parse(newStats),
+                                 timestamp:timeStamp.getTime()});
+    };
+
+    addListenerToConnection = (connection, callbackRpc, streamId, clientId) => {
+      if (!connection._onConnectionStatusEventListener) {
+        connection._onConnectionStatusEventListener =
+          onConnectionStatusEvent.bind(this, callbackRpc, streamId, clientId);
+        connection.on('status_event', connection._onConnectionStatusEventListener);
+      }
+    };
+
+    onConnectionStatusEvent = (callbackRpc, streamId, clientId, connectionEvent, newStatus) => {
+      if (newStatus && global.config.erizoController.report.connection_events) {  //jshint ignore:line
+        var timeStamp = new Date();
+        amqper.broadcast('event', {pub: streamId,
+                                   subs: clientId,
+                                   type: 'connection_status',
+                                   status: newStatus,
+                                   timestamp:timeStamp.getTime()});
+      }
+      callbackRpc('callback', connectionEvent);
+    };
+
+    closeNode = (node) => {
         const clientId = node.clientId;
-        log.debug(`message: closeWebRtcConnection, clientId: ${node.clientId}, ` +
-          `streamId: ${node.streamId}`);
+        const connection = node.connection;
+        log.debug(`message: closeNode, clientId: ${node.clientId}, streamId: ${node.streamId}`);
+
+        node.close();
+
         let client = clients.get(clientId);
         if (client === undefined) {
-          log.debug(`message: trying to close connection with no associated client,` +
-           `clientId: ${clientId}, streamId: ${node.streamId}`);
+          log.debug(`message: trying to close node with no associated client,` +
+                    `clientId: ${clientId}, streamId: ${node.streamId}`);
+           return;
         }
-        
-        let connection = node.connection;
-        let mediaStream = node.mediaStream;
-        var associatedMetadata = connection.metadata || {};
-        if (mediaStream && mediaStream.monitorInterval) {
-          clearInterval(mediaStream.monitorInterval);
-        }
-        node.close();
-        log.info('message: WebRtcConnection status update, ' +
-            'id: ' + connection.id + ', status: ' + CONN_FINISHED + ', ' +
-                logger.objectToLog(associatedMetadata));
+
         let remainingConnections = client.maybeCloseConnection(connection.id);
         if (remainingConnections === 0) {
           log.debug(`message: Removing empty client from list, clientId: ${client.id}`);
@@ -195,44 +93,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
         }
     };
 
-    /*
-     * Gets SDP from roap message.
-     */
-    getSdp = function (roap) {
-
-        var reg1 = new RegExp(/^.*sdp\":\"(.*)\",.*$/),
-            sdp = roap.match(reg1)[1],
-            reg2 = new RegExp(/\\r\\n/g);
-
-        sdp = sdp.replace(reg2, '\n');
-
-        return sdp;
-    };
-
-    /*
-     * Gets roap message from SDP.
-     */
-    getRoap = function (sdp, offerRoap) {
-
-        var reg1 = new RegExp(/\n/g),
-            offererSessionId = offerRoap.match(/("offererSessionId":)(.+?)(,)/)[0],
-            answererSessionId = '106',
-            answer = ('\n{\n \"messageType\":\"ANSWER\",\n');
-
-                sdp = sdp.replace(reg1, '\\r\\n');
-
-                //var reg2 = new RegExp(/^.*offererSessionId\":(...).*$/);
-                //var offererSessionId = offerRoap.match(reg2)[1];
-
-                answer += ' \"sdp\":\"' + sdp + '\",\n';
-                //answer += ' \"offererSessionId\":' + offererSessionId + ',\n';
-                answer += ' ' + offererSessionId + '\n';
-                answer += ' \"answererSessionId\":' + answererSessionId + ',\n \"seq\" : 1\n}\n';
-
-                return answer;
-    };
-
-    that.addExternalInput = function (streamId, url, callback) {
+    that.addExternalInput = function (streamId, url, callbackRpc) {
         if (publishers[streamId] === undefined) {
             let client = getOrCreateClient(url);
             var ei = publishers[streamId] = new ExternalInput(url, streamId, threadPool);
@@ -240,9 +101,9 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
             // We add the connection manually to the client
             client.addConnection(ei);
             if (answer >= 0) {
-                callback('callback', 'success');
+                callbackRpc('callback', 'success');
             } else {
-                callback('callback', answer);
+                callbackRpc('callback', answer);
             }
         } else {
             log.warn('message: Publisher already set, code: ' +
@@ -262,118 +123,18 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
         }
     };
 
-    var processControlMessage = function(publisher, subscriberId, action) {
-      var publisherSide = subscriberId === undefined || action.publisherSide;
-      switch(action.name) {
-        case 'controlhandlers':
-          if (action.enable) {
-            publisher.enableHandlers(publisherSide ? undefined : subscriberId, action.handlers);
-          } else {
-            publisher.disableHandlers(publisherSide ? undefined : subscriberId, action.handlers);
-          }
-          break;
-      }
-    };
-
-    var disableDefaultHandlers = function(node) {
-      let mediaStream = node.mediaStream;
-      var disabledHandlers = global.config.erizo.disabledHandlers;
-      for (var index in disabledHandlers) {
-        mediaStream.disableHandler(disabledHandlers[index]);
-      }
-    };
-
     that.processSignaling = function (clientId, streamId, msg) {
-        log.info('message: Process Signaling message, ' +
-                 'streamId: ' + streamId + ', clientId: ' + clientId);
-        if (publishers[streamId] !== undefined) {
-            let publisher = publishers[streamId];
-            if (publisher.hasSubscriber(clientId)) {
-                let subscriber = publisher.getSubscriber(clientId);
-                let connection = subscriber.connection;
-                let wrtc = connection.wrtc;
-                
-                if (msg.type === 'offer') {
-                    const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
-                    connection.remoteDescription =
-                        new SessionDescription(sdp, connection.mediaConfiguration);
-                    wrtc.setRemoteDescription(
-                        connection.remoteDescription.connectionDescription);
-                    disableDefaultHandlers(subscriber);
-                } else if (msg.type === 'candidate') {
-                    wrtc.addRemoteCandidate(msg.candidate.sdpMid,
-                                                  msg.candidate.sdpMLineIndex,
-                                                  msg.candidate.candidate);
-                } else if (msg.type === 'updatestream') {
-                    if(msg.sdp) {
-                        const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
-                        connection.remoteDescription =
-                            new SessionDescription(sdp, connection.mediaConfiguration);
-                        wrtc.setRemoteDescription(
-                            connection.remoteDescription.connectionDescription);
-                      }
-                    if (msg.config) {
-                        if (msg.config.slideShowMode !== undefined) {
-                            that.setSlideShow(msg.config.slideShowMode, clientId, streamId);
-                        }
-                        if (msg.config.muteStream !== undefined) {
-                            that.muteStream(msg.config.muteStream, clientId, streamId);
-                        }
-                        if (msg.config.qualityLayer !== undefined) {
-                            that.setQualityLayer(msg.config.qualityLayer, clientId, streamId);
-                        }
-                        if (msg.config.video !== undefined) {
-                            that.setVideoConstraints(msg.config.video, clientId, streamId);
-                        }
-                    }
-                } else if (msg.type === 'control') {
-                  processControlMessage(publisher, clientId, msg.action);
-                }
-            } else {
-                let connection = publisher.connection;
-                let wrtc = connection.wrtc;
-                if (msg.type === 'offer') {
-                    const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
-                    connection.remoteDescription =
-                        new SessionDescription(sdp, connection.mediaConfiguration);
-                    wrtc.setRemoteDescription(
-                        connection.remoteDescription.connectionDescription);
-                    disableDefaultHandlers(publisher);
-                } else if (msg.type === 'candidate') {
-                    wrtc.addRemoteCandidate(msg.candidate.sdpMid,
-                                            msg.candidate.sdpMLineIndex,
-                                            msg.candidate.candidate);
-                } else if (msg.type === 'updatestream') {
-                    if (msg.sdp) {
-                        const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
-                        connection.remoteDescription =
-                            new SessionDescription(sdp, connection.mediaConfiguration);
-                        wrtc.setRemoteDescription(
-                            connection.remoteDescription.connectionDescription);
-                    }
-                    if (msg.config) {
-                        if (msg.config.minVideoBW) {
-                            log.debug('message: updating minVideoBW for publisher, ' +
-                                      'id: ' + publishers[streamId].streamId + ', ' +
-                                      'minVideoBW: ' + msg.config.minVideoBW);
-                            publisher.minVideoBW = msg.config.minVideoBW;
-                            for (var sub in publisher.subscribers) {
-                                var theConn = publisher.getSubscriber(sub);
-                                theConn.minVideoBW = msg.config.minVideoBW * 1000; // bps
-                                theConn.lowerThres = Math.floor(theConn.minVideoBW*(1-0.2));
-                                theConn.upperThres = Math.ceil(theConn.minVideoBW*(1+0.1));
-                            }
-                        }
-                        if (msg.config.muteStream !== undefined) {
-                            that.muteStream (msg.config.muteStream, clientId, streamId);
-                        }
-                    }
-                } else if (msg.type === 'control') {
-                  processControlMessage(publisher, undefined, msg.action);
-                }
-            }
-
+      log.info('message: Process Signaling message, ' +
+               'streamId: ' + streamId + ', clientId: ' + clientId);
+      if (publishers[streamId] !== undefined) {
+        let publisher = publishers[streamId];
+        if (publisher.hasSubscriber(clientId)) {
+          let subscriber = publisher.getSubscriber(clientId);
+          subscriber.onSignalingMessage(msg);
+        } else {
+          publisher.onSignalingMessage(msg);
         }
+      }
     };
 
     /*
@@ -381,23 +142,27 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
      * and a new WebRtcConnection. This WebRtcConnection will be the publisher
      * of the OneToManyProcessor.
      */
-    that.addPublisher = function (clientId, streamId, options, callback) {
+    that.addPublisher = function (clientId, streamId, options, callbackRpc) {
         let publisher;
         log.info('addPublisher, clientId', clientId, 'streamId', streamId);
         let client = getOrCreateClient(clientId);
 
         if (publishers[streamId] === undefined) {
-          let connection = client.getOrCreateConnection();
-            log.info('message: Adding publisher, ' +
-                     'clientId: ' + clientId + ', ' +
-                     'streamId: ' + streamId + ', ' +
-                     logger.objectToLog(options) + ', ' +
-                     logger.objectToLog(options.metadata));
-            publisher = new Publisher(clientId, streamId, connection, options);
-            publishers[streamId] = publisher;
-
-            initWebRtcConnection(publisher, callback, streamId, undefined, options);
-
+          options.publicIP = that.publicIP;
+          options.privateRegexp = that.privateRegexp;
+          let connection = client.getOrCreateConnection(options);
+          log.info('message: Adding publisher, ' +
+                   'clientId: ' + clientId + ', ' +
+                   'streamId: ' + streamId + ', ' +
+                   logger.objectToLog(options) + ', ' +
+                   logger.objectToLog(options.metadata));
+          publisher = new Publisher(clientId, streamId, connection, options);
+          publishers[streamId] = publisher;
+          publisher.initMediaStream();
+          publisher.on('callback', onAdaptSchemeNotify.bind(this, callbackRpc));
+          publisher.on('periodic_stats', onPeriodicStats.bind(this, streamId, undefined));
+          addListenerToConnection(connection, callbackRpc, streamId, clientId);
+          connection.init();
         } else {
             publisher = publishers[streamId];
             if (publisher.numSubscribers === 0) {
@@ -416,7 +181,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
      * This WebRtcConnection will be added to the subscribers list of the
      * OneToManyProcessor.
      */
-    that.addSubscriber = function (clientId, streamId, options, callback) {
+    that.addSubscriber = function (clientId, streamId, options, callbackRpc) {
         const publisher = publishers[streamId];
         if (publisher === undefined) {
             log.warn('message: addSubscriber to unknown publisher, ' +
@@ -426,7 +191,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
             //We may need to notify the clients
             return;
         }
-        const subscriber = publisher.getSubscriber(clientId);
+        let subscriber = publisher.getSubscriber(clientId);
         const client = getOrCreateClient(clientId);
         if (subscriber !== undefined) {
             log.warn('message: Duplicated subscription will resubscribe, ' +
@@ -435,10 +200,13 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
                      ', ' + logger.objectToLog(options.metadata));
             that.removeSubscriber(clientId, streamId);
         }
-        let connection = client.getOrCreateConnection();
-        publisher.addSubscriber(clientId, connection, options);
-        initWebRtcConnection(publisher.getSubscriber(clientId),
-          callback, streamId, clientId, options);
+        let connection = client.getOrCreateConnection(options);
+        subscriber = publisher.addSubscriber(clientId, connection, options);
+        subscriber.initMediaStream();
+        subscriber.on('callback', onAdaptSchemeNotify.bind(this, callbackRpc));
+        subscriber.on('periodic_stats', onPeriodicStats.bind(this, streamId, clientId));
+        addListenerToConnection(connection, callbackRpc, streamId, clientId);
+        connection.init();
     };
 
     /*
@@ -449,17 +217,13 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
         var publisher = publishers[streamId];
           if (publisher !== undefined) {
               log.info(`message: Removing publisher, id: ${clientId}, streamId: ${streamId}`);
-              if (publisher.mediaStream.periodicPlis !== undefined) {
-                  log.debug('message: clearing periodic PLIs for publisher, id: ' + streamId);
-                  clearInterval (publisher.mediaStream.periodicPlis);
-              }
               for (let subscriberKey in publisher.subscribers) {
                   let subscriber = publisher.getSubscriber(subscriberKey);
                   log.info('message: Removing subscriber, id: ' + subscriber);
-                  closeWebRtcConnection(subscriber);
+                  closeNode(subscriber);
               }
               publisher.removeExternalOutputs().then(function() {
-                closeWebRtcConnection(publisher);
+                closeNode(publisher);
                 publisher.muxer.close(function(message) {
                     log.info('message: muxer closed succesfully, ' +
                              'id: ' + streamId + ', ' +
@@ -495,26 +259,12 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
     that.removeSubscriber = function (clientId, streamId) {
         const publisher = publishers[streamId];
         if (publisher && publisher.hasSubscriber(clientId)) {
-            
             let subscriber = publisher.getSubscriber(clientId);
+            subscriber.close();
             log.info(`message: removing subscriber, streamId: ${subscriber.streamId}, ` +
               `clientId: ${clientId}`);
-            closeWebRtcConnection(subscriber);
+            closeNode(subscriber);
             publisher.removeSubscriber(clientId);
-        }
-        // get the right mediaStream and stop the slideShow
-        if (publisher && publisher.connection &&
-           publisher.mediaStream &&
-           publisher.mediaStream.periodicPlis !== undefined) {
-            for (var i in publisher.subscribers) {
-                if (publisher.getSubscriber(i).mediaStream.slideShowMode === true) {
-                    return;
-                }
-            }
-            log.debug('message: clearing Pli interval as no more ' +
-                      'slideshows subscribers are present');
-            clearInterval(publisher.mediaStream.periodicPlis);
-            publisher.mediaStream.periodicPlis = undefined;
         }
     };
 
@@ -531,124 +281,31 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
                 if (subscriber) {
                     log.debug('message: removing subscription, ' +
                               'id:', subscriber.clientId);
-                    closeWebRtcConnection(subscriber);
+                    closeNode(subscriber);
                     publisher.removeSubscriber(clientId);
                 }
             }
         }
     };
 
-    /*
-     * Enables/Disables slideshow mode for a subscriber
-     */
-    that.setSlideShow = function (slideShowMode, clientId, streamId) {
-        const publisher = publishers[streamId];
-        const subscriber = publisher.getSubscriber(clientId);
-        if (!subscriber) {
-            log.warn('message: subscriber not found for updating slideshow, ' +
-                     'code: ' + WARN_NOT_FOUND + ', id: ' + clientId + '_' + streamId);
-            return;
-        }
-
-        log.debug('message: setting SlideShow, id: ' + subscriber.clientId +
-                  ', slideShowMode: ' + slideShowMode);
-        let period =  slideShowMode === true ? MIN_SLIDESHOW_PERIOD : slideShowMode;
-        if (Number.isSafeInteger(period)) {
-            period = period < MIN_SLIDESHOW_PERIOD ? MIN_SLIDESHOW_PERIOD : period;
-            period = period > MAX_SLIDESHOW_PERIOD ? MAX_SLIDESHOW_PERIOD : period;
-            subscriber.mediaStream.setSlideShowMode(true);
-            subscriber.mediaStream.slideShowMode = true;
-            if (publisher.mediaStream.periodicPlis) {
-                clearInterval(publisher.mediaStream.periodicPlis);
-                publisher.mediaStream.periodicPlis = undefined;
-            }
-            publisher.mediaStream.periodicPlis = setInterval(function () {
-                if(publisher)
-                    publisher.mediaStream.generatePLIPacket();
-            }, period);
-        } else {
-            for (var pliIndex = 0; pliIndex < PLIS_TO_RECOVER; pliIndex++) {
-              publisher.mediaStream.generatePLIPacket();
-            }
-
-            subscriber.mediaStream.setSlideShowMode(false);
-            subscriber.mediaStream.slideShowMode = false;
-            if (publisher .mediaStream.periodicPlis !== undefined) {
-                for (var i in publisher.subscribers) {
-                    if (publisher.getSubscriber(i).mediaStream.slideShowMode === true) {
-                        return;
-                    }
-                }
-                log.debug('message: clearing PLI interval for publisher slideShow, ' +
-                          'id: ' + publisher.clientId);
-                clearInterval(publisher.mediaStream.periodicPlis);
-                publisher.mediaStream.periodicPlis = undefined;
-            }
-        }
-
-    };
-
-    that.muteStream = function (muteStreamInfo, clientId, streamId) {
-        var publisher = this.publishers[streamId];
-        if (muteStreamInfo.video === undefined) {
-            muteStreamInfo.video = false;
-        }
-
-        if (muteStreamInfo.audio === undefined) {
-            muteStreamInfo.audio = false;
-        }
-        if (publisher.hasSubscriber(clientId)) {
-          publisher.muteSubscriberStream(clientId, muteStreamInfo.video, muteStreamInfo.audio);
-        } else {
-          publisher.muteStream(muteStreamInfo.video, muteStreamInfo.audio);
-        }
-    };
-
-    that.setQualityLayer = function (qualityLayer, clientId, streamId) {
-      var publisher = this.publishers[streamId];
-      if (publisher.hasSubscriber(clientId)) {
-        publisher.setQualityLayer(clientId, qualityLayer.spatialLayer, qualityLayer.temporalLayer);
-      }
-    };
-
-    that.setVideoConstraints = function (video, clientId, streamId) {
-      var publisher = this.publishers[streamId];
-      if (publisher.hasSubscriber(clientId)) {
-        publisher.setVideoConstraints(clientId, video.width, video.height, video.frameRate);
-      }
-    };
-
-    const getWrtcStats = (label, stats, node) => {
-      const promise = new Promise((resolve) => {
-        node.mediaStream.getStats((statsString) => {
-          const unfilteredStats = JSON.parse(statsString);
-          unfilteredStats.metadata = node.connection.metadata;
-          stats[label] = unfilteredStats;
-          resolve();
-        });
-      });
-      return promise;
-    };
-
-    that.getStreamStats = function (streamId, callback) {
+    that.getStreamStats = function (streamId, callbackRpc) {
         var stats = {};
         var publisher;
         log.debug('message: Requested stream stats, streamID: ' + streamId);
         var promises = [];
         if (streamId && publishers[streamId]) {
           publisher = publishers[streamId];
-          promises.push(getWrtcStats('publisher', stats, publisher));
+          promises.push(publisher.getStats('publisher', stats));
           for (var sub in publisher.subscribers) {
-            promises.push(getWrtcStats(sub, stats, publisher.subscribers[sub]));
+            promises.push(publisher.subscribers[sub].getStats(sub, stats));
           }
           Promise.all(promises).then(() => {
-            callback('callback', stats);
+            callbackRpc('callback', stats);
           });
         }
     };
 
-    that.subscribeToStats = function (streamId, timeout, interval, callback) {
-
+    that.subscribeToStats = function (streamId, timeout, interval, callbackRpc) {
         var publisher;
         log.debug('message: Requested subscription to stream stats, streamId: ' + streamId);
 
@@ -682,10 +339,10 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
                     let stats = {};
 
                     stats.streamId = streamId;
-                    promises.push(getWrtcStats('publisher', stats, publisher));
+                    promises.push(publisher.getStats('publisher', stats));
 
                     for (var sub in publisher.subscribers) {
-                        promises.push(getWrtcStats(sub, stats, publisher.subscribers[sub]));
+                        promises.push(publisher.subscribers[sub].getStats(sub, stats));
                     }
 
                     Promise.all(promises).then(() => {
@@ -699,7 +356,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
                     delete statsSubscriptions[streamId];
                 }, timeout*1000);
 
-                callback('success');
+                callbackRpc('success');
 
             } else {
                 log.debug('message: Report subscriptions disabled by config, ignoring message');

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -249,7 +249,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
           } else {
               log.warn('message: removePublisher that does not exist, ' +
                        'code: ' + WARN_NOT_FOUND + ', id: ' + streamId);
-              reject();
+              resolve();
           }
         }.bind(this));
     };

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -200,6 +200,8 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
                      ', ' + logger.objectToLog(options.metadata));
             that.removeSubscriber(clientId, streamId);
         }
+        options.publicIP = that.publicIP;
+        options.privateRegexp = that.privateRegexp;
         let connection = client.getOrCreateConnection(options);
         subscriber = publisher.addSubscriber(clientId, connection, options);
         subscriber.initMediaStream();

--- a/erizo_controller/erizoJS/models/Client.js
+++ b/erizo_controller/erizoJS/models/Client.js
@@ -25,14 +25,14 @@ class Client {
     return id;
   }
 
-  getOrCreateConnection() {
+  getOrCreateConnection(options) {
     let connection = this.connections.values().next().value;
     log.info(`message: getOrCreateConnection for clientId ${this.id}`);
     if (!this.singlePc || !connection) {
-      let id = this._getNewConnectionClientId(); 
-      connection = new Connection(id, this.threadPool, this.ioThreadPool);
+      let id = this._getNewConnectionClientId();
+      connection = new Connection(id, this.threadPool, this.ioThreadPool, options);
       this.addConnection(connection);
-    } 
+    }
     return connection;
   }
 

--- a/erizo_controller/erizoJS/models/Client.js
+++ b/erizo_controller/erizoJS/models/Client.js
@@ -52,7 +52,7 @@ class Client {
     log.debug(`message: maybeCloseConnection, connectionId: ${id}`);
     if (connection !== undefined) {
       // ExternalInputs don't have mediaStreams but have to be closed
-      if (!connection.mediaStreams || connection.mediaStreams.size === 0) {
+      if (connection.getNumMediaStreams() === 0) {
         log.info(`message: closing empty connection, clientId: ${this.id}` +
         ` connectionId: ${connection.id}`);
         connection.close();

--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -1,12 +1,24 @@
 /*global require, exports*/
 'use strict';
-var addon = require('./../../../erizoAPI/build/Release/addon');
-var logger = require('./../../common/logger').logger;
-var log = logger.getLogger('Connection');
+const events = require('events');
+const addon = require('./../../../erizoAPI/build/Release/addon');
+const logger = require('./../../common/logger').logger;
+const SessionDescription = require('./SessionDescription');
+const log = logger.getLogger('Connection');
 
-class Connection {
+const CONN_INITIAL        = 101,
+      // CONN_STARTED        = 102,
+      CONN_GATHERED       = 103,
+      CONN_READY          = 104,
+      CONN_FINISHED       = 105,
+      CONN_CANDIDATE      = 201,
+      CONN_SDP            = 202,
+      CONN_FAILED         = 500,
+      WARN_BAD_CONNECTION = 502;
 
-  constructor (id, threadPool, ioThreadPool) {
+class Connection extends events.EventEmitter {
+  constructor (id, threadPool, ioThreadPool, options = {}) {
+    super();
     log.info(`message: constructor, id: ${id}`);
     this.id = id;
     this.threadPool = threadPool;
@@ -15,6 +27,9 @@ class Connection {
     //  {id: stream}
     this.mediaStreams = new Map();
     this.wrtc = this._createWrtc();
+    this.initialized = false;
+    this.options = options;
+    this.metadata = this.options.metadata || {};
   }
 
   _getMediaConfiguration(mediaConfiguration = 'default') {
@@ -52,27 +67,91 @@ class Connection {
       global.config.erizo.turnpass,
       global.config.erizo.networkinterface);
 
+    if (this.metadata) {
+        wrtc.setMetadata(JSON.stringify(this.metadata));
+    }
     return wrtc;
   }
 
-  _createMediaStream (id) {
+  _createMediaStream (id, mediaStreamOptions) {
     log.debug(`message: _createMediaStream, connectionId: ${this.id}, mediaStreamId: ${id}`);
     const mediaStream = new addon.MediaStream(this.threadPool, this.wrtc, id,
       this._getMediaConfiguration(this.mediaConfiguration));
     mediaStream.id = id;
+    if (mediaStreamOptions) {
+      mediaStream.metadata = mediaStreamOptions;
+      mediaStream.setMetadata(JSON.stringify(mediaStreamOptions));
+    }
     return mediaStream;
   }
 
-  addMediaStream(id) {
+  init() {
+    if (this.initialized) {
+      return;
+    }
+    this.initialized = true;
+    log.debug(`message: Init Connection, connectionId: ${this.id} `+
+              `${logger.objectToLog(this.options)}`);
+
+    this.wrtc.init((newStatus, mess) => {
+      log.info('message: WebRtcConnection status update, ' +
+               'id: ' + this.id + ', status: ' + newStatus +
+                ', ' + logger.objectToLog(this.metadata));
+      switch(newStatus) {
+        case CONN_INITIAL:
+          this.emit('status_event', {type: 'started'}, newStatus);
+          break;
+
+        case CONN_SDP:
+        case CONN_GATHERED:
+          this.wrtc.localDescription = new SessionDescription(this.wrtc.getLocalDescription());
+          const sdp = this.wrtc.localDescription.getSdp();
+          mess = sdp.toString();
+          mess = mess.replace(this.privateRegexp, this.publicIP);
+
+          const info = {type: this.options.createOffer ? 'offer' : 'answer', sdp: mess};
+          this.emit('status_event', info, newStatus);
+          break;
+
+        case CONN_CANDIDATE:
+          mess = mess.replace(this.privateRegexp, this.publicIP);
+          this.emit('status_event', {type: 'candidate', candidate: mess}, newStatus);
+          break;
+
+        case CONN_FAILED:
+          log.warn('message: failed the ICE process, ' + 'code: ' + WARN_BAD_CONNECTION +
+                   ', id: ' + this.id);
+          this.emit('status_event', {type: 'failed', sdp: mess}, newStatus);
+          break;
+
+        case CONN_READY:
+          log.debug('message: connection ready, ' + 'id: ' + this.id +
+                    ', ' + 'status: ' + newStatus);
+          this.emit('status_event', {type: 'ready'}, newStatus);
+          break;
+      }
+    });
+    if (this.options.createOffer) {
+      log.debug('message: create offer requested, id:', this.id);
+      const audioEnabled = this.options.createOffer.audio;
+      const videoEnabled = this.options.createOffer.video;
+      const bundle = this.options.createOffer.bundle;
+      this.wrtc.createOffer(videoEnabled, audioEnabled, bundle);
+    }
+    this.emit('status_event', {type: 'initializing'});
+  }
+
+  addMediaStream(id, mediaStreamOptions) {
     log.info(`message: addMediaStream, connectionId: ${this.id}, mediaStreamId: ${id}`);
     if (this.mediaStreams.get(id) === undefined) {
-      const mediaStream = this._createMediaStream(id);
+      const mediaStream = this._createMediaStream(id, mediaStreamOptions);
       this.wrtc.addMediaStream(mediaStream);
       this.mediaStreams.set(id, mediaStream);
     }
   }
+
   removeMediaStream(id) {
-    if(this.mediaStreams.get(id) !== undefined) {
+    if (this.mediaStreams.get(id) !== undefined) {
       this.wrtc.removeMediaStream(id);
       this.mediaStreams.get(id).close();
       this.mediaStreams.delete(id);
@@ -81,13 +160,31 @@ class Connection {
       log.error(`message: Trying to remove mediaStream not found, id: ${id}`);
     }
   }
-  
+
+  setRemoteDescription(sdp) {
+    this.remoteDescription = new SessionDescription(sdp, this.mediaConfiguration);
+    this.wrtc.setRemoteDescription(this.remoteDescription.connectionDescription);
+  }
+
+  addRemoteCandidate(candidate) {
+    this.wrtc.addRemoteCandidate(candidate.sdpMid, candidate.sdpMLineIndex, candidate.candidate);
+  }
+
   getMediaStream(id) {
     return this.mediaStreams.get(id);
   }
 
+  getNumMediaStreams() {
+    return this.mediaStreams.size;
+  }
+
   close() {
     log.info(`message: Closing connection ${this.id}`);
+    log.info(`message: WebRtcConnection status update, id: ${this.id}, status: ${CONN_FINISHED}, ` +
+            `${logger.objectToLog(this.metadata)}`);
+    if (this._onConnectionStatusEventListener) {
+      this.removeListener('status_event', this._onConnectionStatusEventListener);
+    }
     this.mediaStreams.forEach((mediaStream, id) => {
       log.debug(`message: Closing mediaStream, connectionId : ${this.id}, `+
         `mediaStreamId: ${id}`);
@@ -97,6 +194,6 @@ class Connection {
     delete this.mediaStreams;
     delete this.wrtc;
   }
-  
+
 }
 exports.Connection = Connection;

--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -107,14 +107,14 @@ class Connection extends events.EventEmitter {
           this.wrtc.localDescription = new SessionDescription(this.wrtc.getLocalDescription());
           const sdp = this.wrtc.localDescription.getSdp();
           mess = sdp.toString();
-          mess = mess.replace(this.privateRegexp, this.publicIP);
+          mess = mess.replace(this.options.privateRegexp, this.options.publicIP);
 
           const info = {type: this.options.createOffer ? 'offer' : 'answer', sdp: mess};
           this.emit('status_event', info, newStatus);
           break;
 
         case CONN_CANDIDATE:
-          mess = mess.replace(this.privateRegexp, this.publicIP);
+          mess = mess.replace(this.options.privateRegexp, this.options.publicIP);
           this.emit('status_event', {type: 'candidate', candidate: mess}, newStatus);
           break;
 
@@ -155,7 +155,7 @@ class Connection extends events.EventEmitter {
       this.wrtc.removeMediaStream(id);
       this.mediaStreams.get(id).close();
       this.mediaStreams.delete(id);
-      log.debug(`removed mediaStreamId ${id}, remaining size ${this.mediaStreams.size}`);
+      log.debug(`removed mediaStreamId ${id}, remaining size ${this.getNumMediaStreams()}`);
     } else {
       log.error(`message: Trying to remove mediaStream not found, id: ${id}`);
     }

--- a/erizo_controller/erizoJS/models/Node.js
+++ b/erizo_controller/erizoJS/models/Node.js
@@ -1,0 +1,73 @@
+/*global require, exports*/
+'use strict';
+const EventEmitter = require('events').EventEmitter;
+const Helpers = require('./Helpers');
+const logger = require('./../../common/logger').logger;
+
+const log = logger.getLogger('Node');
+
+const WARN_PRECOND_FAILED = 412;
+
+class Node extends EventEmitter {
+  constructor(clientId, streamId, options = {}) {
+    super();
+    this.clientId = clientId;
+    this.streamId = streamId;
+    this.erizoStreamId = Helpers.getErizoStreamId(clientId, streamId);
+    this.options = options;
+  }
+
+  getStats(label, stats) {
+    const promise = new Promise((resolve) => {
+      if (!this.mediaStream || !this.connection) {
+        resolve();
+        return;
+      }
+      this.mediaStream.getStats((statsString) => {
+        const unfilteredStats = JSON.parse(statsString);
+        unfilteredStats.metadata = this.connection.metadata;
+        stats[label] = unfilteredStats;
+        resolve();
+      });
+    });
+    return promise;
+  }
+
+  _onMonitorMinVideoBWCallback(type, message) {
+    this.emit(type, message);
+  }
+
+  initMediaStream() {
+    if (!this.mediaStream) {
+      return;
+    }
+    const mediaStream = this.mediaStream;
+    if (mediaStream.minVideoBW) {
+      var monitorMinVideoBw = {};
+      if (mediaStream.scheme) {
+        try{
+          monitorMinVideoBw = require('../adapt_schemes/' + mediaStream.scheme)
+            .MonitorSubscriber(log);
+        } catch (e) {
+          log.warn('message: could not find custom adapt scheme, ' +
+                   'code: ' + WARN_PRECOND_FAILED + ', ' +
+                   'id:' + this.clientId + ', ' +
+                   'scheme: ' + mediaStream.scheme + ', ' +
+                   logger.objectToLog(this.options.metadata));
+        }
+      } else {
+        monitorMinVideoBw = require('../adapt_schemes/notify').MonitorSubscriber(log);
+      }
+      monitorMinVideoBw(mediaStream, this._onMonitorMinVideoBWCallback.bind(this), this.clientId);
+    }
+
+    if (global.config.erizoController.report.rtcp_stats) {  // jshint ignore:line
+        log.debug('message: RTCP Stat collection is active');
+        mediaStream.getPeriodicStats((newStats) => {
+            this.emit('periodic_stats', newStats);
+        });
+    }
+  }
+}
+
+exports.Node = Node;

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -1,36 +1,23 @@
 /*global require, exports*/
 'use strict';
-var addon = require('./../../../erizoAPI/build/Release/addon');
-var logger = require('./../../common/logger').logger;
-var Helpers = require('./Helpers');
+const NodeClass = require('./Node').Node;
+const Subscriber = require('./Subscriber').Subscriber;
+const addon = require('./../../../erizoAPI/build/Release/addon');
+const logger = require('./../../common/logger').logger;
+const Helpers = require('./Helpers');
+var SemanticSdp = require('./../../common/semanticSdp/SemanticSdp');
 
 // Logger
-var log = logger.getLogger('Publisher');
+const log = logger.getLogger('Publisher');
 
-class Node {
-  constructor(clientId, streamId) {
-    this.clientId = clientId;
-    this.streamId = streamId;
-    this.erizoStreamId = Helpers.getErizoStreamId(clientId, streamId);
-  }
-}
+const MIN_SLIDESHOW_PERIOD = 2000;
+const MAX_SLIDESHOW_PERIOD = 10000;
+const PLIS_TO_RECOVER = 3;
+const WARN_NOT_FOUND = 404;
 
-class Subscriber extends Node {
-   constructor(clientId, streamId, connection, options) {
-     super(clientId, streamId);
-     this.connection = connection;
-     this.connection.mediaConfiguration = options.mediaConfiguration;
-     this.connection.addMediaStream(this.erizoStreamId);
-     this.mediaStream = connection.getMediaStream(this.erizoStreamId);
-   }
-  close() {
-    this.connection.removeMediaStream(this.mediaStream.id);
-  }
-}
-
-class Source extends Node {
-  constructor(clientId, streamId, threadPool) {
-    super(clientId, streamId);
+class Source extends NodeClass {
+  constructor(clientId, streamId, threadPool, options = {}) {
+    super(clientId, streamId, options);
     this.threadPool = threadPool;
     // {clientId1: Subscriber, clientId2: Subscriber}
     this.subscribers = {};
@@ -48,11 +35,15 @@ class Source extends Node {
     log.info(`message: Adding subscriber, clientId: ${clientId}, ` +
              `${logger.objectToLog(options)}` +
               `, ${logger.objectToLog(options.metadata)}`);
-    const subscriber = new Subscriber(clientId, this.streamId, connection, options); 
-    
+    const subscriber = new Subscriber(clientId, this.streamId, connection, this, options);
+
     this.subscribers[clientId] = subscriber;
     this.muxer.addSubscriber(subscriber.mediaStream, subscriber.mediaStream.id);
     subscriber.mediaStream.minVideoBW = this.minVideoBW;
+
+    subscriber._onSchemeSlideShowModeChangeListener =
+      this._onSchemeSlideShowModeChange.bind(this, clientId);
+    subscriber.on('scheme-slideshow-change', subscriber._onSchemeSlideShowModeChangeListener);
 
     log.debug(`message: Setting scheme from publisher to subscriber, ` +
               `clientId: ${clientId}, scheme: ${this.scheme}, `+
@@ -67,6 +58,7 @@ class Source extends Node {
       this.setVideoConstraints(clientId,
         options.video.width, options.video.height, options.video.frameRate);
     }
+    return subscriber;
   }
 
   removeSubscriber(clientId) {
@@ -76,9 +68,13 @@ class Source extends Node {
         `streamId: ${this.streamId}`);
       return;
     }
-    
+
+    subscriber.removeListener('scheme-slideshow-change',
+      subscriber._onSchemeSlideShowModeChangeListener);
+
     this.muxer.removeSubscriber(subscriber.mediaStream.id);
     delete this.subscribers[clientId];
+    this.maybeStopSlideShow();
   }
 
   getSubscriber(clientId) {
@@ -90,9 +86,9 @@ class Source extends Node {
   }
 
   addExternalOutput(url, options) {
-    var eoId = url + '_' + this.streamId;
+    const eoId = url + '_' + this.streamId;
     log.info('message: Adding ExternalOutput, id: ' + eoId + ', url: ' + url);
-    var externalOutput = new addon.ExternalOutput(this.threadPool, url,
+    const externalOutput = new addon.ExternalOutput(this.threadPool, url,
       Helpers.getMediaConfiguration(options.mediaConfiguration));
     externalOutput.id = eoId;
     externalOutput.init();
@@ -102,14 +98,14 @@ class Source extends Node {
 
   removeExternalOutput(url) {
     log.info(`message: Removing ExternalOutput, url: ${url}`);
-    return new Promise(function(resolve) {
+    return new Promise((resolve) => {
       this.muxer.removeSubscriber(url);
-      this.externalOutputs[url].close(function() {
+      this.externalOutputs[url].close(() => {
         log.info('message: ExternalOutput closed');
         delete this.externalOutputs[url];
         resolve();
       });
-    }.bind(this));
+    });
   }
 
   removeExternalOutputs() {
@@ -129,24 +125,169 @@ class Source extends Node {
     return this.externalOutputs[url];
   }
 
-  muteStream(muteVideo, muteAudio) {
-    this.muteVideo = muteVideo;
-    this.muteAudio = muteAudio;
-    for (var subId in this.subscribers) {
-      var sub = this.getSubscriber(subId);
-      this.muteSubscriberStream(subId, sub.muteVideo, sub.muteAudio);
+  disableDefaultHandlers() {
+    const disabledHandlers = global.config.erizo.disabledHandlers;
+    if (!this.mediaStream) {
+      return;
+    }
+    for (const index in disabledHandlers) {
+      this.mediaStream.disableHandler(disabledHandlers[index]);
     }
   }
 
-  setQualityLayer(clientId, spatialLayer, temporalLayer) {
-    var subscriber = this.getSubscriber(clientId);
-    log.info('message: setQualityLayer, spatialLayer: ', spatialLayer,
-                                     ', temporalLayer: ', temporalLayer);
-    subscriber.mediaStream.setQualityLayer(spatialLayer, temporalLayer);
+  _onSchemeSlideShowModeChange(message, clientId) {
+    this.setSlideShow(message.enabled, clientId);
+  }
+
+  onSignalingMessage(msg) {
+    const connection = this.connection;
+    if (!connection) {
+      return;
+    }
+    if (msg.type === 'offer') {
+      const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
+      connection.setRemoteDescription(sdp);
+      this.disableDefaultHandlers();
+    } else if (msg.type === 'candidate') {
+      connection.addRemoteCandidate(msg.candidate);
+    } else if (msg.type === 'updatestream') {
+      if (msg.sdp) {
+        const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
+        connection.setRemoteDescription(sdp);
+      }
+      if (msg.config) {
+        if (msg.config.minVideoBW) {
+          log.debug('message: updating minVideoBW for publisher, ' +
+                    'id: ' + this.streamId + ', ' +
+                    'minVideoBW: ' + msg.config.minVideoBW);
+          this.minVideoBW = msg.config.minVideoBW;
+          for (const clientId in this.subscribers) {
+            const subscriber = this.getSubscriber(clientId);
+            subscriber.minVideoBW = msg.config.minVideoBW * 1000; // bps
+            subscriber.lowerThres = Math.floor(subscriber.minVideoBW * (1 - 0.2));
+            subscriber.upperThres = Math.ceil(subscriber.minVideoBW * (1 + 0.1));
+          }
+        }
+        if (msg.config.muteStream !== undefined) {
+          this.muteStream(msg.config.muteStream);
+        }
+      }
+    } else if (msg.type === 'control') {
+      this.processControlMessage(undefined, msg.action);
+    }
+  }
+
+  processControlMessage(clientId, action) {
+    const publisherSide = clientId === undefined || action.publisherSide;
+    switch(action.name) {
+      case 'controlhandlers':
+        if (action.enable) {
+          this.enableHandlers(publisherSide ? undefined : clientId, action.handlers);
+        } else {
+          this.disableHandlers(publisherSide ? undefined : clientId, action.handlers);
+        }
+        break;
+    }
+  }
+
+  generateVideoKeyFrame() {
+    if (this.mediaStream) {
+      this.mediaStream.generatePLIPacket();
+    }
+  }
+
+  maybeStopSlideShow() {
+    if (this.connection && this.mediaStream && this.mediaStream.periodicPlis !== undefined) {
+      for (const i in this.subscribers) {
+        if (this.getSubscriber(i).mediaStream.slideShowMode === true) {
+          return;
+        }
+      }
+      log.debug('message: clearing Pli interval as no more ' +
+                'slideshows subscribers are present');
+      clearInterval(this.mediaStream.periodicPlis);
+      this.mediaStream.periodicPlis = undefined;
+    }
+  }
+
+  setSlideShow(slideShowMode, clientId) {
+    if (!this.mediaStream) {
+      return;
+    }
+    const subscriber = this.getSubscriber(clientId);
+    if (!subscriber) {
+        log.warn('message: subscriber not found for updating slideshow, ' +
+                 'code: ' + WARN_NOT_FOUND + ', id: ' + clientId + '_' + this.streamId);
+        return;
+    }
+
+    log.debug('message: setting SlideShow, id: ' + subscriber.clientId +
+              ', slideShowMode: ' + slideShowMode);
+    let period = slideShowMode === true ? MIN_SLIDESHOW_PERIOD : slideShowMode;
+    if (Number.isSafeInteger(period)) {
+      period = period < MIN_SLIDESHOW_PERIOD ? MIN_SLIDESHOW_PERIOD : period;
+      period = period > MAX_SLIDESHOW_PERIOD ? MAX_SLIDESHOW_PERIOD : period;
+      subscriber.mediaStream.setSlideShowMode(true);
+      subscriber.mediaStream.slideShowMode = true;
+      if (this.mediaStream.periodicPlis) {
+        clearInterval(this.mediaStream.periodicPlis);
+        this.mediaStream.periodicPlis = undefined;
+      }
+      this.mediaStream.periodicPlis = setInterval(() => {
+        this.mediaStream.generatePLIPacket();
+      }, period);
+    } else {
+      for (let pliIndex = 0; pliIndex < PLIS_TO_RECOVER; pliIndex++) {
+        this.mediaStream.generatePLIPacket();
+      }
+
+      subscriber.mediaStream.setSlideShowMode(false);
+      subscriber.mediaStream.slideShowMode = false;
+      if (this.mediaStream.periodicPlis !== undefined) {
+        for (const i in this.subscribers) {
+          if (this.getSubscriber(i).mediaStream.slideShowMode === true) {
+              return;
+          }
+        }
+        log.debug('message: clearing PLI interval for publisher slideShow, ' +
+                  'id: ' + this.clientId);
+        clearInterval(this.mediaStream.periodicPlis);
+        this.mediaStream.periodicPlis = undefined;
+      }
+    }
+  }
+
+  muteStream(muteStreamInfo, clientId) {
+    if (muteStreamInfo.video === undefined) {
+        muteStreamInfo.video = false;
+    }
+    if (muteStreamInfo.audio === undefined) {
+        muteStreamInfo.audio = false;
+    }
+    if (clientId && this.hasSubscriber(clientId)) {
+      this.muteSubscriberStream(clientId, muteStreamInfo.video, muteStreamInfo.audio);
+    } else {
+      for (const subId in this.subscribers) {
+        const sub = this.getSubscriber(subId);
+        this.muteVideo = muteStreamInfo.video;
+        this.muteAudio = muteStreamInfo.audio;
+        this.muteSubscriberStream(subId, sub.muteVideo, sub.muteAudio);
+      }
+    }
+  }
+
+  setQualityLayer(qualityLayer, clientId) {
+    const subscriber = this.getSubscriber(clientId);
+    if (!subscriber) {
+      return;
+    }
+    log.info('message: setQualityLayer, spatialLayer: ', qualityLayer.spatialLayer,
+                                     ', temporalLayer: ', qualityLayer.temporalLayer);
+    subscriber.mediaStream.setQualityLayer(qualityLayer.spatialLayer, qualityLayer.temporalLayer);
   }
 
   muteSubscriberStream(clientId, muteVideo, muteAudio) {
-    var subscriber = this.getSubscriber(clientId);
+    const subscriber = this.getSubscriber(clientId);
     subscriber.muteVideo = muteVideo;
     subscriber.muteAudio = muteAudio;
     log.info('message: Mute Stream, video: ', this.muteVideo || muteVideo,
@@ -155,21 +296,30 @@ class Source extends Node {
                           this.muteAudio || muteAudio);
   }
 
-  setVideoConstraints(clientId, width, height, frameRate) {
-    var subscriber = this.getSubscriber(clientId);
-    var maxWidth = (width && width.max !== undefined) ? width.max : -1;
-    var maxHeight = (height && height.max !== undefined) ? height.max : -1;
-    var maxFrameRate = (frameRate && frameRate.max !== undefined) ? frameRate.max : -1;
+  setVideoConstraints(video, clientId) {
+    const subscriber = this.getSubscriber(clientId);
+    if (!subscriber) {
+      return;
+    }
+    const width = video.width;
+    const height = video.height;
+    const frameRate = video.frameRate;
+    const maxWidth = (width && width.max !== undefined) ? width.max : -1;
+    const maxHeight = (height && height.max !== undefined) ? height.max : -1;
+    const maxFrameRate = (frameRate && frameRate.max !== undefined) ? frameRate.max : -1;
     subscriber.mediaStream.setVideoConstraints(maxWidth, maxHeight, maxFrameRate);
   }
 
   enableHandlers(clientId, handlers) {
     let mediaStream = this.mediaStream;
+    if (!mediaStream) {
+      return;
+    }
     if (clientId) {
       mediaStream = this.getSubscriber(clientId).mediaStream;
     }
     if (mediaStream) {
-      for (var index in handlers) {
+      for (const index in handlers) {
         mediaStream.enableHandler(handlers[index]);
       }
     }
@@ -177,27 +327,34 @@ class Source extends Node {
 
   disableHandlers(clientId, handlers) {
     let mediaStream = this.mediaStream;
+    if (!mediaStream) {
+      return;
+    }
     if (clientId) {
       mediaStream = this.getSubscriber(clientId).mediaStream;
     }
     if (mediaStream) {
-      for (var index in handlers) {
+      for (const index in handlers) {
         mediaStream.disableHandler(handlers[index]);
       }
     }
+  }
+
+  close() {
   }
 }
 
 class Publisher extends Source {
   constructor(clientId, streamId, connection, options) {
-    super(clientId, streamId, connection.threadPool);
+    super(clientId, streamId, connection.threadPool, options);
     this.mediaConfiguration = options.mediaConfiguration;
+    this.options = options;
     this.connection = connection;
+
     this.connection.mediaConfiguration = options.mediaConfiguration;
-    
-    this.connection.addMediaStream(streamId);
+
+    this.connection.addMediaStream(streamId, options.metadata);
     this.mediaStream = this.connection.getMediaStream(streamId);
-    
 
     this.minVideoBW = options.minVideoBW;
     this.scheme = options.scheme;
@@ -207,22 +364,30 @@ class Publisher extends Source {
     this.muxer.setPublisher(this.mediaStream);
     const muteVideo = (options.muteStream && options.muteStream.video) || false;
     const muteAudio = (options.muteStream && options.muteStream.audio) || false;
-    this.muteStream(muteVideo, muteAudio);
+    this.muteStream({video: muteVideo, audio: muteAudio});
   }
 
   close() {
     this.connection.removeMediaStream(this.mediaStream.id);
+    if (this.mediaStream.monitorInterval) {
+      clearInterval(this.mediaStream.monitorInterval);
+    }
+    if (this.mediaStream.periodicPlis !== undefined) {
+        log.debug('message: clearing periodic PLIs for publisher, id: ' + this.streamId);
+        clearInterval(this.mediaStream.periodicPlis);
+        this.mediaStream.periodicPlis = undefined;
+    }
   }
 }
 
 class ExternalInput extends Source {
   constructor(url, streamId, threadPool) {
     super(url, streamId, threadPool);
-    var eiId = streamId + '_' + url;
+    const eiId = streamId + '_' + url;
 
     log.info('message: Adding ExternalInput, id: ' + eiId);
 
-    var ei = new addon.ExternalInput(url);
+    const ei = new addon.ExternalInput(url);
 
     this.ei = ei;
     ei.id = streamId;

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -190,7 +190,7 @@ class Source extends NodeClass {
     }
   }
 
-  generateVideoKeyFrame() {
+  requestVideoKeyFrame() {
     if (this.mediaStream) {
       this.mediaStream.generatePLIPacket();
     }
@@ -243,17 +243,7 @@ class Source extends NodeClass {
 
       subscriber.mediaStream.setSlideShowMode(false);
       subscriber.mediaStream.slideShowMode = false;
-      if (this.mediaStream.periodicPlis !== undefined) {
-        for (const i in this.subscribers) {
-          if (this.getSubscriber(i).mediaStream.slideShowMode === true) {
-              return;
-          }
-        }
-        log.debug('message: clearing PLI interval for publisher slideShow, ' +
-                  'id: ' + this.clientId);
-        clearInterval(this.mediaStream.periodicPlis);
-        this.mediaStream.periodicPlis = undefined;
-      }
+      this.maybeStopSlideShow();
     }
   }
 

--- a/erizo_controller/erizoJS/models/Subscriber.js
+++ b/erizo_controller/erizoJS/models/Subscriber.js
@@ -26,7 +26,7 @@ class Subscriber extends NodeClass {
   _onConnectionStatusEvent(connectionEvent) {
     if (connectionEvent.type === 'ready') {
       if (this.clientId && this.options.browser === 'bowser') {
-          this.publisher.generateVideoKeyFrame();
+          this.publisher.requestVideoKeyFrame();
       }
       if (this.options.slideShowMode === true || 
           Number.isSafeInteger(this.options.slideShowMode)) {

--- a/erizo_controller/erizoJS/models/Subscriber.js
+++ b/erizo_controller/erizoJS/models/Subscriber.js
@@ -1,0 +1,91 @@
+/*global require, exports*/
+'use strict';
+const NodeClass = require('./Node').Node;
+const logger = require('./../../common/logger').logger;
+var SemanticSdp = require('./../../common/semanticSdp/SemanticSdp');
+
+// Logger
+const log = logger.getLogger('Subscriber');
+
+class Subscriber extends NodeClass {
+  constructor(clientId, streamId, connection, publisher, options) {
+    super(clientId, streamId, options);
+    this.connection = connection;
+    this.connection.mediaConfiguration = options.mediaConfiguration;
+    this.connection.addMediaStream(this.erizoStreamId, options.metadata);
+    this.mediaStream = connection.getMediaStream(this.erizoStreamId);
+    this.publisher = publisher;
+    this._listenToConnectionStuff();
+  }
+
+  _listenToConnectionStuff() {
+    this._statusListener = this._onConnectionStatusEvent.bind(this);
+    this.connection.on('status_event', this._statusListener);
+  }
+
+  _onConnectionStatusEvent(connectionEvent) {
+    if (connectionEvent.type === 'ready') {
+      if (this.clientId && this.options.browser === 'bowser') {
+          this.publisher.generateVideoKeyFrame();
+      }
+      if (this.options.slideShowMode === true || 
+          Number.isSafeInteger(this.options.slideShowMode)) {
+        this.publisher.setSlideShow(this.options.slideShowMode, this.clientId);
+      }
+    }
+  }
+
+  disableDefaultHandlers() {
+    const disabledHandlers = global.config.erizo.disabledHandlers;
+    for (const index in disabledHandlers) {
+      this.mediaStream.disableHandler(disabledHandlers[index]);
+    }
+  }
+
+  onSignalingMessage(msg, publisher) {
+    let connection = this.connection;
+
+    if (msg.type === 'offer') {
+      const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
+      connection.setRemoteDescription(sdp);
+      this.disableDefaultHandlers();
+    } else if (msg.type === 'candidate') {
+      connection.addRemoteCandidate(msg.candidate);
+    } else if (msg.type === 'updatestream') {
+      if (msg.sdp) {
+        const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
+        connection.setRemoteDescription(sdp);
+      }
+      if (msg.config) {
+        if (msg.config.slideShowMode !== undefined) {
+          this.publisher.setSlideShow(msg.config.slideShowMode, this.clientId);
+        }
+        if (msg.config.muteStream !== undefined) {
+          this.publisher.muteStream(msg.config.muteStream, this.clientId);
+        }
+        if (msg.config.qualityLayer !== undefined) {
+          this.publisher.setQualityLayer(msg.config.qualityLayer, this.clientId);
+        }
+        if (msg.config.video !== undefined) {
+          this.publisher.setVideoConstraints(msg.config.video, this.clientId);
+        }
+      }
+    } else if (msg.type === 'control') {
+      publisher.processControlMessage(this.clientId, msg.action);
+    }
+  }
+
+  close() {
+    log.debug(`msg: Closing subscriber, streamId:${this.streamId}`);
+    this.publisher = undefined;
+    if (this.connection) {
+      this.connection.removeListener('status_event', this._statusListener);
+      this.connection.removeMediaStream(this.mediaStream.id);
+    }
+    if (this.mediaStream && this.mediaStream.monitorInterval) {
+      clearInterval(this.mediaStream.monitorInterval);
+    }
+  }
+}
+
+exports.Subscriber = Subscriber;

--- a/erizo_controller/test/erizoJS/erizoJSController.js
+++ b/erizo_controller/test/erizoJS/erizoJSController.js
@@ -262,7 +262,7 @@ describe('Erizo JS Controller', function() {
     describe('Process Signaling Message', function() {
       beforeEach(function() {
         mocks.WebRtcConnection.init.onFirstCall().returns(1);
-        controller.addPublisher(kArbitraryClientId, kArbitraryStreamId, kArbitraryUrl, callback);
+        controller.addPublisher(kArbitraryClientId, kArbitraryStreamId, {}, callback);
       });
 
       it('should set remote sdp when received', function() {
@@ -294,7 +294,7 @@ describe('Erizo JS Controller', function() {
       beforeEach(function() {
         subCallback = sinon.stub();
         mocks.WebRtcConnection.init.onFirstCall().returns(1);
-        controller.addPublisher(kArbitraryClientId, kArbitraryStreamId, kArbitraryUrl, callback);
+        controller.addPublisher(kArbitraryClientId, kArbitraryStreamId, {}, callback);
       });
 
       it('should succeed creating WebRtcConnection and adding sub to muxer', function() {

--- a/erizo_controller/test/erizoJS/erizoJSController.js
+++ b/erizo_controller/test/erizoJS/erizoJSController.js
@@ -143,7 +143,6 @@ describe('Erizo JS Controller', function() {
     var callback;
     var kArbitraryStreamId = 'pubStreamId1';
     var kArbitraryClientId = 'pubClientid1';
-    var kArbitraryUrl = 'url1';
 
     beforeEach(function() {
       callback = sinon.stub();


### PR DESCRIPTION
**Description**

This PR refactors the way we handle messages in ErizoJSController. The main idea is to decouple things between ErizoJSController, Connection, Publisher and Subscriber, while keeping the focus on making things easier for Single Peer Connection.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.