### PR TITLE
Updated docs to clarify maxVideoBW and defaultVideoBW

### DIFF
--- a/doc/client_api.md
+++ b/doc/client_api.md
@@ -383,7 +383,7 @@ room.addEventListener("stream-added", function(event) {
 });
 ```
 
-`room.publish` also allows to set a bandwidth limit for the localStream. We do this by passing the `maxVideoBW` variable as an option. The BW is expressed in Kbps. Keep in mind that the field `config.erizoController.defaultVideoBW` in the server configuration has higher priority than this one.
+`room.publish` also allows to set a bandwidth limit for the localStream. We do this by passing the `maxVideoBW` variable as an option. The BW is expressed in Kbps. Keep in mind that the field `config.erizoController.maxVideoBW` in the server configuration has higher priority than this one and that `config.erizoController.defaultVideoBW` will be used by default if this option is not passed.
 
 ```
 room.publish(localStream, {maxVideoBW:300});
@@ -464,10 +464,16 @@ room.addEventListener("stream-subscribed", function(streamEvt) {
 room.subscribe(stream, {audio: true, video: false});
 ```
 
+`room.subscribe` also allows to set a bandwidth limit for a subscription. We do this by passing the `maxVideoBW` variable as an option. The BW is expressed in Kbps. Keep in mind that the field `config.erizoController.maxVideoBW` in the server configuration has higher priority than this one and that `config.erizoController.defaultVideoBW` will be used by default if this option is not passed. More importantly, if the publisher is not using simulcast, the lowest `maxVideoBW` set to a subscriber will limit the max bandwidth used by that particular stream for the publisher and all the subscribers.
+
+```
+room.subscribe(stream, {maxVideoBW:300});
+```
+
 We can also force the client to use a TURN server when subscribing by setting the next parameter:
 
 ```
-room.publish(localStream, {forceTurn: true});
+room.subscribe(localStream, {forceTurn: true});
 ```
 
 In `room.subscribe` you can include a callback with two parameters, `result` and `error`. If the stream has been subscribed, `result` is true. On the other hand, if there has been any kind of error, `result` is `undefined` and the error is described in `error`.

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -51,7 +51,7 @@ config.erizoController = {};
 // }
 config.erizoController.iceServers = [{'url': 'stun:stun.l.google.com:19302'}]; // default value: [{'url': 'stun:stun.l.google.com:19302'}]
 
-// Default and max video bandwidth parameters to be used by clients
+// Default and max video bandwidth parameters to be used by clients for both published and subscribed streams
 config.erizoController.defaultVideoBW = 300; //default value: 300
 config.erizoController.maxVideoBW = 300; //default value: 300
 


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

The role of maxVideoBW for subscribed streams was not clear in the docs. This PR updates that and fixes some typos.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

- [x] It includes documentation for these changes in `/doc`.