### PR TITLE
Fix/erizo client build errors

### DIFF
--- a/erizo_controller/erizoClient/gulp/erizoFcTasks.js
+++ b/erizo_controller/erizoClient/gulp/erizoFcTasks.js
@@ -14,9 +14,9 @@ const erizoFcTasks = (gulp, plugins, config) => {
   that.bundle = () =>
     gulp.src(erizoFcConfig.entry)
     .pipe(plugins.webpackGulp(erizoFcConfig.webpackConfig, plugins.webpack))
-    .on('error', anError => console.log('An error ', anError))
+    .on('error', anError => plugins.exitOnError(anError))
     .pipe(gulp.dest(erizoFcConfig.debug))
-    .on('error', anError => console.log('An error ', anError));
+    .on('error', anError => plugins.exitOnError(anError));
 
   that.compile = () => gulp.src(`${erizoFcConfig.debug}/**/*.js`)
     .pipe(gulp.dest(erizoFcConfig.production));

--- a/erizo_controller/erizoClient/gulp/erizoTasks.js
+++ b/erizo_controller/erizoClient/gulp/erizoTasks.js
@@ -15,9 +15,9 @@ const erizoTasks = (gulp, plugins, config) => {
   that.bundle = () =>
     gulp.src(erizoConfig.entry, { base: './' })
     .pipe(plugins.webpackGulp(erizoConfig.webpackConfig, plugins.webpack))
-    .on('error', anError => console.log('An error ', anError))
+    .on('error', anError => plugins.exitOnError(anError))
     .pipe(gulp.dest(erizoConfig.debug))
-    .on('error', anError => console.log('An error ', anError));
+    .on('error', anError => plugins.exitOnError(anError));
 
   that.compile = () =>
     gulp.src(`${erizoConfig.debug}/**/*.js`, { base: './' })
@@ -28,7 +28,9 @@ const erizoTasks = (gulp, plugins, config) => {
         jsOutputFile: 'erizo.js',
         createSourceMap: true,
       }))
+      .on('error', anError => plugins.exitOnError(anError))
       .pipe(plugins.sourcemaps.write('/')) // gulp-sourcemaps automatically adds the sourcemap url comment
+      .on('error', anError => plugins.exitOnError(anError))
       .pipe(gulp.dest(erizoConfig.production));
 
   that.dist = () =>

--- a/erizo_controller/erizoClient/gulpfile.js
+++ b/erizo_controller/erizoClient/gulpfile.js
@@ -11,6 +11,12 @@ plugins.closureCompiler = require('google-closure-compiler-js').gulp();
 plugins.webpack = require('webpack');
 plugins.webpackGulp = require('webpack-stream');
 
