### PR TITLE
Fix crashes calling uv_finish_close

### DIFF
--- a/erizoAPI/MediaStream.h
+++ b/erizoAPI/MediaStream.h
@@ -50,7 +50,7 @@ class MediaStream : public MediaSink, public erizo::MediaStreamStatsListener {
 
     Nan::Callback *statsCallback_;
 
-    uv_async_t asyncStats_;
+    uv_async_t *async_stats_;
     bool hasCallback_;
     bool closed_;
     std::string id_;

--- a/erizoAPI/WebRtcConnection.h
+++ b/erizoAPI/WebRtcConnection.h
@@ -39,7 +39,7 @@ class WebRtcConnection : public erizo::WebRtcConnectionEventListener,
     void close();
 
     Nan::Callback *eventCallback_;
-    uv_async_t async_;
+    uv_async_t *async_;
     bool closed_;
     std::string id_;
     /*


### PR DESCRIPTION
**Description**

Fix some crashes that seem to happen when calling uv_close(). My guess is that it then asynchronously calls uv_finish_close with an object (uv_handle_t) which is already destroyed, so the memory is corrupted.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

[] It includes documentation for these changes in `/doc`.