### PR TITLE
Fix issues that happened during first trials of Single Peer Connection

### DIFF
--- a/erizoAPI/ConnectionDescription.cc
+++ b/erizoAPI/ConnectionDescription.cc
@@ -71,7 +71,8 @@ NAN_MODULE_INIT(ConnectionDescription::Init) {
   Nan::SetPrototypeMethod(tpl, "setVideoSsrcList", setVideoSsrcList);
   Nan::SetPrototypeMethod(tpl, "getVideoSsrcMap", getVideoSsrcMap);
 
-  Nan::SetPrototypeMethod(tpl, "setDirection", setDirection);
+  Nan::SetPrototypeMethod(tpl, "setVideoDirection", setVideoDirection);
+  Nan::SetPrototypeMethod(tpl, "setAudioDirection", setAudioDirection);
   Nan::SetPrototypeMethod(tpl, "getDirection", getDirection);
 
   Nan::SetPrototypeMethod(tpl, "setFingerprint", setFingerprint);
@@ -322,19 +323,29 @@ NAN_METHOD(ConnectionDescription::getVideoSsrcMap) {
   info.GetReturnValue().Set(video_ssrc_map);
 }
 
-NAN_METHOD(ConnectionDescription::setDirection) {
+NAN_METHOD(ConnectionDescription::setVideoDirection) {
+  GET_SDP();
+  std::string direction = getString(info[0]);
+
+  if (direction == "sendonly") {
+    sdp->videoDirection = erizo::SENDONLY;
+  } else if (direction == "sendrecv") {
+    sdp->videoDirection = erizo::SENDRECV;
+  } else if (direction == "recvonly") {
+    sdp->videoDirection = erizo::RECVONLY;
+  }
+}
+
+NAN_METHOD(ConnectionDescription::setAudioDirection) {
   GET_SDP();
   std::string direction = getString(info[0]);
 
   if (direction == "sendonly") {
     sdp->audioDirection = erizo::SENDONLY;
-    sdp->videoDirection = erizo::SENDONLY;
   } else if (direction == "sendrecv") {
     sdp->audioDirection = erizo::SENDRECV;
-    sdp->videoDirection = erizo::SENDRECV;
   } else if (direction == "recvonly") {
     sdp->audioDirection = erizo::RECVONLY;
-    sdp->videoDirection = erizo::RECVONLY;
   }
 }
 

--- a/erizoAPI/ConnectionDescription.h
+++ b/erizoAPI/ConnectionDescription.h
@@ -49,7 +49,8 @@ class ConnectionDescription : public Nan::ObjectWrap {
     static NAN_METHOD(getAudioSsrcMap);
     static NAN_METHOD(getVideoSsrcMap);
 
-    static NAN_METHOD(setDirection);
+    static NAN_METHOD(setVideoDirection);
+    static NAN_METHOD(setAudioDirection);
     static NAN_METHOD(getDirection);
 
     static NAN_METHOD(setFingerprint);

--- a/erizo_controller/common/semanticSdp/SDPInfo.js
+++ b/erizo_controller/common/semanticSdp/SDPInfo.js
@@ -430,6 +430,12 @@ class SDPInfo {
 
       sdp.media.push(md);
     });
+    bundle.mids.sort();
+    sdp.media.sort((m1, m2) => {
+      if (m1.mid < m2.mid) return -1;
+      if (m1.mid > m2.mid) return 1;
+      return 0;
+    });
 
     for (const stream of this.streams.values()) { // eslint-disable-line no-restricted-syntax
       for (const track of stream.getTracks().values()) { // eslint-disable-line no-restricted-syntax

--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -106,8 +106,16 @@ class ErizoConnection extends EventEmitterConst {
     this.stack.sendSignalingMessage(msg);
   }
 
-  enableSimulcast(sdpInput) {
-    this.stack.enableSimulcast(sdpInput);
+  setSimulcast(enable) {
+    this.stack.setSimulcast(enable);
+  }
+
+  setVideo(video) {
+    this.stack.setVideo(video);
+  }
+
+  setAudio(audio) {
+    this.stack.setAudio(audio);
   }
 
   updateSpec(configInput, streamId, callback) {
@@ -150,6 +158,16 @@ class ErizoConnectionManager {
         this.ErizoConnectionsMap.set(erizoId, connectionEntry);
       }
     }
+    if (specInput.simulcast) {
+      connection.setSimulcast(specInput.simulcast);
+    }
+    if (specInput.video) {
+      connection.setVideo(specInput.video);
+    }
+    if (specInput.audio) {
+      connection.setVideo(specInput.audio);
+    }
+
     return connection;
   }
 

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -29,19 +29,21 @@ const BaseStack = (specInput) => {
   if (specBase.forceTurn === true) {
     that.pcConfig.iceTransportPolicy = 'relay';
   }
-  if (specBase.audio === undefined) {
-    specBase.audio = true;
+  that.audio = specBase.audio;
+  that.video = specBase.video;
+  if (that.audio === undefined) {
+    that.audio = true;
   }
-  if (specBase.video === undefined) {
-    specBase.video = true;
+  if (that.video === undefined) {
+    that.video = true;
   }
   specBase.remoteCandidates = [];
   specBase.localCandidates = [];
   specBase.remoteDescriptionSet = false;
 
   that.mediaConstraints = {
-    offerToReceiveVideo: (specBase.video !== undefined && specBase.video !== false),
-    offerToReceiveAudio: (specBase.audio !== undefined && specBase.audio !== false),
+    offerToReceiveVideo: (that.video !== undefined && that.video !== false),
+    offerToReceiveAudio: (that.audio !== undefined && that.audio !== false),
   };
 
   that.peerConnection = new RTCPeerConnection(that.pcConfig, that.con);
@@ -228,6 +230,18 @@ const BaseStack = (specInput) => {
   that.close = () => {
     that.state = 'closed';
     that.peerConnection.close();
+  };
+
+  that.setSimulcast = (enable) => {
+    that.simulcast = enable;
+  };
+
+  that.setVideo = (video) => {
+    that.video = video;
+  };
+
+  that.setAudio = (audio) => {
+    that.audio = audio;
   };
 
   that.updateSpec = (configInput, streamId, callback = () => {}) => {

--- a/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
@@ -11,10 +11,7 @@ const ChromeStableStack = (specInput) => {
   that.enableSimulcast = (sdpInput) => {
     let result;
     let sdp = sdpInput;
-    if (!spec.video) {
-      return sdp;
-    }
-    if (!spec.simulcast) {
+    if (!that.simulcast) {
       return sdp;
     }
 
@@ -24,7 +21,7 @@ const ChromeStableStack = (specInput) => {
       return sdp;
     }
     // TODO (pedro): Consider adding these to SdpHelpers
-    const numSpatialLayers = spec.simulcast.numSpatialLayers || defaultSimulcastSpatialLayers;
+    const numSpatialLayers = that.simulcast.numSpatialLayers || defaultSimulcastSpatialLayers;
     const baseSsrc = parseInt(matchGroup[1], 10);
     const baseSsrcRtx = parseInt(matchGroup[2], 10);
     const cname = sdp.match(new RegExp(`a=ssrc:${matchGroup[1]} cname:(.*)\r?\n`))[1];
@@ -67,14 +64,14 @@ const ChromeStableStack = (specInput) => {
   };
 
   that.setStartVideoBW = (sdpInfo) => {
-    if (spec.video && spec.startVideoBW) {
+    if (that.video && spec.startVideoBW) {
       Logger.debug(`startVideoBW requested: ${spec.startVideoBW}`);
       SdpHelpers.setParamForCodecs(sdpInfo, 'video', 'x-google-start-bitrate', spec.startVideoBW);
     }
   };
 
   that.setHardMinVideoBW = (sdpInfo) => {
-    if (spec.video && spec.hardMinVideoBW) {
+    if (that.video && spec.hardMinVideoBW) {
       Logger.debug(`hardMinVideoBW requested: ${spec.hardMinVideoBW}`);
       SdpHelpers.setParamForCodecs(sdpInfo, 'video', 'x-google-min-bitrate', spec.hardMinVideoBW);
     }

--- a/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
@@ -4,7 +4,6 @@ import BaseStack from './BaseStack';
 const FirefoxStack = (specInput) => {
   Logger.info('Starting Firefox stack');
   const that = BaseStack(specInput);
-  const spec = specInput;
   const defaultSimulcastSpatialLayers = 2;
 
   const possibleLayers = [
@@ -14,7 +13,7 @@ const FirefoxStack = (specInput) => {
   ];
 
   const getSimulcastParameters = (sender) => {
-    let numSpatialLayers = spec.simulcast.numSpatialLayers || defaultSimulcastSpatialLayers;
+    let numSpatialLayers = that.simulcast.numSpatialLayers || defaultSimulcastSpatialLayers;
     const totalLayers = possibleLayers.length;
     numSpatialLayers = numSpatialLayers < totalLayers ?
                           numSpatialLayers : totalLayers;
@@ -28,7 +27,7 @@ const FirefoxStack = (specInput) => {
   };
 
   const enableSimulcast = () => {
-    if (!spec.simulcast) {
+    if (!that.simulcast) {
       return;
     }
     that.peerConnection.getSenders().forEach((sender) => {

--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -35,7 +35,7 @@ global.config.erizoController.recording_path =
   global.config.erizoController.recording_path || undefined;
 global.config.erizoController.exitOnNuveCheckFail = global.config.erizoController.exitOnNuveCheckFail || false;
 global.config.erizoController.allowSinglePC = global.config.erizoController.allowSinglePC || '';
-global.config.erizoController.maxErizosUsedByRoom = global.config.erizoController.maxErizosUsedByRoom || 0;
+global.config.erizoController.maxErizosUsedByRoom = global.config.erizoController.maxErizosUsedByRoom || 100;
 
 // jshint ignore:end
 global.config.erizoController.roles = global.config.erizoController.roles ||

--- a/erizo_controller/erizoController/models/ErizoList.js
+++ b/erizo_controller/erizoController/models/ErizoList.js
@@ -6,7 +6,7 @@ const MAX_ERIZOS_PER_ROOM = 100;
 class ErizoList extends EventEmitter {
   constructor(maxErizos = MAX_ERIZOS_PER_ROOM) {
     super();
-    this.maxErizos = maxErizos;
+    this.maxErizos = maxErizos > 0 maxErizos : MAX_ERIZOS_PER_ROOM;
     this.erizos = new Array(maxErizos);
     this.erizos.fill(1);
     this.erizos = this.erizos.map(() => {

--- a/erizo_controller/erizoController/models/ErizoList.js
+++ b/erizo_controller/erizoController/models/ErizoList.js
@@ -6,7 +6,11 @@ const MAX_ERIZOS_PER_ROOM = 100;
 class ErizoList extends EventEmitter {
   constructor(maxErizos = MAX_ERIZOS_PER_ROOM) {
     super();
-    this.maxErizos = maxErizos > 0 maxErizos : MAX_ERIZOS_PER_ROOM;
+    if (maxErizos > 0) {
+      this.maxErizos = maxErizos;
+    } else {
+      this.maxErizos = MAX_ERIZOS_PER_ROOM;
+    }
     this.erizos = new Array(maxErizos);
     this.erizos.fill(1);
     this.erizos = this.erizos.map(() => {

--- a/erizo_controller/erizoJS/models/SessionDescription.js
+++ b/erizo_controller/erizoJS/models/SessionDescription.js
@@ -119,7 +119,7 @@ function getMediaInfoFromDescription(info, sdp, mediaType) {
   }
 
   const sources = new Map();
-  if (mediaType === 'audio' && info.getDirection() !== 'recvonly') {
+  if (mediaType === 'audio' && info.getDirection('audio') !== 'recvonly') {
     const audioSsrcMap = info.getAudioSsrcMap();
     Object.keys(audioSsrcMap).forEach((streamLabel) => {
       addSsrc(sources, audioSsrcMap[streamLabel], sdp, media, streamLabel);
@@ -127,7 +127,7 @@ function getMediaInfoFromDescription(info, sdp, mediaType) {
   } else if (mediaType === 'video') {
     media.setBitrate(info.getVideoBandwidth());
 
-    if (info.getDirection() !== 'recvonly') {
+    if (info.getDirection('video') !== 'recvonly') {
       const videoSsrcMap = info.getVideoSsrcMap();
       Object.keys(videoSsrcMap).forEach((streamLabel) => {
         videoSsrcMap[streamLabel].forEach((ssrc) => {
@@ -257,7 +257,14 @@ class SessionDescription {
 
     // we use the same field for both audio and video
     if (sdp.medias && sdp.medias.length > 0) {
-      info.setDirection(Direction.toString(sdp.medias[0].getDirection()));
+      sdp.medias.forEach((media) => {
+        if (media.getType() === 'audio') {
+          info.setAudioDirection(Direction.toString(media.getDirection()));
+        } else {
+          info.setVideoDirection(Direction.toString(media.getDirection()));
+        }
+      });
+
     }
 
     info.setProfile('UDP/TLS/RTP/SAVPF'); // TODO

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -82,7 +82,7 @@ config.erizoController.listen_port = 8080; //default value: 8080
 
 config.erizoController.exitOnNuveCheckFail = false;  // default value: false
 config.erizoController.allowSinglePC = false;  // default value: false
-config.erizoController.maxErizosUsedByRoom = 0;  // default value: 0
+config.erizoController.maxErizosUsedByRoom = 100;  // default value: 100
 
 config.erizoController.warning_n_rooms = 15; // default value: 15
 config.erizoController.limit_n_rooms = 20; // default value: 20


### PR DESCRIPTION
**Description**

Bugs fixed in this PR:
- Firefox not accepting different orders of video/audio medias in the SDP.
- Wrong SDP directions when using Erizo.
- Simulcast with Single PC did not work sometimes.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed

[] It includes documentation for these changes in `/doc`.