### PR TITLE
[WIP] Added protection for async calls when closing

### DIFF
--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -45,6 +45,7 @@ void WebRtcConnection::close() {
     ELOG_DEBUG("%s, message: Already closed", toLog());
     return;
   }
+  boost::mutex::scoped_lock lock(mutex);
   ELOG_DEBUG("%s, message: Closing", toLog());
   if (me) {
     me->setWebRtcConnectionEventListener(nullptr);


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR locks the async mutex in both `WebRTCConnection` and `MediaStream` in ErizoAPI. This could avoid race conditions with events when closing streams.

It's a WIP because it needs more testing locally.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.