### PR TITLE
Support legacy websocket polling

### DIFF
--- a/erizo_controller/erizoClient/src/Socket.js
+++ b/erizo_controller/erizoClient/src/Socket.js
@@ -19,6 +19,7 @@ const Socket = (newIo) => {
   const that = EventDispatcher();
   const defaultCallback = () => {};
   const messageBuffer = [];
+  that.reconnectSupported = false;
 
   that.CONNECTED = Symbol('connected');
   that.RECONNECTING = Symbol('reconnecting');
@@ -53,7 +54,6 @@ const Socket = (newIo) => {
       reconnectionAttempts: 3,
       secure: token.secure,
       forceNew: true,
-      transports: ['websocket'],
       rejectUnauthorized: false,
     };
     const transport = token.secure ? 'wss://' : 'ws://';
@@ -62,12 +62,16 @@ const Socket = (newIo) => {
 
     // Hack to know the exact reason of the WS closure (socket.io does not publish it)
     let closeCode = WEBSOCKET_NORMAL_CLOSURE;
-    const socketOnCloseFunction = socket.io.engine.transport.ws.onclose;
-    socket.io.engine.transport.ws.onclose = (closeEvent) => {
-      Logger.warning('WebSocket closed, code:', closeEvent.code);
-      closeCode = closeEvent.code;
-      socketOnCloseFunction(closeEvent);
-    };
+    if (socket.io.engine.transport.ws) {
+      that.reconnectSupported = true;
+      const socketOnCloseFunction = socket.io.engine.transport.ws.onclose;
+      socket.io.engine.transport.ws.onclose = (closeEvent) => {
+        Logger.warning('WebSocket closed, code:', closeEvent.code);
+        closeCode = closeEvent.code;
+        socketOnCloseFunction(closeEvent);
+      };
+    }
+
     that.socket = socket;
     socket.on('onAddStream', emit.bind(that, 'onAddStream'));
 
@@ -86,10 +90,21 @@ const Socket = (newIo) => {
     // We receive an event of a stream removed from the room
     socket.on('onRemoveStream', emit.bind(that, 'onRemoveStream'));
 
+    socket.io.engine.on('upgrade', (newTransport) => {
+      Logger.info('Transport changed: ', newTransport);
+      that.reconnectSupported = true;
+      const socketOnCloseFunction = socket.io.engine.transport.ws.onclose;
+      socket.io.engine.transport.ws.onclose = (closeEvent) => {
+        Logger.warning('WebSocket closed, code:', closeEvent.code);
+        closeCode = closeEvent.code;
+        socketOnCloseFunction(closeEvent);
+      };
+    });
+
     // The socket has disconnected
     socket.on('disconnect', (reason) => {
       Logger.debug('disconnect', that.id, reason);
-      if (closeCode !== WEBSOCKET_NORMAL_CLOSURE) {
+      if (that.reconnectSupported && closeCode !== WEBSOCKET_NORMAL_CLOSURE) {
         that.state = that.RECONNECTING;
         return;
       }

--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -134,7 +134,6 @@ if (global.config.erizoController.listen_ssl) {  // jshint ignore:line
 server.listen(global.config.erizoController.listen_port); // jshint ignore:line
 var io = require('socket.io').listen(server, {log:false});
 
-io.set('transports', ['websocket']);
 
 var EXIT_ON_NUVE_CHECK_FAIL = global.config.erizoController.exitOnNuveCheckFail;
 var WARNING_N_ROOMS = global.config.erizoController.warning_n_rooms; // jshint ignore:line

--- a/erizo_controller/erizoController/models/Channel.js
+++ b/erizo_controller/erizoController/models/Channel.js
@@ -30,6 +30,7 @@ function listenToSocketHandshakeEvents(channel) {
   channel.socket.on('token', channel.onToken.bind(channel));
   channel.socket.on('reconnected', channel.onReconnected.bind(channel));
   channel.socket.on('disconnect', channel.onDisconnect.bind(channel));
+  channel.socket.conn.on('upgrade', channel.bindToOncloseEvent.bind(channel))
 }
 
 const CONNECTED = Symbol('connected');
@@ -47,9 +48,19 @@ class Channel extends events.EventEmitter {
     this.state = DISCONNECTED;
     this.messageBuffer = [];
     this.id = uuidv4();
+    this.reconnectSupported = false;
 
     // Hack to know the exact reason of the WS closure (socket.io does not publish it)
     this.closeCode = WEBSOCKET_NORMAL_CLOSURE;
+    if (this.socket.conn.transport.socket) {
+      this.bindToOncloseEvent();
+    };
+    listenToSocketHandshakeEvents(this);
+  }
+
+  bindToOncloseEvent(transport) {
+    log.debug('bound to onclose event, transport websocket');
+    this.reconnectSupported = true;
     let onCloseFunction = this.socket.conn.transport.socket.internalOnClose;
     this.socket.conn.transport.socket.internalOnClose = (code, reason) => {
       this.closeCode = code;
@@ -57,8 +68,7 @@ class Channel extends events.EventEmitter {
         onCloseFunction(code, reason);
       }
     };
-    listenToSocketHandshakeEvents(this);
-  }
+  };
 
   onToken(options, callback) {
     const token = options.token;
@@ -97,7 +107,7 @@ class Channel extends events.EventEmitter {
 
   onDisconnect() {
     log.debug('message: socket disconnected, code:', this.closeCode);
-    if (this.closeCode !== WEBSOCKET_NORMAL_CLOSURE &&
+    if (this.reconnectSupported && this.closeCode !== WEBSOCKET_NORMAL_CLOSURE &&
         this.closeCode !== WEBSOCKET_GOING_AWAY_CLOSURE) {
       this.state = RECONNECTING;
       this.disconnecting = setTimeout(() => {


### PR DESCRIPTION
We experienced some problems with some network configuration since the websockets were dropped by the firewall, but they can connect to our frontend (which is not forced to websockets).

So the idea here, is no permit a first connection via polling, and then if the upgrade to websocket succeded, then we can enable the "reconnect" feature.

Please give it a try since it's copied from my work repo, but should work

[] It needs and includes Unit Tests
[] It includes documentation for these changes in `/doc`.