+const errorExitCode = 2;
+
+plugins.exitOnError = (error) => {
+  console.log('Error running task', error);
+  return process.exit(errorExitCode);
+}
 
 const config = {
   paths: {

--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -7,10 +7,10 @@ import { EventEmitter, ConnectionEvent } from './Events';
 import ErizoMap from './utils/ErizoMap';
 import ConnectionHelpers from './utils/ConnectionHelpers';
 
-const EventEmitterErizo = EventEmitter; // makes google-closure-compiler happy
+const EventEmitterConst = EventEmitter; // makes google-closure-compiler happy
 let ErizoSessionId = 103;
 
-class ErizoConnection extends EventEmitterErizo {
+class ErizoConnection extends EventEmitterConst {
   constructor(specInput, erizoId = undefined) {
     super();
     Logger.debug('Building a new Connection');

--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -7,10 +7,10 @@ import { EventEmitter, ConnectionEvent } from './Events';
 import ErizoMap from './utils/ErizoMap';
 import ConnectionHelpers from './utils/ConnectionHelpers';
 
-
+const EventEmitterErizo = EventEmitter; // makes google-closure-compiler happy
 let ErizoSessionId = 103;
 
-class ErizoConnection extends EventEmitter {
+class ErizoConnection extends EventEmitterErizo {
   constructor(specInput, erizoId = undefined) {
     super();
     Logger.debug('Building a new Connection');

--- a/erizo_controller/installErizo_controller.sh
+++ b/erizo_controller/installErizo_controller.sh
@@ -10,16 +10,25 @@ NVM_CHECK="$LICODE_ROOT"/scripts/checkNvm.sh
 
 . $NVM_CHECK
 
+check_result() {
+  if [ "$1" -ne 0 ]
+  then
+    echo "ERROR: Failed building ErizoClient"
+    exit $1
+  fi
+}
+
 echo [erizo_controller] Installing node_modules for erizo_controller
 
 nvm use
 npm install --loglevel error amqp socket.io@2.0.3 log4js@1.0.1 node-getopt uuid@3.1.0 sdp-transform@2.3.0
-npm install --loglevel error -g google-closure-compiler-js
 
 echo [erizo_controller] Done, node_modules installed
 
 cd ./erizoClient/
 
 gulp erizo
+
+check_result $?
 
 echo [erizo_controller] Done, erizo.js compiled

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     }
   ],
   "scripts": {
-    "buildClient": "cd erizo_controller/erizoClient && gulp",
+    "buildClient": "cd erizo_controller/erizoClient && ../../node_modules/.bin/gulp",
     "test": " ./node_modules/mocha/bin/mocha nuve/nuveAPI/test/* erizo_controller/test/*",
-    "lintClient": "cd erizo_controller/erizoClient && gulp lint",
+    "lintClient": "cd erizo_controller/erizoClient && ../../node_modules/.bin/gulp lint",
     "lint": "./node_modules/jshint/bin/jshint erizo_controller/erizoAgent/ erizo_controller/erizoController/ erizo_controller/erizoJS/ erizo_controller/common/amqper.js erizo_controller/common/logger.js erizo_controller/test/ nuve/ extras/basic_example/basicServer.js extras/basic_example/public/*.js spine/"
   }
 }

--- a/scripts/installMacDeps.sh
+++ b/scripts/installMacDeps.sh
@@ -96,8 +96,8 @@ install_brew_deps(){
   install_nvm_node
   nvm use
   npm install
-  npm install -g node-gyp gulp-cli
-  npm install webpack gulp gulp-eslint@3 run-sequence webpack-stream google-closure-compiler-js del gulp-sourcemaps script-loader expose-loader
+  npm install -g node-gyp
+  npm install gulp@3.9.1 gulp-eslint@3 run-sequence@2.2.1 webpack-stream@4.0.0 google-closure-compiler-js@20170910.0.1 del@3.0.0 gulp-sourcemaps@2.6.4 script-loader@0.7.2 expose-loader@0.7.5
   if [ "$DISABLE_SERVICES" != "true" ]; then
     brew install rabbitmq mongodb
   fi

--- a/scripts/installMacDeps.sh
+++ b/scripts/installMacDeps.sh
@@ -97,7 +97,7 @@ install_brew_deps(){
   nvm use
   npm install
   npm install -g node-gyp
-  npm install gulp@3.9.1 gulp-eslint@3 run-sequence@2.2.1 webpack-stream@4.0.0 google-closure-compiler-js@20170910.0.1 del@3.0.0 gulp-sourcemaps@2.6.4 script-loader@0.7.2 expose-loader@0.7.5
+  npm install gulp@3.9.1 gulp-eslint@3 run-sequence@2.2.1 webpack-stream@4.0.0 google-closure-compiler-js@20170521.0.0 del@3.0.0 gulp-sourcemaps@2.6.4 script-loader@0.7.2 expose-loader@0.7.5
   if [ "$DISABLE_SERVICES" != "true" ]; then
     brew install rabbitmq mongodb
   fi

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -70,7 +70,7 @@ install_apt_deps(){
   nvm use
   npm install
   npm install -g node-gyp
-  npm install gulp@3.9.1 gulp-eslint@3 run-sequence@2.2.1 webpack-stream@4.0.0 google-closure-compiler-js@20170910.0.1 del@3.0.0 gulp-sourcemaps@2.6.4 script-loader@0.7.2 expose-loader@0.7.5
+  npm install gulp@3.9.1 gulp-eslint@3 run-sequence@2.2.1 webpack-stream@4.0.0 google-closure-compiler-js@20170521.0.0 del@3.0.0 gulp-sourcemaps@2.6.4 script-loader@0.7.2 expose-loader@0.7.5
   sudo apt-get install -qq python-software-properties -y
   sudo apt-get install -qq software-properties-common -y
   sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -69,8 +69,8 @@ install_apt_deps(){
   install_nvm_node
   nvm use
   npm install
-  npm install -g node-gyp gulp-cli
-  npm install webpack gulp gulp-eslint@3 run-sequence webpack-stream google-closure-compiler-js del gulp-sourcemaps script-loader expose-loader
+  npm install -g node-gyp
+  npm install gulp@3.9.1 gulp-eslint@3 run-sequence@2.2.1 webpack-stream@4.0.0 google-closure-compiler-js@20170910.0.1 del@3.0.0 gulp-sourcemaps@2.6.4 script-loader@0.7.2 expose-loader@0.7.5
   sudo apt-get install -qq python-software-properties -y
   sudo apt-get install -qq software-properties-common -y
   sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This fixes ErizoClient builds by specifying version numbers for all components involved and working around a couple of errors.
It also makes sure we notice when builds fail in CI by capturing gulp errors and terminating the process with an error code. That error code is also now properly propagated to the parent scripts if any (for instance `installErizo.sh`.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.