### PR TITLE
 Add maxVideoBW as a config instead of part of SDP when using Erizo

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -235,6 +235,15 @@ int MediaStream::deliverVideoData_(std::shared_ptr<DataPacket> video_packet) {
 int MediaStream::deliverFeedback_(std::shared_ptr<DataPacket> fb_packet) {
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(fb_packet->data);
   uint32_t recvSSRC = chead->getSourceSSRC();
+  if (chead->isREMB()) {
+    for (uint8_t index = 0; index < chead->getREMBNumSSRC(); index++) {
+      uint32_t ssrc = chead->getREMBFeedSSRC(index);
+      if (isVideoSourceSSRC(ssrc)) {
+        recvSSRC = ssrc;
+        break;
+      }
+    }
+  }
   if (isVideoSourceSSRC(recvSSRC)) {
     fb_packet->type = VIDEO_PACKET;
     sendPacketAsync(fb_packet);

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -91,6 +91,15 @@ uint32_t MediaStream::getMaxVideoBW() {
   return bitrate;
 }
 
+void MediaStream::setMaxVideoBW(uint32_t max_video_bw) {
+  asyncTask([max_video_bw] (std::shared_ptr<MediaStream> stream) {
+    if (stream->rtcp_processor_) {
+      stream->rtcp_processor_->setMaxVideoBW(max_video_bw * 1000);
+      stream->pipeline_->notifyUpdate();
+    }
+  });
+}
+
 void MediaStream::syncClose() {
   ELOG_DEBUG("%s message:Close called", toLog());
   if (!sending_) {

--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -61,6 +61,7 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   bool init();
   void close() override;
   virtual uint32_t getMaxVideoBW();
+  void setMaxVideoBW(uint32_t max_video_bw);
   void syncClose();
   bool setRemoteSdp(std::shared_ptr<SdpInfo> sdp);
   bool setLocalSdp(std::shared_ptr<SdpInfo> sdp);

--- a/erizoAPI/MediaStream.cc
+++ b/erizoAPI/MediaStream.cc
@@ -97,6 +97,7 @@ NAN_MODULE_INIT(MediaStream::Init) {
   Nan::SetPrototypeMethod(tpl, "setFeedbackReports", setFeedbackReports);
   Nan::SetPrototypeMethod(tpl, "setSlideShowMode", setSlideShowMode);
   Nan::SetPrototypeMethod(tpl, "muteStream", muteStream);
+  Nan::SetPrototypeMethod(tpl, "setMaxVideoBW", setMaxVideoBW);
   Nan::SetPrototypeMethod(tpl, "setQualityLayer", setQualityLayer);
   Nan::SetPrototypeMethod(tpl, "setVideoConstraints", setVideoConstraints);
   Nan::SetPrototypeMethod(tpl, "setMetadata", setMetadata);
@@ -185,6 +186,17 @@ NAN_METHOD(MediaStream::muteStream) {
   bool mute_video = info[0]->BooleanValue();
   bool mute_audio = info[1]->BooleanValue();
   me->muteStream(mute_video, mute_audio);
+}
+
+NAN_METHOD(MediaStream::setMaxVideoBW) {
+  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  std::shared_ptr<erizo::MediaStream> me = obj->me;
+  if (!me) {
+    return;
+  }
+
+  int max_video_bw = info[0]->IntegerValue();
+  me->setMaxVideoBW(max_video_bw);
 }
 
 NAN_METHOD(MediaStream::setVideoConstraints) {

--- a/erizoAPI/MediaStream.h
+++ b/erizoAPI/MediaStream.h
@@ -105,6 +105,11 @@ class MediaStream : public MediaSink, public erizo::MediaStreamStatsListener {
      */
     static NAN_METHOD(muteStream);
     /*
+     * Sets Max Video BW
+     * Param: The value for the max video bandwidth
+     */
+    static NAN_METHOD(setMaxVideoBW);
+    /*
      * Sets constraints to the subscribing video
      * Param: Max width, height and framerate.
      */

--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -110,8 +110,8 @@ class ErizoConnection extends EventEmitterConst {
     this.stack.enableSimulcast(sdpInput);
   }
 
-  updateSpec(configInput, callback) {
-    this.stack.updateSpec(configInput, callback);
+  updateSpec(configInput, streamId, callback) {
+    this.stack.updateSpec(configInput, streamId, callback);
   }
 }
 

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -114,6 +114,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       limitMaxAudioBW: spec.maxAudioBW,
       limitMaxVideoBW: spec.maxVideoBW,
       forceTurn: stream.forceTurn,
+      p2p: true,
     };
     return options;
   };
@@ -176,6 +177,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       label: stream.getLabel(),
       iceServers: that.iceServers,
       forceTurn: stream.forceTurn,
+      p2p: false,
     };
     if (!isRemote) {
       connectionOpts.simulcast = options.simulcast;
@@ -452,6 +454,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     Logger.info('Publishing to Erizo Normally, is createOffer', options.createOffer);
     const constraints = createSdpConstraints('erizo', stream, options);
     constraints.minVideoBW = options.minVideoBW;
+    constraints.maxVideoBW = options.maxVideoBW;
     constraints.scheme = options.scheme;
 
     socket.sendSDP('publish', constraints, undefined, (id, erizoId, error) => {
@@ -491,6 +494,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     const constraint = { streamId: stream.getID(),
       audio: options.audio && stream.hasAudio(),
       video: getVideoConstraints(stream, options.video),
+      maxVideoBW: options.maxVideoBW,
       data: options.data && stream.hasData(),
       browser: that.ConnectionHelpers.getBrowser(),
       createOffer: options.createOffer,

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -372,7 +372,7 @@ const Stream = (altConnectionHelpers, specInput) => {
     const config = { muteStream: { audio: that.audioMuted, video: that.videoMuted } };
     that.checkOptions(config, true);
     if (that.pc) {
-      that.pc.updateSpec(config, callback);
+      that.pc.updateSpec(config, that.getID(), callback);
     }
   };
 
@@ -395,7 +395,7 @@ const Stream = (altConnectionHelpers, specInput) => {
     }
     const config = { qualityLayer: { spatialLayer, temporalLayer } };
     that.checkOptions(config, true);
-    that.pc.updateSpec(config, callback);
+    that.pc.updateSpec(config, that.getID(), callback);
   };
 
   // eslint-disable-next-line no-underscore-dangle
@@ -407,7 +407,7 @@ const Stream = (altConnectionHelpers, specInput) => {
     }
     const config = { qualityLayer: { spatialLayer: -1, temporalLayer: -1 } };
     that.checkOptions(config, true);
-    that.pc.updateSpec(config, callback);
+    that.pc.updateSpec(config, that.getID(), callback);
   };
 
   const controlHandler = (handlersInput, publisherSideInput, enable) => {
@@ -443,13 +443,13 @@ const Stream = (altConnectionHelpers, specInput) => {
       if (that.local) {
         if (that.room.p2p) {
           for (let index = 0; index < that.pc.length; index += 1) {
-            that.pc[index].updateSpec(config, callback);
+            that.pc[index].updateSpec(config, that.getID(), callback);
           }
         } else {
-          that.pc.updateSpec(config, callback);
+          that.pc.updateSpec(config, that.getID(), callback);
         }
       } else {
-        that.pc.updateSpec(config, callback);
+        that.pc.updateSpec(config, that.getID(), callback);
       }
     } else {
       callback('This stream has no peerConnection attached, ignoring');

--- a/erizo_controller/erizoClient/src/utils/SdpHelpers.js
+++ b/erizo_controller/erizoClient/src/utils/SdpHelpers.js
@@ -23,6 +23,9 @@ SdpHelpers.addSpatialLayer = (cname, msid, mslabel,
   `a=ssrc:${spatialLayerIdRtx} label:${label}\r\n`;
 
 SdpHelpers.setMaxBW = (sdp, spec) => {
+  if (!spec.p2p) {
+    return;
+  }
   if (spec.video && spec.maxVideoBW) {
     const video = sdp.getMedia('video');
     if (video) {

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -229,7 +229,7 @@ const BaseStack = (specInput) => {
     that.peerConnection.close();
   };
 
-  that.updateSpec = (configInput, callback = () => {}) => {
+  that.updateSpec = (configInput, streamId, callback = () => {}) => {
     const config = configInput;
     if (config.maxVideoBW || config.maxAudioBW) {
       if (config.maxVideoBW) {
@@ -264,13 +264,13 @@ const BaseStack = (specInput) => {
             return that.peerConnection.setRemoteDescription(new RTCSessionDescription(remoteDesc));
           }).then(() => {
             specBase.remoteDescriptionSet = true;
-            specBase.callback({ type: 'updatestream', sdp: localDesc.sdp });
+            specBase.callback({ type: 'updatestream', sdp: localDesc.sdp }, streamId);
           }).catch(errorCallback.bind(null, 'updateSpec', callback));
       } else {
         Logger.debug('Updating without SDP renegotiation, ' +
                      'newVideoBW:', specBase.maxVideoBW,
                      'newAudioBW:', specBase.maxAudioBW);
-        specBase.callback({ type: 'updatestream', sdp: localDesc.sdp });
+        specBase.callback({ type: 'updatestream', sdp: localDesc.sdp }, streamId);
       }
     }
     if (config.minVideoBW || (config.slideShowMode !== undefined) ||
@@ -280,7 +280,7 @@ const BaseStack = (specInput) => {
       Logger.debug('SlideShowMode Changed to ', config.slideShowMode);
       Logger.debug('muteStream changed to ', config.muteStream);
       Logger.debug('Video Constraints', config.video);
-      specBase.callback({ type: 'updatestream', config });
+      specBase.callback({ type: 'updatestream', config }, streamId);
     }
   };
 

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -102,6 +102,7 @@ const BaseStack = (specInput) => {
     specBase.callback({
       type: localDesc.type,
       sdp: localDesc.sdp,
+      config: { maxVideoBW: specBase.maxVideoBW },
     }, streamId);
   };
 
@@ -231,7 +232,9 @@ const BaseStack = (specInput) => {
 
   that.updateSpec = (configInput, streamId, callback = () => {}) => {
     const config = configInput;
-    if (config.maxVideoBW || config.maxAudioBW) {
+    const shouldApplyMaxVideoBWToSdp = specBase.p2p && config.maxVideoBW;
+    const shouldSendMaxVideoBWInOptions = !specBase.p2p && config.maxVideoBW;
+    if (shouldApplyMaxVideoBWToSdp || config.maxAudioBW) {
       if (config.maxVideoBW) {
         Logger.debug('Maxvideo Requested:', config.maxVideoBW,
                                 'limit:', specBase.limitMaxVideoBW);
@@ -273,9 +276,13 @@ const BaseStack = (specInput) => {
         specBase.callback({ type: 'updatestream', sdp: localDesc.sdp }, streamId);
       }
     }
-    if (config.minVideoBW || (config.slideShowMode !== undefined) ||
-            (config.muteStream !== undefined) || (config.qualityLayer !== undefined) ||
-            (config.video !== undefined)) {
+    if (shouldSendMaxVideoBWInOptions ||
+        config.minVideoBW ||
+        (config.slideShowMode !== undefined) ||
+        (config.muteStream !== undefined) ||
+        (config.qualityLayer !== undefined) ||
+        (config.video !== undefined)) {
+      Logger.debug('MaxVideoBW Changed to ', config.maxVideoBW);
       Logger.debug('MinVideo Changed to ', config.minVideoBW);
       Logger.debug('SlideShowMode Changed to ', config.slideShowMode);
       Logger.debug('muteStream changed to ', config.muteStream);

--- a/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
@@ -42,11 +42,11 @@ const FirefoxStack = (specInput) => {
 
   const baseCreateOffer = that.createOffer;
 
-  that.createOffer = (isSubscribe) => {
+  that.createOffer = (isSubscribe, forceOfferToReceive = false, streamId = '') => {
     if (isSubscribe !== true) {
       enableSimulcast();
     }
-    baseCreateOffer(isSubscribe);
+    baseCreateOffer(isSubscribe, forceOfferToReceive, streamId);
   };
 
   return that;

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -147,6 +147,9 @@ class Source extends NodeClass {
     if (msg.type === 'offer') {
       const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
       connection.setRemoteDescription(sdp, this.streamId);
+      if (msg.config.maxVideoBW) {
+        this.mediaStream.setMaxVideoBW(msg.config.maxVideoBW);
+      }
       this.disableDefaultHandlers();
     } else if (msg.type === 'candidate') {
       connection.addRemoteCandidate(msg.candidate);
@@ -154,6 +157,9 @@ class Source extends NodeClass {
       if (msg.sdp) {
         const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
         connection.setRemoteDescription(sdp, this.streamId);
+        if (this.mediaStream) {
+          this.mediaStream.setMaxVideoBW();
+        }
       }
       if (msg.config) {
         if (msg.config.minVideoBW) {
@@ -170,6 +176,9 @@ class Source extends NodeClass {
         }
         if (msg.config.muteStream !== undefined) {
           this.muteStream(msg.config.muteStream);
+        }
+        if (msg.config.maxVideoBW) {
+          this.mediaStream.setMaxVideoBW(msg.config.maxVideoBW);
         }
       }
     } else if (msg.type === 'control') {

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -147,7 +147,7 @@ class Source extends NodeClass {
     if (msg.type === 'offer') {
       const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
       connection.setRemoteDescription(sdp, this.streamId);
-      if (msg.config.maxVideoBW) {
+      if (msg.config && msg.config.maxVideoBW) {
         this.mediaStream.setMaxVideoBW(msg.config.maxVideoBW);
       }
       this.disableDefaultHandlers();

--- a/erizo_controller/erizoJS/models/Subscriber.js
+++ b/erizo_controller/erizoJS/models/Subscriber.js
@@ -76,7 +76,7 @@ class Subscriber extends NodeClass {
     if (msg.type === 'offer') {
       const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
       connection.setRemoteDescription(sdp, this.erizoStreamId);
-      if (msg.config.maxVideoBW) {
+      if (msg.config && msg.config.maxVideoBW) {
         this.mediaStream.setMaxVideoBW(msg.config.maxVideoBW);
       }
       this.disableDefaultHandlers();

--- a/erizo_controller/erizoJS/models/Subscriber.js
+++ b/erizo_controller/erizoJS/models/Subscriber.js
@@ -76,6 +76,9 @@ class Subscriber extends NodeClass {
     if (msg.type === 'offer') {
       const sdp = SemanticSdp.SDPInfo.processString(msg.sdp);
       connection.setRemoteDescription(sdp, this.erizoStreamId);
+      if (msg.config.maxVideoBW) {
+        this.mediaStream.setMaxVideoBW(msg.config.maxVideoBW);
+      }
       this.disableDefaultHandlers();
     } else if (msg.type === 'candidate') {
       connection.addRemoteCandidate(msg.candidate);
@@ -96,6 +99,9 @@ class Subscriber extends NodeClass {
         }
         if (msg.config.video !== undefined) {
           this.publisher.setVideoConstraints(msg.config.video, this.clientId);
+        }
+        if (msg.config.maxVideoBW) {
+          this.mediaStream.setMaxVideoBW(msg.config.maxVideoBW);
         }
       }
     } else if (msg.type === 'control') {

--- a/erizo_controller/test/erizoJS/erizoJSController.js
+++ b/erizo_controller/test/erizoJS/erizoJSController.js
@@ -272,7 +272,8 @@ describe('Erizo JS Controller', function() {
       });
 
       it('should set remote sdp when received', function() {
-        controller.processSignaling(undefined, kArbitraryStreamId, {type: 'offer', sdp: '', config: {}});
+        controller.processSignaling(undefined, kArbitraryStreamId,
+          {type: 'offer', sdp: '', config: {}});
 
         expect(mocks.WebRtcConnection.setRemoteDescription.callCount).to.equal(1);
       });

--- a/erizo_controller/test/erizoJS/erizoJSController.js
+++ b/erizo_controller/test/erizoJS/erizoJSController.js
@@ -272,7 +272,7 @@ describe('Erizo JS Controller', function() {
       });
 
       it('should set remote sdp when received', function() {
-        controller.processSignaling(undefined, kArbitraryStreamId, {type: 'offer', sdp: ''});
+        controller.processSignaling(undefined, kArbitraryStreamId, {type: 'offer', sdp: '', config: {}});
 
         expect(mocks.WebRtcConnection.setRemoteDescription.callCount).to.equal(1);
       });
@@ -348,7 +348,7 @@ describe('Erizo JS Controller', function() {
 
         it('should set remote sdp when received', function() {
           controller.processSignaling(kArbitrarySubClientId, kArbitraryStreamId, {type: 'offer',
-            sdp: ''});
+            sdp: '', config: {}});
 
           expect(mocks.WebRtcConnection.setRemoteDescription.callCount).to.equal(1);
         });

--- a/erizo_controller/test/utils.js
+++ b/erizo_controller/test/utils.js
@@ -167,6 +167,7 @@ var reset = module.exports.reset = function() {
     close: sinon.stub(),
     setAudioReceiver: sinon.stub(),
     setVideoReceiver: sinon.stub(),
+    setMaxVideoBW: sinon.stub(),
     getStats: sinon.stub(),
     getPeriodicStats: sinon.stub(),
     generatePLIPacket: sinon.stub(),


### PR DESCRIPTION
**Description**

Add maxVideoBW as a config instead of part of SDP when using Erizo. This allows us to set different limits for each Stream when using Single Peer Connection.

It also includes some fixes. For instance, Firefox was not working anymore, and updateConfiguration/muteStream could fail in some cases.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.