### PR TITLE
Use a variable instead of event object to concatenate candidate attr.

### DIFF
--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -72,15 +72,14 @@ const BaseStack = (specInput) => {
         candidate: 'end',
       };
     } else {
-      if (!candidate.candidate.match(/a=/)) {
-        candidate.candidate = `a=${candidate.candidate}`;
-      }
-
       candidateObject = {
         sdpMLineIndex: candidate.sdpMLineIndex,
         sdpMid: candidate.sdpMid,
         candidate: candidate.candidate,
       };
+      if (!candidateObject.candidate.match(/a=/)) {
+        candidateObject.candidate = `a=${candidateObject.candidate}`;
+      }
     }
 
     if (specBase.remoteDescriptionSet) {


### PR DESCRIPTION
By WebRTC spec, RTCIceCandidate.candidate is a readonly attribute. It makes
more sense to store, check, and concatenate candidate attribute line in another
variable, instead of the event object.

Spec: https://www.w3.org/TR/webrtc/#dom-rtcicecandidate

macOS Safari implements the event behavior by the spec. Include this patch to make Safari work correctly.

<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

<!--
Add a short description here, please.
If the contribution needs and includes Unit Tests check the box below.
-->

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.