### PR TITLE
Fix several crashes and bugs in Single Peer Connection

### DIFF
--- a/erizo/src/erizo/MediaDefinitions.h
+++ b/erizo/src/erizo/MediaDefinitions.h
@@ -199,10 +199,17 @@ class MediaSource: public virtual Monitor {
     virtual int sendPLI() = 0;
     uint32_t getVideoSourceSSRC() {
         boost::mutex::scoped_lock lock(monitor_mutex_);
+        if (video_source_ssrc_list_.empty()) {
+          return 0;
+        }
         return video_source_ssrc_list_[0];
     }
     void setVideoSourceSSRC(uint32_t ssrc) {
         boost::mutex::scoped_lock lock(monitor_mutex_);
+        if (video_source_ssrc_list_.empty()) {
+          video_source_ssrc_list_.push_back(ssrc);
+          return;
+        }
         video_source_ssrc_list_[0] = ssrc;
     }
     std::vector<uint32_t> getVideoSourceSSRCList() {

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -138,18 +138,15 @@ bool MediaStream::setRemoteSdp(std::shared_ptr<SdpInfo> sdp) {
 
 
   bundle_ = remote_sdp_->isBundle;
-  try {
-    auto video_ssrc_list = remote_sdp_->video_ssrc_map.at(getLabel());
-    setVideoSourceSSRCList(video_ssrc_list);
-  } catch(const std::out_of_range& oor) {
+  auto video_ssrc_list_it = remote_sdp_->video_ssrc_map.find(getLabel());
+  if (video_ssrc_list_it != remote_sdp_->video_ssrc_map.end()) {
+    setVideoSourceSSRCList(video_ssrc_list_it->second);
   }
 
-  try {
-    auto audio_ssrc = remote_sdp_->audio_ssrc_map.at(getLabel());
-    setAudioSourceSSRC(audio_ssrc);
-  } catch(const std::out_of_range& oor) {
+  auto audio_ssrc_it = remote_sdp_->audio_ssrc_map.find(getLabel());
+  if (audio_ssrc_it != remote_sdp_->audio_ssrc_map.end()) {
+    setAudioSourceSSRC(audio_ssrc_it->second);
   }
-
 
   if (getVideoSourceSSRCList().empty() ||
       (getVideoSourceSSRCList().size() == 1 && getVideoSourceSSRCList()[0] == 0)) {

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -425,9 +425,9 @@ WebRTCEvent MediaStream::getCurrentState() {
 }
 
 void MediaStream::getJSONStats(std::function<void(std::string)> callback) {
-  asyncTask([callback] (std::shared_ptr<MediaStream> connection) {
-    std::string requested_stats = connection->stats_->getStats();
-    //  ELOG_DEBUG("%s message: Stats, stats: %s", connection->toLog(), requested_stats.c_str());
+  asyncTask([callback] (std::shared_ptr<MediaStream> stream) {
+    std::string requested_stats = stream->stats_->getStats();
+    //  ELOG_DEBUG("%s message: Stats, stats: %s", stream->toLog(), requested_stats.c_str());
     callback(requested_stats);
   });
 }

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -44,7 +44,8 @@ DEFINE_LOGGER(MediaStream, "MediaStream");
 MediaStream::MediaStream(std::shared_ptr<Worker> worker,
   std::shared_ptr<WebRtcConnection> connection,
   const std::string& media_stream_id,
-  const std::string& media_stream_label) :
+  const std::string& media_stream_label,
+  bool is_publisher) :
     audio_enabled_{false}, video_enabled_{false},
     connection_{connection},
     stream_id_{media_stream_id},
@@ -53,7 +54,8 @@ MediaStream::MediaStream(std::shared_ptr<Worker> worker,
     pipeline_{Pipeline::create()},
     worker_{worker},
     audio_muted_{false}, video_muted_{false},
-    pipeline_initialized_{false} {
+    pipeline_initialized_{false},
+    is_publisher_{is_publisher} {
   setVideoSinkSSRC(kDefaultVideoSinkSSRC);
   setAudioSinkSSRC(kDefaultAudioSinkSSRC);
   ELOG_INFO("%s message: constructor, id: %s",

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -149,14 +149,15 @@ bool MediaStream::setRemoteSdp(std::shared_ptr<SdpInfo> sdp) {
   }
 
 
-  if (getVideoSourceSSRCList().empty()) {
+  if (getVideoSourceSSRCList().empty() ||
+      (getVideoSourceSSRCList().size() == 1 && getVideoSourceSSRCList()[0] == 0)) {
     std::vector<uint32_t> default_ssrc_list;
-    default_ssrc_list.push_back(55543);
+    default_ssrc_list.push_back(kDefaultVideoSinkSSRC);
     setVideoSourceSSRCList(default_ssrc_list);
   }
 
   if (getAudioSourceSSRC() == 0) {
-    setAudioSourceSSRC(44444);
+    setAudioSourceSSRC(kDefaultAudioSinkSSRC);
   }
 
   audio_enabled_ = remote_sdp_->hasAudio;

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -9,6 +9,8 @@
 #include <string>
 #include <cstring>
 #include <vector>
+#include <cstdlib>
+#include <ctime>
 
 #include "./MediaStream.h"
 #include "./SdpInfo.h"
@@ -61,6 +63,9 @@ MediaStream::MediaStream(std::shared_ptr<Worker> worker,
   stats_ = std::make_shared<Stats>();
   quality_manager_ = std::make_shared<QualityManager>();
   packet_buffer_ = std::make_shared<PacketBufferService>();
+  std::srand(std::time(nullptr));
+  audio_sink_ssrc_ = std::rand();
+  video_sink_ssrc_ = std::rand();
 
   rtcp_processor_ = std::make_shared<RtcpForwarder>(static_cast<MediaSink*>(this), static_cast<MediaSource*>(this));
 

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -235,10 +235,12 @@ int MediaStream::deliverEvent_(MediaEventPtr event) {
   return 1;
 }
 
-void MediaStream::onTransportData(std::shared_ptr<DataPacket> packet, Transport *transport) {
+void MediaStream::onTransportData(std::shared_ptr<DataPacket> incoming_packet, Transport *transport) {
   if ((audio_sink_ == nullptr && video_sink_ == nullptr && fb_sink_ == nullptr)) {
     return;
   }
+
+  std::shared_ptr<DataPacket> packet = std::make_shared<DataPacket>(*incoming_packet);
 
   if (transport->mediaType == AUDIO_TYPE) {
     packet->type = AUDIO_PACKET;

--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -131,7 +131,7 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   bool isPublisher() { return is_publisher_; }
 
   inline std::string toLog() {
-    return "id: " + stream_id_ + ", " + printLogContext();
+    return "id: " + stream_id_ + ", role:" + (is_publisher_ ? "publisher" : "subscriber") + " " + printLogContext();
   }
 
  private:

--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -87,6 +87,7 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
 
   void sendPacketAsync(std::shared_ptr<DataPacket> packet);
 
+  void setTransportInfo(std::string audio_info, std::string video_info);
 
   void setFeedbackReports(bool will_send_feedback, uint32_t target_bitrate = 0);
   void setSlideShowMode(bool state);

--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -52,7 +52,8 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
    * Constructs an empty MediaStream without any configuration.
    */
   MediaStream(std::shared_ptr<Worker> worker, std::shared_ptr<WebRtcConnection> connection,
-      const std::string& media_stream_id, const std::string& media_stream_label);
+      const std::string& media_stream_id, const std::string& media_stream_label,
+      bool is_publisher);
   /**
    * Destructor.
    */
@@ -125,7 +126,9 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   void parseIncomingPayloadType(char *buf, int len, packetType type);
 
   bool isPipelineInitialized() { return pipeline_initialized_; }
+  bool isRunning() { return pipeline_initialized_ && sending_; }
   Pipeline::Ptr getPipeline() { return pipeline_; }
+  bool isPublisher() { return is_publisher_; }
 
   inline std::string toLog() {
     return "id: " + stream_id_ + ", " + printLogContext();
@@ -171,6 +174,8 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   bool video_muted_;
 
   bool pipeline_initialized_;
+
+  bool is_publisher_;
  protected:
   std::shared_ptr<SdpInfo> remote_sdp_;
   std::shared_ptr<SdpInfo> local_sdp_;

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -452,12 +452,7 @@ void WebRtcConnection::onTransportData(std::shared_ptr<DataPacket> packet, Trans
   if (chead->isRtcp() && chead->packettype != RTCP_Sender_PT) {  // Sender Report
     ssrc = chead->getSourceSSRC();
   }
-  int index = 0;
-  forEachMediaStream([&index, packet, transport, ssrc] (const std::shared_ptr<MediaStream> &media_stream) {
-    if (index == 1) {
-      return;
-    }
-    index++;
+  forEachMediaStream([packet, transport, ssrc] (const std::shared_ptr<MediaStream> &media_stream) {
     if (media_stream->isSourceSSRC(ssrc) || media_stream->isSinkSSRC(ssrc)) {
       media_stream->onTransportData(packet, transport);
     }

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -39,7 +39,7 @@ class MediaStream;
  */
 enum WebRTCEvent {
   CONN_INITIAL = 101, CONN_STARTED = 102, CONN_GATHERED = 103, CONN_READY = 104, CONN_FINISHED = 105,
-  CONN_CANDIDATE = 201, CONN_SDP = 202,
+  CONN_CANDIDATE = 201, CONN_SDP = 202, CONN_SDP_PROCESSED = 203,
   CONN_FAILED = 500
 };
 
@@ -140,6 +140,7 @@ class WebRtcConnection: public TransportListener, public LogContext,
   void addMediaStream(std::shared_ptr<MediaStream> media_stream);
   void removeMediaStream(const std::string& stream_id);
   void forEachMediaStream(std::function<void(const std::shared_ptr<MediaStream>&)> func);
+  void forEachMediaStreamAsync(std::function<void(const std::shared_ptr<MediaStream>&)> func);
 
   std::shared_ptr<Stats> getStatsService() { return stats_; }
 
@@ -153,6 +154,8 @@ class WebRtcConnection: public TransportListener, public LogContext,
 
  private:
   bool processRemoteSdp();
+  void setRemoteSdpsToMediaStreams();
+  void onRemoteSdpsSetToMediaStreams();
   std::string getJSONCandidate(const std::string& mid, const std::string& sdp);
   void trackTransportInfo();
 
@@ -184,7 +187,7 @@ class WebRtcConnection: public TransportListener, public LogContext,
   std::shared_ptr<SdpInfo> local_sdp_;
   bool audio_muted_;
   bool video_muted_;
-  bool remote_sdp_processed_;
+  bool first_remote_sdp_processed_;
 };
 
 }  // namespace erizo

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -47,7 +47,7 @@ class WebRtcConnectionEventListener {
  public:
     virtual ~WebRtcConnectionEventListener() {
     }
-    virtual void notifyEvent(WebRTCEvent newEvent, const std::string& message) = 0;
+    virtual void notifyEvent(WebRTCEvent newEvent, const std::string& message, const std::string &stream_id = "") = 0;
 };
 
 /**
@@ -81,13 +81,13 @@ class WebRtcConnection: public TransportListener, public LogContext,
   void close();
   void syncClose();
 
-  bool setRemoteSdpInfo(std::shared_ptr<SdpInfo> sdp);
+  bool setRemoteSdpInfo(std::shared_ptr<SdpInfo> sdp, std::string stream_id);
   /**
    * Sets the SDP of the remote peer.
    * @param sdp The SDP.
    * @return true if the SDP was received correctly.
    */
-  bool setRemoteSdp(const std::string &sdp);
+  bool setRemoteSdp(const std::string &sdp, std::string stream_id);
 
   bool createOffer(bool video_enabled, bool audio_enabled, bool bundle);
   /**
@@ -153,9 +153,9 @@ class WebRtcConnection: public TransportListener, public LogContext,
   }
 
  private:
-  bool processRemoteSdp();
-  void setRemoteSdpsToMediaStreams();
-  void onRemoteSdpsSetToMediaStreams();
+  bool processRemoteSdp(std::string stream_id);
+  void setRemoteSdpsToMediaStreams(std::string stream_id);
+  void onRemoteSdpsSetToMediaStreams(std::string stream_id);
   std::string getJSONCandidate(const std::string& mid, const std::string& sdp);
   void trackTransportInfo();
 

--- a/erizo/src/test/utils/Mocks.h
+++ b/erizo/src/test/utils/Mocks.h
@@ -75,7 +75,7 @@ class MockMediaStream: public MediaStream {
   MockMediaStream(std::shared_ptr<Worker> worker, std::shared_ptr<WebRtcConnection> connection,
     const std::string& media_stream_id, const std::string& media_stream_label,
     std::vector<RtpMap> rtp_mappings) :
-  MediaStream(worker, connection, media_stream_id, media_stream_label) {
+  MediaStream(worker, connection, media_stream_id, media_stream_label, true) {
     local_sdp_ = std::make_shared<SdpInfo>(rtp_mappings);
     remote_sdp_ = std::make_shared<SdpInfo>(rtp_mappings);
   }

--- a/erizoAPI/MediaStream.cc
+++ b/erizoAPI/MediaStream.cc
@@ -128,10 +128,12 @@ NAN_METHOD(MediaStream::New) {
     v8::String::Utf8Value paramLabel(Nan::To<v8::String>(info[3]).ToLocalChecked());
     std::string stream_label = std::string(*paramLabel);
 
+    bool is_publisher = info[5]->BooleanValue();
+
     std::shared_ptr<erizo::Worker> worker = thread_pool->me->getLessUsedWorker();
 
     MediaStream* obj = new MediaStream();
-    obj->me = std::make_shared<erizo::MediaStream>(worker, wrtc, wrtc_id, stream_label);
+    obj->me = std::make_shared<erizo::MediaStream>(worker, wrtc, wrtc_id, stream_label, is_publisher);
     obj->msink = obj->me.get();
     obj->id_ = wrtc_id;
     obj->label_ = stream_label;

--- a/erizoAPI/WebRtcConnection.h
+++ b/erizoAPI/WebRtcConnection.h
@@ -27,7 +27,7 @@ class WebRtcConnection : public erizo::WebRtcConnectionEventListener,
     std::shared_ptr<erizo::WebRtcConnection> me;
     int eventSt;
     std::queue<int> eventSts;
-    std::queue<std::string> eventMsgs;
+    std::queue<std::pair<std::string, std::string>> eventMsgs;
 
     boost::mutex mutex;
 
@@ -110,7 +110,9 @@ class WebRtcConnection : public erizo::WebRtcConnectionEventListener,
 
     static NAUV_WORK_CB(eventsCallback);
 
-    virtual void notifyEvent(erizo::WebRTCEvent event, const std::string& message = "");
+    virtual void notifyEvent(erizo::WebRTCEvent event,
+                             const std::string& message = "",
+                             const std::string& stream_id = "");
 };
 
 #endif  // ERIZOAPI_WEBRTCCONNECTION_H_

--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -77,8 +77,8 @@ class ErizoConnection extends EventEmitterConst {
     this.stack.close();
   }
 
-  createOffer(isSubscribe, forceOfferToReceive) {
-    this.stack.createOffer(isSubscribe, forceOfferToReceive);
+  createOffer(isSubscribe, forceOfferToReceive, streamId) {
+    this.stack.createOffer(isSubscribe, forceOfferToReceive, streamId);
   }
 
   addStream(stream) {

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -159,12 +159,12 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
 
   const getErizoConnectionOptions = (stream, options, isRemote) => {
     const connectionOpts = {
-      callback(message) {
-        Logger.info('Sending message', message);
+      callback(message, streamId = stream.getID()) {
+        Logger.info('Sending message', message, stream.getID(), streamId);
         socket.sendSDP('signaling_message', {
-          streamId: stream.getID(),
+          streamId,
           msg: message,
-          browser: stream.pc.browser }, undefined, () => {});
+          browser: stream.pc && stream.pc.browser }, undefined, () => {});
       },
       nop2p: true,
       audio: options.audio && stream.hasAudio(),
@@ -192,7 +192,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
         onStreamFailed(stream);
       }
     });
-    stream.pc.createOffer(true);
+    stream.pc.createOffer(true, false, stream.getID());
   };
 
   const createLocalStreamErizoConnection = (streamInput, erizoId, options) => {
@@ -206,7 +206,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       }
     });
     stream.pc.addStream(stream);
-    if (!options.createOffer) { stream.pc.createOffer(false, spec.singlePC); }
+    if (!options.createOffer) { stream.pc.createOffer(false, spec.singlePC, stream.getID()); }
   };
 
   // We receive an event with a new stream in the room.

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -89,7 +89,7 @@ const BaseStack = (specInput) => {
     }
   };
 
-  const setLocalDescForOffer = (isSubscribe, sessionDescription) => {
+  const setLocalDescForOffer = (isSubscribe, streamId, sessionDescription) => {
     localDesc = sessionDescription;
     if (!isSubscribe) {
       localDesc.sdp = that.enableSimulcast(localDesc.sdp);
@@ -102,7 +102,7 @@ const BaseStack = (specInput) => {
     specBase.callback({
       type: localDesc.type,
       sdp: localDesc.sdp,
-    });
+    }, streamId);
   };
 
   const setLocalDescForAnswerp2p = (sessionDescription) => {
@@ -169,7 +169,7 @@ const BaseStack = (specInput) => {
         isNegotiating = false;
         if (offerQueue.length > 0) {
           const args = offerQueue.pop();
-          that.createOffer(args[0], args[1]);
+          that.createOffer(args[0], args[1], args[2]);
         }
       }).catch(errorCallback.bind(null, 'processAnswer', undefined));
     }).catch(errorCallback.bind(null, 'processAnswer', undefined));
@@ -271,7 +271,7 @@ const BaseStack = (specInput) => {
     }
   };
 
-  that.createOffer = (isSubscribe = false, forceOfferToReceive = false) => {
+  that.createOffer = (isSubscribe = false, forceOfferToReceive = false, streamId = '') => {
     if (!isSubscribe && !forceOfferToReceive) {
       that.mediaConstraints = {
         offerToReceiveVideo: false,
@@ -279,13 +279,13 @@ const BaseStack = (specInput) => {
       };
     }
     if (isNegotiating) {
-      offerQueue.push([isSubscribe, forceOfferToReceive]);
+      offerQueue.push([isSubscribe, forceOfferToReceive, streamId]);
       return;
     }
     isNegotiating = true;
-    Logger.debug('Creating offer', that.mediaConstraints);
+    Logger.debug('Creating offer', that.mediaConstraints, streamId);
     that.peerConnection.createOffer(that.mediaConstraints)
-    .then(setLocalDescForOffer.bind(null, isSubscribe))
+    .then(setLocalDescForOffer.bind(null, isSubscribe, streamId))
     .catch(errorCallback.bind(null, 'Create Offer', undefined));
   };
 

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -14,6 +14,7 @@ const BaseStack = (specInput) => {
   let localSdp;
   let remoteSdp;
   let isNegotiating = false;
+  let latestSessionVersion = -1;
 
   Logger.info('Starting Base stack', specBase);
 
@@ -135,11 +136,17 @@ const BaseStack = (specInput) => {
 
   const processAnswer = (message) => {
     const msg = message;
+
+    remoteSdp = SemanticSdp.SDPInfo.processString(msg.sdp);
+    const sessionVersion = remoteSdp && remoteSdp.origin && remoteSdp.origin.sessionVersion;
+    if (latestSessionVersion >= sessionVersion) {
+      return;
+    }
     Logger.info('Set remote and local description');
     Logger.debug('Remote Description', msg.sdp);
     Logger.debug('Local Description', localDesc.sdp);
+    latestSessionVersion = sessionVersion;
 
-    remoteSdp = SemanticSdp.SDPInfo.processString(msg.sdp);
     SdpHelpers.setMaxBW(remoteSdp, specBase);
     msg.sdp = remoteSdp.toString();
     that.remoteSdp = remoteSdp;

--- a/erizo_controller/erizoController/models/Channel.js
+++ b/erizo_controller/erizoController/models/Channel.js
@@ -62,7 +62,7 @@ class Channel extends events.EventEmitter {
 
   onToken(options, callback) {
     const token = options.token;
-    log.debug('message: token received, options: ', options);
+    log.debug('message: token received');
     if (checkSignature(token, NUVE_KEY)) {
       this.nuve.deleteToken(token.tokenId).then(tokenDB => {
         if (token.host === tokenDB.host) {

--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -266,7 +266,6 @@ class Client extends events.EventEmitter {
   }
 
   onSubscribe(options, sdp, callback) {
-    log.info('Subscribing', options, this.user);
     if (this.user === undefined || !this.user.permissions[Permission.SUBSCRIBE]) {
         callback(null, 'Unauthorized');
         return;

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -20,7 +20,6 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
         statsSubscriptions = {},
         onAdaptSchemeNotify,
         onPeriodicStats,
-        addListenerToConnection,
         onConnectionStatusEvent,
         closeNode,
         getOrCreateClient,
@@ -50,14 +49,6 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
                                  subs: clientId,
                                  stats: JSON.parse(newStats),
                                  timestamp:timeStamp.getTime()});
-    };
-
-    addListenerToConnection = (connection, callbackRpc, clientId, streamId) => {
-      if (!connection._onConnectionStatusEventListener) {
-        connection._onConnectionStatusEventListener =
-          onConnectionStatusEvent.bind(this, callbackRpc, clientId, streamId);
-        connection.on('status_event', connection._onConnectionStatusEventListener);
-      }
     };
 
     onConnectionStatusEvent = (callbackRpc, clientId, streamId, connectionEvent, newStatus) => {
@@ -161,10 +152,13 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
           publisher.initMediaStream();
           publisher.on('callback', onAdaptSchemeNotify.bind(this, callbackRpc));
           publisher.on('periodic_stats', onPeriodicStats.bind(this, streamId, undefined));
-          addListenerToConnection(connection, callbackRpc, clientId, streamId);
+          publisher.on('status_event', onConnectionStatusEvent.bind(this, callbackRpc, clientId, streamId));
           const isNewConnection = connection.init();
           if (options.singlePC && !isNewConnection) {
             callbackRpc('callback', {type: 'initializing'});
+            if (connection.ready) {
+              callbackRpc('callback', {type: 'ready'});
+            }
           }
         } else {
             publisher = publishers[streamId];
@@ -211,9 +205,13 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
         subscriber.initMediaStream();
         subscriber.on('callback', onAdaptSchemeNotify.bind(this, callbackRpc));
         subscriber.on('periodic_stats', onPeriodicStats.bind(this, clientId, streamId));
-        addListenerToConnection(connection, callbackRpc, clientId, streamId);
-        if (!connection.init()) {
+        subscriber.on('status_event', onConnectionStatusEvent.bind(this, callbackRpc, clientId, streamId));
+        const isNewConnection = connection.init();
+        if (options.singlePC && !isNewConnection) {
           callbackRpc('callback', {type: 'initializing'});
+          if (connection.ready) {
+            callbackRpc('callback', {type: 'ready'});
+          }
         }
     };
 

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -152,13 +152,11 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
           publisher.initMediaStream();
           publisher.on('callback', onAdaptSchemeNotify.bind(this, callbackRpc));
           publisher.on('periodic_stats', onPeriodicStats.bind(this, streamId, undefined));
-          publisher.on('status_event', onConnectionStatusEvent.bind(this, callbackRpc, clientId, streamId));
-          const isNewConnection = connection.init();
+          publisher.on('status_event',
+            onConnectionStatusEvent.bind(this, callbackRpc, clientId, streamId));
+          const isNewConnection = connection.init(streamId);
           if (options.singlePC && !isNewConnection) {
             callbackRpc('callback', {type: 'initializing'});
-            if (connection.ready) {
-              callbackRpc('callback', {type: 'ready'});
-            }
           }
         } else {
             publisher = publishers[streamId];
@@ -205,13 +203,11 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
         subscriber.initMediaStream();
         subscriber.on('callback', onAdaptSchemeNotify.bind(this, callbackRpc));
         subscriber.on('periodic_stats', onPeriodicStats.bind(this, clientId, streamId));
-        subscriber.on('status_event', onConnectionStatusEvent.bind(this, callbackRpc, clientId, streamId));
-        const isNewConnection = connection.init();
+        subscriber.on('status_event',
+          onConnectionStatusEvent.bind(this, callbackRpc, clientId, streamId));
+        const isNewConnection = connection.init(subscriber.erizoStreamId);
         if (options.singlePC && !isNewConnection) {
           callbackRpc('callback', {type: 'initializing'});
-          if (connection.ready) {
-            callbackRpc('callback', {type: 'ready'});
-          }
         }
     };
 

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -146,14 +146,14 @@ class Source extends NodeClass {
     }
     if (msg.type === 'offer') {
       const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
-      connection.setRemoteDescription(sdp);
+      connection.setRemoteDescription(sdp, this.streamId);
       this.disableDefaultHandlers();
     } else if (msg.type === 'candidate') {
       connection.addRemoteCandidate(msg.candidate);
     } else if (msg.type === 'updatestream') {
       if (msg.sdp) {
         const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
-        connection.setRemoteDescription(sdp);
+        connection.setRemoteDescription(sdp, this.streamId);
       }
       if (msg.config) {
         if (msg.config.minVideoBW) {
@@ -342,13 +342,15 @@ class Publisher extends Source {
     this.connection = connection;
 
     this.connection.mediaConfiguration = options.mediaConfiguration;
-    this.connection.addMediaStream(streamId, options);
+    this.connection.addMediaStream(streamId, options, true);
     this._connectionListener = this._emitStatusEvent.bind(this);
     connection.on('status_event', this._connectionListener);
     this.mediaStream = this.connection.getMediaStream(streamId);
 
     this.minVideoBW = options.minVideoBW;
     this.scheme = options.scheme;
+    this.ready = false;
+    this.connectionReady = connection.ready;
 
     this.mediaStream.setAudioReceiver(this.muxer);
     this.mediaStream.setVideoReceiver(this.muxer);
@@ -358,7 +360,31 @@ class Publisher extends Source {
     this.muteStream({video: muteVideo, audio: muteAudio});
   }
 
-  _emitStatusEvent(evt, status) {
+  _emitStatusEvent(evt, status, streamId) {
+    log.debug('onStatusEvent in publisher', evt.type, this.streamId, streamId);
+    const isGlobalStatus = streamId === undefined || streamId === '';
+    const isNotMe = !isGlobalStatus && (streamId + '') !== (this.streamId + '');
+    if (isNotMe) {
+      log.debug('onStatusEvent dropped in publisher', streamId, this.streamId);
+      return;
+    }
+    if (evt.type === 'ready') {
+      if (this.connectionReady) {
+        return;
+      }
+      this.connectionReady = true;
+      if (!(this.ready && this.connectionReady)) {
+        log.debug('ready event dropped in publisher', this.ready, this.connectionReady);
+        return;
+      }
+    }
+
+    if (evt.type === 'answer' || evt.type === 'offer') {
+      if (!this.ready && this.connectionReady) {
+        this.emit('status_event', {type: 'ready'});
+      }
+      this.ready = true;
+    }
     this.emit('status_event', evt, status);
   }
 

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -343,6 +343,8 @@ class Publisher extends Source {
 
     this.connection.mediaConfiguration = options.mediaConfiguration;
     this.connection.addMediaStream(streamId, options);
+    this._connectionListener = this._emitStatusEvent.bind(this);
+    connection.on('status_event', this._connectionListener);
     this.mediaStream = this.connection.getMediaStream(streamId);
 
     this.minVideoBW = options.minVideoBW;
@@ -356,8 +358,13 @@ class Publisher extends Source {
     this.muteStream({video: muteVideo, audio: muteAudio});
   }
 
+  _emitStatusEvent(evt, status) {
+    this.emit('status_event', evt, status);
+  }
+
   close() {
     this.connection.removeMediaStream(this.mediaStream.id);
+    this.connection.removeListener('status_event', this._connectionListener);
     if (this.mediaStream.monitorInterval) {
       clearInterval(this.mediaStream.monitorInterval);
     }

--- a/erizo_controller/erizoJS/models/Subscriber.js
+++ b/erizo_controller/erizoJS/models/Subscriber.js
@@ -12,14 +12,41 @@ class Subscriber extends NodeClass {
     super(clientId, streamId, options);
     this.connection = connection;
     this.connection.mediaConfiguration = options.mediaConfiguration;
-    this.connection.addMediaStream(this.erizoStreamId, options);
+    this.connection.addMediaStream(this.erizoStreamId, options, false);
     this._connectionListener = this._emitStatusEvent.bind(this);
     connection.on('status_event', this._connectionListener);
     this.mediaStream = connection.getMediaStream(this.erizoStreamId);
     this.publisher = publisher;
+    this.ready = false;
+    this.connectionReady = connection.ready;
   }
 
-  _emitStatusEvent(evt, status) {
+  _emitStatusEvent(evt, status, streamId) {
+    const isGlobalStatus = streamId === undefined || streamId === '';
+    const isNotMe = !isGlobalStatus && (streamId + '') !== (this.erizoStreamId + '');
+    if (isNotMe) {
+      log.debug('onStatusEvent dropped in publisher', streamId, this.erizoStreamId);
+      return;
+    }
+    if (evt.type === 'ready') {
+      if (this.connectionReady) {
+        return;
+      }
+      this.connectionReady = true;
+      if (!(this.ready && this.connectionReady)) {
+        log.debug('ready event dropped in publisher', this.ready, this.connectionReady);
+        return;
+      }
+    }
+
+    if (evt.type === 'answer' || evt.type === 'offer') {
+      if (!this.ready && this.connectionReady) {
+        const readyEvent = {type: 'ready'};
+        this._onConnectionStatusEvent(readyEvent);
+        this.emit('status_event', readyEvent);
+      }
+      this.ready = true;
+    }
     this._onConnectionStatusEvent(evt);
     this.emit('status_event', evt, status);
   }
@@ -48,14 +75,14 @@ class Subscriber extends NodeClass {
 
     if (msg.type === 'offer') {
       const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
-      connection.setRemoteDescription(sdp);
+      connection.setRemoteDescription(sdp, this.erizoStreamId);
       this.disableDefaultHandlers();
     } else if (msg.type === 'candidate') {
       connection.addRemoteCandidate(msg.candidate);
     } else if (msg.type === 'updatestream') {
       if (msg.sdp) {
         const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
-        connection.setRemoteDescription(sdp);
+        connection.setRemoteDescription(sdp, this.erizoStreamId);
       }
       if (msg.config) {
         if (msg.config.slideShowMode !== undefined) {

--- a/erizo_controller/erizoJS/models/Subscriber.js
+++ b/erizo_controller/erizoJS/models/Subscriber.js
@@ -13,14 +13,15 @@ class Subscriber extends NodeClass {
     this.connection = connection;
     this.connection.mediaConfiguration = options.mediaConfiguration;
     this.connection.addMediaStream(this.erizoStreamId, options);
+    this._connectionListener = this._emitStatusEvent.bind(this);
+    connection.on('status_event', this._connectionListener);
     this.mediaStream = connection.getMediaStream(this.erizoStreamId);
     this.publisher = publisher;
-    this._listenToConnectionStuff();
   }
 
-  _listenToConnectionStuff() {
-    this._statusListener = this._onConnectionStatusEvent.bind(this);
-    this.connection.on('status_event', this._statusListener);
+  _emitStatusEvent(evt, status) {
+    this._onConnectionStatusEvent(evt);
+    this.emit('status_event', evt, status);
   }
 
   _onConnectionStatusEvent(connectionEvent) {
@@ -79,7 +80,7 @@ class Subscriber extends NodeClass {
     log.debug(`msg: Closing subscriber, streamId:${this.streamId}`);
     this.publisher = undefined;
     if (this.connection) {
-      this.connection.removeListener('status_event', this._statusListener);
+      this.connection.removeListener('status_event', this._connectionListener);
       this.connection.removeMediaStream(this.mediaStream.id);
     }
     if (this.mediaStream && this.mediaStream.monitorInterval) {

--- a/scripts/installErizo.sh
+++ b/scripts/installErizo.sh
@@ -68,7 +68,7 @@ install_erizo_api(){
   . $NVM_CHECK
   nvm use
   npm install nan@2.3.2
-  ./build.sh
+  $FAST_BUILD ./build.sh
   check_result $?
   cd $CURRENT_DIR
 }
@@ -129,6 +129,7 @@ else
         ;;
       f)
         FAST_MAKE='-j4'
+        FAST_BUILD='env JOBS=4'
         ;;
       d)
         DELETE_OBJECT_FILES='true'

--- a/spine/Events.js
+++ b/spine/Events.js
@@ -1,0 +1,177 @@
+/* global */
+const logger = require('./logger').logger;
+
+const log = logger.getLogger('Events');
+
+/*
+ * Class EventDispatcher provides event handling to sub-classes.
+ * It is inherited from Publisher, Room, etc.
+ */
+const EventDispatcher = () => {
+  const that = {};
+  // Private vars
+  const dispatcher = {
+    eventListeners: {},
+  };
+
+  // Public functions
+
+  // It adds an event listener attached to an event type.
+  that.addEventListener = (eventType, listener) => {
+    if (dispatcher.eventListeners[eventType] === undefined) {
+      dispatcher.eventListeners[eventType] = [];
+    }
+    dispatcher.eventListeners[eventType].push(listener);
+  };
+
+  // It removes an available event listener.
+  that.removeEventListener = (eventType, listener) => {
+    if (!dispatcher.eventListeners[eventType]) {
+      return;
+    }
+    const index = dispatcher.eventListeners[eventType].indexOf(listener);
+    if (index !== -1) {
+      dispatcher.eventListeners[eventType].splice(index, 1);
+    }
+  };
+
+  // It dispatch a new event to the event listeners, based on the type
+  // of event. All events are intended to be LicodeEvents.
+  that.dispatchEvent = (event) => {
+    if (!event || !event.type) {
+      throw new Error('Undefined event');
+    }
+    log.debug(`Event: ${event.type}`);
+    const listeners = dispatcher.eventListeners[event.type] || [];
+    for (let i = 0; i < listeners.length; i += 1) {
+      listeners[i](event);
+    }
+  };
+
+  that.on = that.addEventListener;
+  that.off = that.removeEventListener;
+  that.emit = that.dispatchEvent;
+
+  return that;
+};
+
+class EventEmitter {
+  constructor() {
+    this.emitter = EventDispatcher();
+  }
+  addEventListener(eventType, listener) {
+    this.emitter.addEventListener(eventType, listener);
+  }
+  removeEventListener(eventType, listener) {
+    this.emitter.removeEventListener(eventType, listener);
+  }
+  dispatchEvent(evt) {
+    this.emitter.dispatchEvent(evt);
+  }
+  on(eventType, listener) {
+    this.addEventListener(eventType, listener);
+  }
+  off(eventType, listener) {
+    this.removeEventListener(eventType, listener);
+  }
+  emit(evt) {
+    this.dispatchEvent(evt);
+  }
+}
+
+
+// **** EVENTS ****
+
+/*
+ * Class LicodeEvent represents a generic Event in the library.
+ * It handles the type of event, that is important when adding
+ * event listeners to EventDispatchers and dispatching new events.
+ * A LicodeEvent can be initialized this way:
+ * var event = LicodeEvent({type: "room-connected"});
+ */
+const LicodeEvent = (spec) => {
+  const that = {};
+
+  // Event type. Examples are: 'room-connected', 'stream-added', etc.
+  that.type = spec.type;
+
+  return that;
+};
+
+/*
+ * Class ConnectionEvent represents an Event that happens in a Room. It is a
+ * LicodeEvent.
+ * It is usually initialized as:
+ * var roomEvent = RoomEvent({type:"stream-added", streams:[stream1, stream2]});
+ * Event types:
+ * 'stream-added' - a stream has been added to the connection.
+ * 'stream-removed' - a stream has been removed from the connection.
+ * 'ice-state-change' - ICE state changed
+ */
+const ConnectionEvent = (spec) => {
+  const that = LicodeEvent(spec);
+
+  that.stream = spec.stream;
+  that.state = spec.state;
+
+  return that;
+};
+
+/*
+ * Class RoomEvent represents an Event that happens in a Room. It is a
+ * LicodeEvent.
+ * It is usually initialized as:
+ * var roomEvent = RoomEvent({type:"room-connected", streams:[stream1, stream2]});
+ * Event types:
+ * 'room-connected' - points out that the user has been successfully connected to the room.
+ * 'room-disconnected' - shows that the user has been already disconnected.
+ */
+const RoomEvent = (spec) => {
+  const that = LicodeEvent(spec);
+
+  // A list with the streams that are published in the room.
+  that.streams = spec.streams;
+  that.message = spec.message;
+
+  return that;
+};
+
+/*
+ * Class StreamEvent represents an event related to a stream. It is a LicodeEvent.
+ * It is usually initialized this way:
+ * var streamEvent = StreamEvent({type:"stream-added", stream:stream1});
+ * Event types:
+ * 'stream-added' - indicates that there is a new stream available in the room.
+ * 'stream-removed' - shows that a previous available stream has been removed from the room.
+ */
+const StreamEvent = (spec) => {
+  const that = LicodeEvent(spec);
+
+  // The stream related to this event.
+  that.stream = spec.stream;
+
+  that.msg = spec.msg;
+  that.bandwidth = spec.bandwidth;
+  that.attrs = spec.attrs;
+
+  return that;
+};
+
+/*
+ * Class PublisherEvent represents an event related to a publisher. It is a LicodeEvent.
+ * It usually initializes as:
+ * var publisherEvent = PublisherEvent({})
+ * Event types:
+ * 'access-accepted' - indicates that the user has accepted to share his camera and microphone
+ */
+const PublisherEvent = (spec) => {
+  const that = LicodeEvent(spec);
+
+  return that;
+};
+
+exports.EventEmitter = EventEmitter;
+exports.EventDispatcher = EventDispatcher;
+exports.ConnectionEvent = ConnectionEvent;
+//exports = { EventDispatcher, EventEmitter, LicodeEvent, RoomEvent, StreamEvent, PublisherEvent,
+//  ConnectionEvent };

--- a/spine/nativeClient.js
+++ b/spine/nativeClient.js
@@ -24,10 +24,12 @@ exports.ErizoNativeConnection = (config) => {
   const that = {};
   let wrtc;
   let mediaStream;
+  let streamId;
   let syntheticInput;
   let externalInput;
   let oneToMany;
   let externalOutput;
+  let firstOfferSent = false;
   const configuration = Object.assign({}, config);
 
   that.connected = false;
@@ -126,8 +128,10 @@ exports.ErizoNativeConnection = (config) => {
   global.config.erizo.turnpass,
   global.config.erizo.networkinterface);
 
+  streamId = `spine_${Math.floor(Math.random() * 1000)}`;
+
   mediaStream = new addon.MediaStream(threadPool, wrtc,
-      `spine_${Math.floor(Math.random() * 1000)}`, config.label,
+      streamId, config.label,
       JSON.stringify(global.mediaConfig));
 
   wrtc.addMediaStream(mediaStream);
@@ -177,7 +181,8 @@ exports.ErizoNativeConnection = (config) => {
     if (signalingMsg.type === 'started') {
       initWebRtcConnection((mess, info) => {
         log.info('Message from wrtc', info.type);
-        if (info.type === 'offer') {
+        if (info.type === 'offer' && !firstOfferSent) {
+          firstOfferSent = true;
           configuration.callback({ type: info.type, sdp: info.sdp });
         }
       }, {});
@@ -191,7 +196,7 @@ exports.ErizoNativeConnection = (config) => {
         log.info('Passing delayed answer');
         const sdp = SemanticSdp.SDPInfo.processString(signalingMsg.sdp);
         this.remoteDescription = new SessionDescription(sdp, 'default');
-        wrtc.setRemoteDescription(this.remoteDescription.connectionDescription);
+        wrtc.setRemoteDescription(this.remoteDescription.connectionDescription, streamId);
         sdp.streams.forEach((stream) => {
           let label = '';
           for (const track of stream.tracks.values()) {

--- a/spine/nativeClient.js
+++ b/spine/nativeClient.js
@@ -39,6 +39,7 @@ exports.ErizoNativeConnection = (config) => {
   // CONN_FINISHED = 105,
   const CONN_CANDIDATE = 201;
   const CONN_SDP = 202;
+  const CONN_SDP_PROCESSED  = 203;
   const CONN_FAILED = 500;
 
   const generatePLIs = () => {
@@ -67,6 +68,7 @@ exports.ErizoNativeConnection = (config) => {
 
         case CONN_SDP:
         case CONN_GATHERED:
+        case CONN_SDP_PROCESSED:
           setTimeout(() => {
             wrtc.localDescription = new SessionDescription(wrtc.getLocalDescription());
             const sdp = wrtc.localDescription.getSdp();


### PR DESCRIPTION
**Description**
This Pull Request is a set of changes to fix a bunch of issues that I found during the initial implementation of Single Peer Connection. Probably not all issues will be resolved in this first round, but at least it should lead us to something more or less reliable to start experimenting with it broadly. 

Since this PR is getting bigger and bigger I will try to fix issues in individual commits to make reviewers work a bit easier. At some point, if it's too big I will merge this PR and create another with more fixes.

*Note*: These things needed to make Single PC work properly will not be part of this PR:
- Detect compound RTCP packets and forward each part to the corresponding MediaStream.
- Get rid of the fixed 55543 and 44444 ports and make them unique for each stream.
- Translate from Plan B to Unified Plan when using Firefox.
- Investigate if REMB packets give a global estimation of bandwidth, based on all streams that take part of the PeerConnection. And implement the logic to generate REMB packets with the corresponding estimation for each stream (and possibly prioritize some streams over the others).

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

[] It includes documentation for these changes in `/doc`.