### PR TITLE
[POC] Replace libav with FFmpeg 3.4.2 *do not merge*

### DIFF
--- a/erizo/src/CMakeLists.txt
+++ b/erizo/src/CMakeLists.txt
@@ -86,7 +86,7 @@ test_lib(${SSL})
 find_library(CRYPTO crypto HINTS "${THIRD_PARTY_LIB}")
 test_lib(${CRYPTO})
 
-# Libav
+# FFMPEG
 find_library(AVUTIL avutil HINTS "${THIRD_PARTY_LIB}")
 test_lib(${AVUTIL})
 set (LIBS ${AVUTIL})
@@ -108,6 +108,9 @@ include("${CMAKE_CURRENT_SOURCE_DIR}/third_party/webrtc.cmake")
 include("${CMAKE_CURRENT_SOURCE_DIR}/third_party/nicer.cmake")
 
 ## Erizo
+if(APPLE)
+add_definitions(-Wall -Werror)
+endif()
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/erizo")
 
 ## Examples

--- a/erizo/src/erizo/media/ExternalInput.cpp
+++ b/erizo/src/erizo/media/ExternalInput.cpp
@@ -184,7 +184,7 @@ void ExternalInput::receiveLoop() {
     AVPacket orig_pkt = avpacket_;
     if (needTranscoding_) {
       if (avpacket_.stream_index == video_stream_index_) {  // packet is video
-        inCodec_.decodeVideo(avpacket_.data, avpacket_.size, decodedBuffer_.get(), bufflen_, &gotDecodedFrame);
+        inCodec_.decodeVideoBuffer(avpacket_.data, avpacket_.size, decodedBuffer_.get(), bufflen_, &gotDecodedFrame);
         RawDataPacket packetR;
         if (gotDecodedFrame) {
           packetR.data = decodedBuffer_.get();

--- a/erizo/src/erizo/media/ExternalInput.cpp
+++ b/erizo/src/erizo/media/ExternalInput.cpp
@@ -86,12 +86,12 @@ int ExternalInput::init() {
                audio_stream_index_, audio_st->time_base.num, audio_st->time_base.den);
     audio_time_base_ = audio_st->time_base.den;
     ELOG_DEBUG("Audio Time base %d", audio_time_base_);
-    if (audio_st->codec->codec_id == AV_CODEC_ID_PCM_MULAW) {
+    if (audio_st->codecpar->codec_id == AV_CODEC_ID_PCM_MULAW) {
       ELOG_DEBUG("PCM U8");
       om.audioCodec.sampleRate = 8000;
       om.audioCodec.codec = AUDIO_CODEC_PCM_U8;
       om.rtpAudioInfo.PT = PCMU_8000_PT;
-    } else if (audio_st->codec->codec_id == AV_CODEC_ID_OPUS) {
+    } else if (audio_st->codecpar->codec_id == AV_CODEC_ID_OPUS) {
       ELOG_DEBUG("OPUS");
       om.audioCodec.sampleRate = 48000;
       om.audioCodec.codec = AUDIO_CODEC_OPUS;
@@ -102,7 +102,7 @@ int ExternalInput::init() {
   }
 
 
-  if (st->codec->codec_id == AV_CODEC_ID_VP8 || !om.hasVideo) {
+  if (st->codecpar->codec_id == AV_CODEC_ID_VP8 || !om.hasVideo) {
     ELOG_DEBUG("No need for video transcoding, already VP8");
     video_time_base_ = st->time_base.den;
     needTranscoding_ = false;
@@ -110,12 +110,12 @@ int ExternalInput::init() {
     MediaInfo om;
     om.processorType = PACKAGE_ONLY;
     if (audio_st) {
-      if (audio_st->codec->codec_id == AV_CODEC_ID_PCM_MULAW) {
+      if (audio_st->codecpar->codec_id == AV_CODEC_ID_PCM_MULAW) {
         ELOG_DEBUG("PCM U8");
         om.audioCodec.sampleRate = 8000;
         om.audioCodec.codec = AUDIO_CODEC_PCM_U8;
         om.rtpAudioInfo.PT = PCMU_8000_PT;
-      } else if (audio_st->codec->codec_id == AV_CODEC_ID_OPUS) {
+      } else if (audio_st->codecpar->codec_id == AV_CODEC_ID_OPUS) {
         ELOG_DEBUG("OPUS");
         om.audioCodec.sampleRate = 48000;
         om.audioCodec.codec = AUDIO_CODEC_OPUS;
@@ -126,9 +126,9 @@ int ExternalInput::init() {
     op_->init(om, this);
   } else {
     needTranscoding_ = true;
-    inCodec_.initDecoder(st->codec);
+    inCodec_.initDecoder(&video_codec_ctx_, st->codecpar);
 
-    bufflen_ = st->codec->width*st->codec->height*3/2;
+    bufflen_ = video_codec_ctx_->width*video_codec_ctx_->height*3/2;
     decodedBuffer_.reset((unsigned char*) malloc(bufflen_));
 
 

--- a/erizo/src/erizo/media/ExternalInput.cpp
+++ b/erizo/src/erizo/media/ExternalInput.cpp
@@ -27,7 +27,7 @@ ExternalInput::~ExternalInput() {
   thread_.join();
   if (needTranscoding_)
     encodeThread_.join();
-  av_free_packet(&avpacket_);
+  av_packet_unref(&avpacket_);
   if (context_ != NULL)
     avformat_free_context(context_);
   ELOG_DEBUG("ExternalInput closed");
@@ -221,7 +221,7 @@ void ExternalInput::receiveLoop() {
         }
       }
     }
-    av_free_packet(&orig_pkt);
+    av_packet_unref(&orig_pkt);
   }
   ELOG_DEBUG("Ended stream to play %s", url_.c_str());
   running_ = false;

--- a/erizo/src/erizo/media/ExternalInput.h
+++ b/erizo/src/erizo/media/ExternalInput.h
@@ -52,6 +52,7 @@ class ExternalInput : public MediaSource, public RTPDataReceiver {
   std::queue<RawDataPacket> packetQueue_;
   AVFormatContext* context_;
   AVPacket avpacket_;
+  AVCodecContext *video_codec_ctx_;
   int video_stream_index_, video_time_base_;
   int audio_stream_index_, audio_time_base_;
   int bufflen_;

--- a/erizo/src/erizo/media/ExternalOutput.h
+++ b/erizo/src/erizo/media/ExternalOutput.h
@@ -107,8 +107,12 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
   // so the second scheme seems not applicable.  Too bad.
   bool need_to_send_fir_;
   std::vector<RtpMap> rtp_mappings_;
-  enum AVCodecID video_codec_;
-  enum AVCodecID audio_codec_;
+  enum AVCodecID video_codec_id_;
+  enum AVCodecID audio_codec_id_;
+  AVCodec *video_codec;
+  AVCodec *audio_codec;
+  AVCodecContext *video_ctx_;
+  AVCodecContext *audio_ctx_;
   std::map<uint, RtpMap> video_maps_;
   std::map<uint, RtpMap> audio_maps_;
   RtpMap video_map_;

--- a/erizo/src/erizo/media/MediaInfo.h
+++ b/erizo/src/erizo/media/MediaInfo.h
@@ -1,0 +1,36 @@
+#ifndef ERIZO_SRC_ERIZO_MEDIA_MEDIAINFO_H_
+#define ERIZO_SRC_ERIZO_MEDIA_MEDIAINFO_H_
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+}
+
+#include <string>
+#include "codecs/Codecs.h"
+
+namespace erizo {
+
+struct RTPInfo {
+  enum AVCodecID codec;
+  unsigned int ssrc;
+  unsigned int PT;
+};
+
+enum ProcessorType {
+  RTP_ONLY, AVF, PACKAGE_ONLY
+};
+
+struct MediaInfo {
+  std::string url;
+  bool hasVideo;
+  bool hasAudio;
+  ProcessorType processorType;
+  RTPInfo rtpVideoInfo;
+  RTPInfo rtpAudioInfo;
+  VideoCodecInfo videoCodec;
+  AudioCodecInfo audioCodec;
+};
+
+}  // namespace erizo
+
+#endif  // ERIZO_SRC_ERIZO_MEDIA_MEDIAINFO_H_

--- a/erizo/src/erizo/media/codecs/AudioCodec.cpp
+++ b/erizo/src/erizo/media/codecs/AudioCodec.cpp
@@ -24,9 +24,10 @@ inline AVCodecID AudioCodecID2ffmpegDecoderID(AudioCodecID codec) {
 }
 
 AudioEncoder::AudioEncoder() {
-  aCoder_ = NULL;
-  aCoderContext_ = NULL;
-  aFrame_ = NULL;
+  encode_codec_ = NULL;
+  encode_context_ = NULL;
+  encoded_frame_ = NULL;
+  initialized = false;
 }
 
 AudioEncoder::~AudioEncoder() {
@@ -35,97 +36,64 @@ AudioEncoder::~AudioEncoder() {
 }
 
 int AudioEncoder::initEncoder(const AudioCodecInfo& mediaInfo) {
-  ELOG_DEBUG("Init audioEncoder begin");
-  aCoder_ = avcodec_find_encoder(AudioCodecID2ffmpegDecoderID(mediaInfo.codec));
-  if (!aCoder_) {
-    ELOG_DEBUG("Audio Codec not found");
-    return false;
-  }
-
-  aCoderContext_ = avcodec_alloc_context3(aCoder_);
-  if (!aCoderContext_) {
-    ELOG_DEBUG("Memory error allocating audio coder context");
-    return false;
-  }
-
-  aCoderContext_->sample_fmt = AV_SAMPLE_FMT_FLT;
-  // aCoderContext_->bit_rate = mediaInfo.bitRate;
-  aCoderContext_->sample_rate = 8 /*mediaInfo.sampleRate*/;
-  aCoderContext_->channels = 1;
-  char errbuff[500];
-  int res = avcodec_open2(aCoderContext_, aCoder_, NULL);
-  if (res != 0) {
-    av_strerror(res, reinterpret_cast<char*>(&errbuff), 500);
-    ELOG_DEBUG("fail when opening input %s", errbuff);
+  if (!coder_.allocCodecContext(&encode_context_, &encode_codec_,
+      AudioCodecID2ffmpegDecoderID(mediaInfo.codec), OPERATION_ENCODE)) {
     return -1;
   }
-  ELOG_DEBUG("Init audioEncoder end");
-  return true;
-}
 
-int AudioEncoder::encodeAudio(unsigned char* inBuffer, int nSamples, AVPacket* pkt) {
-  AVFrame *frame = av_frame_alloc();
-  if (!frame) {
-    ELOG_ERROR("could not allocate audio frame");
-    return 0;
-  }
-  int ret, got_output, buffer_size;
+  encode_context_->sample_fmt = AV_SAMPLE_FMT_FLT;
+  // encode_context_->bit_rate = mediaInfo.bitRate;
+  encode_context_->sample_rate = 8 /*mediaInfo.sampleRate*/;
+  encode_context_->channels = 1;
 
-  frame->nb_samples = aCoderContext_->frame_size;
-  frame->format = aCoderContext_->sample_fmt;
-  // frame->channel_layout = aCoderContext_->channel_layout;
-
-  /* the codec gives us the frame size, in samples,
-   * we calculate the size of the samples buffer in bytes */
-  ELOG_DEBUG("channels %d, frame_size %d, sample_fmt %d",
-      aCoderContext_->channels, aCoderContext_->frame_size,
-      aCoderContext_->sample_fmt);
-  buffer_size = av_samples_get_buffer_size(NULL, aCoderContext_->channels,
-      aCoderContext_->frame_size, aCoderContext_->sample_fmt, 0);
-  uint16_t* samples = reinterpret_cast<uint16_t*>(malloc(buffer_size));
-  if (!samples) {
-    ELOG_ERROR("could not allocate %d bytes for samples buffer", buffer_size);
-    return 0;
-  }
-  /* setup the data pointers in the AVFrame */
-  ret = avcodec_fill_audio_frame(frame, aCoderContext_->channels,
-      aCoderContext_->sample_fmt, (const uint8_t*) samples, buffer_size,
-      0);
-  if (ret < 0) {
-      free(samples);
-      ELOG_ERROR("could not setup audio frame");
-      return 0;
-  }
-
-  ret = avcodec_encode_audio2(aCoderContext_, pkt, frame, &got_output);
-  if (ret < 0) {
-    ELOG_ERROR("error encoding audio frame");
-    free(samples);
-    return 0;
-  }
-  if (got_output) {
-    // fwrite(pkt.data, 1, pkt.size, f);
-    ELOG_DEBUG("Got OUTPUT");
-  }
-
-  return ret;
+  initialized = coder_.openCodecContext(encode_context_, encode_codec_, NULL);
+  return initialized;
 }
 
 int AudioEncoder::closeEncoder() {
-  if (aCoderContext_ != NULL) {
-    avcodec_close(aCoderContext_);
+  if (encode_context_ != nullptr) {
+    avcodec_close(encode_context_);
+    avcodec_free_context(&encode_context_);
   }
-  if (aFrame_ != NULL) {
-    av_frame_free(&aFrame_);
+  if (encoded_frame_ != nullptr) {
+    av_frame_free(&encoded_frame_);
   }
   return 0;
 }
 
+void AudioEncoder::encodeAudioBuffer(unsigned char* inBuffer, int nSamples, AVPacket* pkt,
+    EncodeAudioBufferCB &done) {
+  AVFrame *frame = av_frame_alloc();
+  if (!frame) {
+    ELOG_ERROR("Could not allocate audio frame for encoding.");
+    return;
+  }
+  int ret;
+
+  frame->nb_samples = encode_context_->frame_size;
+
+  if ((ret = avcodec_fill_audio_frame(frame,
+                  encode_context_->channels,
+                  encode_context_->sample_fmt,
+                  (const uint8_t*)inBuffer,
+                  nSamples * 2,
+                  0)) < 0) {
+    ELOG_ERROR("avcodec_fill_audio_frame failed: %s", av_err2str(ret));
+    return;
+  }
+
+  EncodeCB done_callback = [done](AVPacket *pkt, AVFrame *frame, bool got_packet) {
+    av_frame_free(&frame);
+    done(pkt, got_packet);
+  };
+  coder_.encode(encode_context_, frame, pkt, done_callback);
+}
 
 AudioDecoder::AudioDecoder() {
-  aDecoder_ = NULL;
-  aDecoderContext_ = NULL;
+  decode_codec_ = NULL;
+  decode_context_ = NULL;
   dFrame_ = NULL;
+  initialized = false;
 }
 
 AudioDecoder::~AudioDecoder() {
@@ -134,123 +102,64 @@ AudioDecoder::~AudioDecoder() {
 }
 
 int AudioDecoder::initDecoder(const AudioCodecInfo& info) {
-  aDecoder_ = avcodec_find_decoder(static_cast<AVCodecID>(info.codec));
-  if (!aDecoder_) {
-    ELOG_DEBUG("Audio decoder not found");
-    return false;
+  if (!coder_.allocCodecContext(&decode_context_, &decode_codec_,
+      AudioCodecID2ffmpegDecoderID(info.codec), OPERATION_DECODE)) {
+    return -1;
   }
 
-  aDecoderContext_ = avcodec_alloc_context3(aDecoder_);
-  if (!aDecoderContext_) {
-    ELOG_DEBUG("Error allocating audio decoder context");
-    return false;
-  }
+  decode_context_->sample_fmt = AV_SAMPLE_FMT_S16;
+  decode_context_->bit_rate = info.bitRate;
+  decode_context_->sample_rate = info.sampleRate;
+  decode_context_->channels = 1;
 
-  aDecoderContext_->sample_fmt = AV_SAMPLE_FMT_S16;
-  aDecoderContext_->bit_rate = info.bitRate;
-  aDecoderContext_->sample_rate = info.sampleRate;
-  aDecoderContext_->channels = 1;
-
-  if (avcodec_open2(aDecoderContext_, aDecoder_, NULL) < 0) {
-    ELOG_DEBUG("Error opening audio decoder");
-    return false;
-  }
-  return true;
-}
-
-int AudioDecoder::initDecoder(AVCodecContext* context) {
-  return 0;
+  initialized = coder_.openCodecContext(decode_context_, decode_codec_, NULL);
+  return initialized;
 }
 
 int AudioDecoder::decodeAudio(unsigned char* inBuff, int inBuffLen,
-    unsigned char* outBuff, int outBuffLen, int* gotFrame) {
-  AVPacket avpkt;
-  int outSize = 0;
-  int decSize = 0;
-  int len = -1;
-  uint8_t *decBuff = reinterpret_cast<uint8_t*>(malloc(16000));
+    unsigned char* outBuff, int outBuffLen) {
 
+  int out_size = 0;
+  AVPacket avpkt;
   av_init_packet(&avpkt);
   avpkt.data = (unsigned char*) inBuff;
   avpkt.size = inBuffLen;
 
-  while (avpkt.size > 0) {
-    outSize = 16000;
+  AVFrame *frame;
+  frame = av_frame_alloc();
 
-    // Puede fallar. Cogido de libavcodec/utils.c del paso de avcodec_decode_audio3 a avcodec_decode_audio4
-    // avcodec_decode_audio3(aDecoderContext, (short*)decBuff, &outSize, &avpkt);
-
-    AVFrame frame;
-    int got_frame = 0;
-
-    //      aDecoderContext->get_buffer = avcodec_default_get_buffer;
-    //      aDecoderContext->release_buffer = avcodec_default_release_buffer;
-
-    len = avcodec_decode_audio4(aDecoderContext_, &frame, &got_frame,
-        &avpkt);
-    if (len >= 0 && got_frame) {
-      int plane_size;
-      // int planar = av_sample_fmt_is_planar(aDecoderContext->sample_fmt);
-      int data_size = av_samples_get_buffer_size(&plane_size,
-          aDecoderContext_->channels, frame.nb_samples,
-          aDecoderContext_->sample_fmt, 1);
-      if (outSize < data_size) {
-        ELOG_DEBUG("output buffer size is too small for the current frame");
-        free(decBuff);
-        return AVERROR(EINVAL);
+  if (coder_.decode(decode_context_, frame, &avpkt)) {
+    // Asume S16 Non-Planar Audio for now.
+    int planar = av_sample_fmt_is_planar(decode_context_->sample_fmt);
+    if (planar == 0) {
+      out_size = av_samples_get_buffer_size(NULL,
+                          av_frame_get_channels(frame),
+                          frame->nb_samples,
+                          (AVSampleFormat)frame->format, 1);
+      if (out_size > outBuffLen) {
+        ELOG_ERROR("Data size bigger than buffer size.");
+        out_size = 0;
+      } else {
+        memcpy(outBuff, frame->data[0], out_size);
       }
-
-      memcpy(decBuff, frame.extended_data[0], plane_size);
-
-      /* Si hay más de un canal
-         if (planar && aDecoderContext->channels > 1) {
-         uint8_t *out = ((uint8_t *)decBuff) + plane_size;
-         for (int ch = 1; ch < aDecoderContext->channels; ch++) {
-         memcpy(out, frame.extended_data[ch], plane_size);
-         out += plane_size;
-         }
-         }
-         */
-      outSize = data_size;
     } else {
-      outSize = 0;
+      ELOG_ERROR("Audio planar buffer is not handled yet.");
     }
-
-    if (len < 0) {
-      ELOG_DEBUG("Error al decodificar audio");
-      free(decBuff);
-      return -1;
-    }
-
-    avpkt.size -= len;
-    avpkt.data += len;
-
-    if (outSize <= 0) {
-      continue;
-    }
-
-    memcpy(outBuff, decBuff, outSize);
-    outBuff += outSize;
-    decSize += outSize;
+    av_packet_unref(&avpkt);
   }
 
-  free(decBuff);
-
-  if (outSize <= 0) {
-    ELOG_DEBUG("Error de decodificación de audio debido a tamaño incorrecto");
-    return -1;
-  }
-
-  return decSize;
+  av_frame_free(&frame);
+  return out_size;
 }
 
 int AudioDecoder::closeDecoder() {
-  if (aDecoderContext_ != NULL) {
-    avcodec_close(aDecoderContext_);
+  if (decode_context_ != NULL) {
+    avcodec_close(decode_context_);
   }
   if (dFrame_ != NULL) {
     av_frame_free(&dFrame_);
   }
+  initialized = false;
   return 0;
 }
 }  // namespace erizo

--- a/erizo/src/erizo/media/codecs/AudioCodec.h
+++ b/erizo/src/erizo/media/codecs/AudioCodec.h
@@ -4,6 +4,7 @@
 #ifndef ERIZO_SRC_ERIZO_MEDIA_CODECS_AUDIOCODEC_H_
 #define ERIZO_SRC_ERIZO_MEDIA_CODECS_AUDIOCODEC_H_
 
+#define __STDC_CONSTANT_MACROS
 extern "C" {
   #include <libavutil/avutil.h>
   #include <libavcodec/avcodec.h>

--- a/erizo/src/erizo/media/codecs/AudioCodec.h
+++ b/erizo/src/erizo/media/codecs/AudioCodec.h
@@ -10,10 +10,14 @@ extern "C" {
   #include <libavcodec/avcodec.h>
 }
 
+#include "media/MediaInfo.h"
 #include "./Codecs.h"
+#include "./Coder.h"
 #include "./logger.h"
 
 namespace erizo {
+
+typedef std::function<void(AVPacket *av_packet, bool got_packet)> EncodeAudioBufferCB;
 
 class AudioEncoder {
   DECLARE_LOGGER();
@@ -22,13 +26,16 @@ class AudioEncoder {
   AudioEncoder();
   virtual ~AudioEncoder();
   int initEncoder(const AudioCodecInfo& info);
-  int encodeAudio(unsigned char* inBuffer, int nSamples, AVPacket* pkt);
+  void encodeAudioBuffer(unsigned char* inBuffer, int nSamples, AVPacket* pkt,
+      EncodeAudioBufferCB &done);
   int closeEncoder();
+  bool initialized;
 
  private:
-  AVCodec* aCoder_;
-  AVCodecContext* aCoderContext_;
-  AVFrame* aFrame_;
+  Coder coder_;
+  AVCodec *encode_codec_;
+  AVCodecContext *encode_context_;
+  AVFrame *encoded_frame_;
 };
 
 class AudioDecoder {
@@ -38,13 +45,14 @@ class AudioDecoder {
   AudioDecoder();
   virtual ~AudioDecoder();
   int initDecoder(const AudioCodecInfo& info);
-  int initDecoder(AVCodecContext* context);
-  int decodeAudio(unsigned char* inBuff, int inBuffLen, unsigned char* outBuff, int outBuffLen, int* gotFrame);
+  int decodeAudio(unsigned char* inBuff, int inBuffLen, unsigned char* outBuff, int outBuffLen);
   int closeDecoder();
+  bool initialized;
 
  private:
-  AVCodec* aDecoder_;
-  AVCodecContext* aDecoderContext_;
+  Coder coder_;
+  AVCodec* decode_codec_;
+  AVCodecContext* decode_context_;
   AVFrame* dFrame_;
 };
 

--- a/erizo/src/erizo/media/codecs/Codecs.h
+++ b/erizo/src/erizo/media/codecs/Codecs.h
@@ -29,6 +29,8 @@ struct AudioCodecInfo {
   AudioCodecID codec;
   int bitRate;
   int sampleRate;
+  int sampleFmt;
+  int channels;
 };
 }  // namespace erizo
 #endif  // ERIZO_SRC_ERIZO_MEDIA_CODECS_CODECS_H_

--- a/erizo/src/erizo/media/codecs/Coder.cpp
+++ b/erizo/src/erizo/media/codecs/Coder.cpp
@@ -1,0 +1,115 @@
+#include "media/codecs/Coder.h"
+
+namespace erizo {
+
+DEFINE_LOGGER(Coder, "media.codecs.Coder");
+
+Coder::Coder() {
+}
+
+Coder::~Coder() {
+}
+
+bool Coder::allocCodecContext(AVCodecContext **ctx, AVCodec **c, AVCodecID codec_id,
+    CoderOperationType operation) {
+  AVCodec *codec = nullptr;
+  AVCodecContext *codec_ctx = *ctx;
+  if (operation == OPERATION_ENCODE) {
+    codec = avcodec_find_encoder(codec_id);
+  } else {
+    codec = avcodec_find_decoder(codec_id);
+  }
+  if (codec == nullptr) {
+    ELOG_ERROR("Cannot find codec %d", codec_id);
+    return false;
+  }
+  codec_ctx = avcodec_alloc_context3(codec);
+  if (!codec_ctx) {
+      ELOG_ERROR("Could not allocate codec context for %s", codec->name);
+      return false;
+  } else {
+    ELOG_INFO("Successfully allocated context for codec %s.", codec->name);
+  }
+  *c = codec;
+  *ctx = codec_ctx;
+  return true;
+}
+
+bool Coder::openCodecContext(AVCodecContext *codec_ctx, AVCodec *codec, AVDictionary *opt) {
+  const char *operation = (av_codec_is_encoder(codec_ctx->codec) ? "encoder" : "decoder");
+  int ret = avcodec_open2(codec_ctx, NULL, &opt);
+  if (ret < 0) {
+      static char error_str[255];
+      av_strerror(ret, error_str, sizeof(error_str));
+      ELOG_ERROR("Could not open %s codec of %s: %s", operation,
+          codec->name,
+          error_str);
+  }
+  av_dict_free(&opt);
+  this->logCodecContext(codec_ctx);
+  return ret < 0 ? false : true;
+}
+
+void Coder::logCodecContext(AVCodecContext *codec_ctx) {
+  const char *operation = (av_codec_is_encoder(codec_ctx->codec) ? "encoder" : "decoder");
+  if (codec_ctx->codec->type == AVMEDIA_TYPE_AUDIO) {
+    ELOG_DEBUG("\nAudio %s codec: %s \nchannel_layout: %d\nchannels: %d\nframe_size: %d\nsample_rate: %d\nsample_fmt: %s\nbits per sample: %d",
+        operation, codec_ctx->codec->name, codec_ctx->channel_layout, codec_ctx->channels, codec_ctx->frame_size,
+        codec_ctx->sample_rate, av_get_sample_fmt_name(codec_ctx->sample_fmt),
+        av_get_bytes_per_sample (codec_ctx->sample_fmt));
+  } else if (codec_ctx->codec->type == AVMEDIA_TYPE_VIDEO) {
+    ELOG_DEBUG("\nVideo %s codec: %s\n framerate: {%d/%d}\n time_base: {%d/%d}\n",
+        operation, codec_ctx->codec->name, codec_ctx->framerate.num, codec_ctx->framerate.den,
+        codec_ctx->time_base.num, codec_ctx->time_base.den);
+  }
+}
+
+bool Coder::decode(AVCodecContext *decode_ctx, AVFrame *frame, AVPacket *av_packet) {
+  int ret;
+  ret = avcodec_send_packet(decode_ctx, av_packet);
+  if (ret < 0) {
+    ELOG_ERROR("avcodec_send_packet failed. %d %s", ret, av_err2str(ret));
+    return false;
+  }
+  ret = avcodec_receive_frame(decode_ctx, frame);
+  if (ret != 0) {
+    ELOG_ERROR("avcodec_receive_frame. %d %s", ret, av_err2str(ret));
+    return false;
+  }
+  ELOG_DEBUG("decoded %s, nb_samples: %d, size: %d", decode_ctx->codec->name,
+      frame->nb_samples, av_packet->size);
+  return true;
+}
+
+void Coder::encode(AVCodecContext *encode_ctx, AVFrame *frame, AVPacket *av_packet, const EncodeCB &done) {
+  auto t_started = std::chrono::high_resolution_clock::now();
+  int ret = avcodec_send_frame(encode_ctx, frame);
+  if (ret < 0) {
+    ELOG_ERROR("avcodec_send_frame failed for %s. %d %s", encode_ctx->codec->name,
+        ret, av_err2str(ret));
+    done(av_packet, frame, false);
+  }
+  while(ret >= 0) {
+    ret = avcodec_receive_packet(encode_ctx, av_packet);
+    if (ret == AVERROR_EOF) {
+      ELOG_DEBUG("avcodec_receive_packet AVERROR_EOF, %s, ret: %d, %s", encode_ctx->codec->name,
+          ret, av_err2str(ret))
+      done(av_packet, frame, false);
+      return;
+    } else if (ret == AVERROR(EAGAIN)) {
+      done(av_packet, frame, false);
+      return;
+    } else if (ret == 0) {
+      auto t_done = std::chrono::high_resolution_clock::now();
+      ELOG_DEBUG("Encoding %s time: %d milliseconds", encode_ctx->codec->name,
+          std::chrono::duration_cast<std::chrono::milliseconds>(t_done-t_started).count());
+      done(av_packet, frame, true);
+    } else {
+      ELOG_ERROR("avcodec_receive_packet failed. %s, %d %s", encode_ctx->codec->name,
+          ret, av_err2str(ret));
+      done(av_packet, frame, false);
+    }
+  }
+}
+
+}  // namespace erizo

--- a/erizo/src/erizo/media/codecs/Coder.h
+++ b/erizo/src/erizo/media/codecs/Coder.h
@@ -1,0 +1,49 @@
+#ifndef ERIZO_SRC_ERIZO_MEDIA_CODECS_CODER_H_
+#define ERIZO_SRC_ERIZO_MEDIA_CODECS_CODER_H_
+
+#include <functional>
+#include "./logger.h"
+
+#include <boost/thread.hpp>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+#include <libavutil/frame.h>
+#include <libavutil/audio_fifo.h>
+#include <libavutil/opt.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/error.h>
+#include <libavutil/samplefmt.h>
+#include <libavutil/channel_layout.h>
+#include <libavutil/mathematics.h>
+#include <libavutil/avutil.h>
+#include <libavresample/avresample.h>
+}
+
+namespace erizo {
+
+typedef std::function<void(AVPacket *packet, AVFrame *frame, bool success)> EncodeCB;
+
+enum CoderOperationType {
+  OPERATION_ENCODE,
+  OPERATION_DECODE
+};
+
+class Coder {
+  DECLARE_LOGGER();
+
+ public:
+  Coder();
+  virtual ~Coder();
+  bool allocCodecContext(AVCodecContext **ctx, AVCodec **c, AVCodecID codec_id,
+    CoderOperationType operation);
+  bool openCodecContext(AVCodecContext *codec_ctx, AVCodec *codec, AVDictionary *opt);
+  void logCodecContext(AVCodecContext *codec_ctx);
+  bool decode(AVCodecContext *decode_ctx, AVFrame *frame, AVPacket *av_packet);
+  void encode(AVCodecContext *encode_ctx, AVFrame *frame, AVPacket *av_packet,
+      const EncodeCB &done);
+};
+
+}  // namespace erizo
+#endif  // ERIZO_SRC_ERIZO_MEDIA_CODECS_CODER_H_

--- a/erizo/src/erizo/media/codecs/VideoCodec.cpp
+++ b/erizo/src/erizo/media/codecs/VideoCodec.cpp
@@ -63,7 +63,7 @@ int VideoEncoder::initEncoder(const VideoCodecInfo& info) {
 
   vCoderContext->width = info.width;
   vCoderContext->height = info.height;
-  vCoderContext->pix_fmt = PIX_FMT_YUV420P;
+  vCoderContext->pix_fmt = AV_PIX_FMT_YUV420P;
   vCoderContext->time_base = (AVRational) {1, 90000};
 
   vCoderContext->sample_aspect_ratio = (AVRational) { info.width, info.height };
@@ -277,7 +277,7 @@ decoding:
     cromV += dst_linesize;
     src += src_linesize;
   }
-  av_free_packet(&avpkt);
+  av_packet_unref(&avpkt);
 
   return outSize * 3 / 2;
 }

--- a/erizo/src/erizo/media/codecs/VideoCodec.h
+++ b/erizo/src/erizo/media/codecs/VideoCodec.h
@@ -5,7 +5,11 @@
 #ifndef ERIZO_SRC_ERIZO_MEDIA_CODECS_VIDEOCODEC_H_
 #define ERIZO_SRC_ERIZO_MEDIA_CODECS_VIDEOCODEC_H_
 
+#include <functional>
+
+#include "media/MediaInfo.h"
 #include "media/codecs/Codecs.h"
+#include "media/codecs/Coder.h"
 #include "./logger.h"
 
 extern "C" {
@@ -24,6 +28,8 @@ extern "C" {
 
 namespace erizo {
 
+typedef std::function<void(bool success, int len)> EncodeVideoBufferCB;
+
 class VideoEncoder {
   DECLARE_LOGGER();
 
@@ -31,12 +37,15 @@ class VideoEncoder {
   VideoEncoder();
   virtual ~VideoEncoder();
   int initEncoder(const VideoCodecInfo& info);
-  int encodeVideo(unsigned char* inBuffer, int length, unsigned char* outBuffer, int outLength);
+  void encodeVideoBuffer(unsigned char* inBuffer, int len, unsigned char* outBuffer,
+      const EncodeVideoBufferCB &done);
   int closeEncoder();
+  bool initialized;
 
  private:
-  AVCodec* vCoder;
-  AVCodecContext* vCoderContext;
+  Coder coder_;
+  AVCodec* av_codec;
+  AVCodecContext* encode_context_;
   AVFrame* cPicture;
 };
 
@@ -48,15 +57,17 @@ class VideoDecoder {
   virtual ~VideoDecoder();
   int initDecoder(const VideoCodecInfo& info);
   int initDecoder(AVCodecContext** context, AVCodecParameters *codecpar);
-  int decodeVideo(unsigned char* inBuff, int inBuffLen,
-      unsigned char* outBuff, int outBuffLen, int* gotFrame);
+  int decodeVideoBuffer(unsigned char* inBuff, int inBuffLen, unsigned char* outBuff,
+      int outBuffLen, int* gotFrame);
   int closeDecoder();
+  bool initialized;
 
  private:
-  AVCodec* vDecoder;
-  bool initWithContext_;
-  AVCodecContext* vDecoderContext;
+  Coder coder_;
+  AVCodec* av_codec;
+  AVCodecContext* decode_context_;
   AVFrame* dPicture;
+  bool initWithContext_;
 };
 
 }  // namespace erizo

--- a/erizo/src/erizo/media/codecs/VideoCodec.h
+++ b/erizo/src/erizo/media/codecs/VideoCodec.h
@@ -47,7 +47,7 @@ class VideoDecoder {
   VideoDecoder();
   virtual ~VideoDecoder();
   int initDecoder(const VideoCodecInfo& info);
-  int initDecoder(AVCodecContext* context);
+  int initDecoder(AVCodecContext** context, AVCodecParameters *codecpar);
   int decodeVideo(unsigned char* inBuff, int inBuffLen,
       unsigned char* outBuff, int outBuffLen, int* gotFrame);
   int closeDecoder();

--- a/erizo_controller/erizoAgent/log4cxx.properties
+++ b/erizo_controller/erizoAgent/log4cxx.properties
@@ -34,7 +34,7 @@ log4j.logger.media.InputProcessor=WARN
 log4j.logger.media.OneToManyTranscoder=WARN
 log4j.logger.media.OutputProcessor=WARN
 
-
+log4j.logger.media.codecs.Coder=WARN
 log4j.logger.media.codecs.VideoEncoder=WARN
 log4j.logger.media.codecs.VideoDecoder=WARN
 log4j.logger.media.codecs.AudioEncoder=WARN

--- a/scripts/installMacDeps.sh
+++ b/scripts/installMacDeps.sh
@@ -173,11 +173,9 @@ install_mediadeps(){
   brew install opus libvpx x264
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O -L https://github.com/libav/libav/archive/v11.6.tar.gz
-    tar -zxvf v11.6.tar.gz
-    cd libav-11.6
-    curl -OL https://github.com/libav/libav/commit/4d05e9392f84702e3c833efa86e84c7f1cf5f612.patch
-    patch libavcodec/libvpxenc.c 4d05e9392f84702e3c833efa86e84c7f1cf5f612.patch && \
+    curl -O -L https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.bz2
+    tar -zxvf ffmpeg-3.4.2.tar.bz2
+    cd ffmpeg-3.4.2
     PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus --disable-doc && \
     make $FAST_MAKE -s V=0 && \
     make install
@@ -193,11 +191,9 @@ install_mediadeps_nogpl(){
   brew install opus libvpx
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O -L https://github.com/libav/libav/archive/v11.6.tar.gz
-    tar -zxvf v11.6.tar.gz
-    cd libav-11.6
-    curl -OL https://github.com/libav/libav/commit/4d05e9392f84702e3c833efa86e84c7f1cf5f612.patch
-    patch libavcodec/libvpxenc.c 4d05e9392f84702e3c833efa86e84c7f1cf5f612.patch && \
+    curl -O -L https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.bz2
+    tar -zxvf ffmpeg-3.4.2.tar.bz2
+    cd ffmpeg-3.4.2
     PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-libvpx --enable-libopus --disable-doc && \
     make $FAST_MAKE -s V=0 && \
     make install

--- a/scripts/installMacDeps.sh
+++ b/scripts/installMacDeps.sh
@@ -173,8 +173,8 @@ install_mediadeps(){
   brew install opus libvpx x264
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O -L https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.bz2
-    tar -zxvf ffmpeg-3.4.2.tar.bz2
+    curl -O -L https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.gz
+    tar -zxvf ffmpeg-3.4.2.tar.gz
     cd ffmpeg-3.4.2
     PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus --disable-doc && \
     make $FAST_MAKE -s V=0 && \
@@ -191,8 +191,8 @@ install_mediadeps_nogpl(){
   brew install opus libvpx
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    curl -O -L https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.bz2
-    tar -zxvf ffmpeg-3.4.2.tar.bz2
+    curl -O -L https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.gz
+    tar -zxvf ffmpeg-3.4.2.tar.gz
     cd ffmpeg-3.4.2
     PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-libvpx --enable-libopus --disable-doc && \
     make $FAST_MAKE -s V=0 && \

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -157,16 +157,13 @@ install_mediadeps(){
   sudo apt-get -qq install yasm libvpx. libx264.
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    if [ ! -f ./v11.1.tar.gz ]; then
-      curl -O -L https://github.com/libav/libav/archive/v11.1.tar.gz
-      tar -zxvf v11.1.tar.gz
-      cd libav-11.1
-      PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus --disable-doc
-      make $FAST_MAKE -s V=0
-      make install
-    else
-      echo "libav already installed"
-    fi
+    rm -r libav*
+    curl -O -L https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.bz2
+    tar -zxvf ffmpeg-3.4.2.tar.bz2
+    cd ffmpeg-3.4.2
+    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus --disable-doc
+    make $FAST_MAKE -s V=0
+    make install
     cd $CURRENT_DIR
   else
     mkdir -p $LIB_DIR
@@ -180,16 +177,13 @@ install_mediadeps_nogpl(){
   sudo apt-get -qq install yasm libvpx.
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    if [ ! -f ./v11.1.tar.gz ]; then
-      curl -O -L https://github.com/libav/libav/archive/v11.1.tar.gz
-      tar -zxvf v11.1.tar.gz
-      cd libav-11.1
-      PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libopus --disable-doc
-      make $FAST_MAKE -s V=0
-      make install
-    else
-      echo "libav already installed"
-    fi
+    rm -r libav*
+    curl -O -L https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.bz2
+    tar -zxvf ffmpeg-3.4.2.tar.bz2
+    cd ffmpeg-3.4.2
+    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libopus --disable-doc
+    make $FAST_MAKE -s V=0
+    make install
     cd $CURRENT_DIR
   else
     mkdir -p $LIB_DIR
@@ -217,7 +211,7 @@ cleanup(){
     cd $LIB_DIR
     rm -r libnice*
     rm -r libsrtp*
-    rm -r libav*
+    rm -r fmpeg*
     rm -r v11*
     rm -r openssl*
     rm -r opus*

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -157,9 +157,8 @@ install_mediadeps(){
   sudo apt-get -qq install yasm libvpx. libx264.
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    rm -r libav*
-    curl -O -L https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.bz2
-    tar -zxvf ffmpeg-3.4.2.tar.bz2
+    curl -O -L https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.gz
+    tar -zxvf ffmpeg-3.4.2.tar.gz
     cd ffmpeg-3.4.2
     PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus --disable-doc
     make $FAST_MAKE -s V=0
@@ -177,9 +176,8 @@ install_mediadeps_nogpl(){
   sudo apt-get -qq install yasm libvpx.
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    rm -r libav*
-    curl -O -L https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.bz2
-    tar -zxvf ffmpeg-3.4.2.tar.bz2
+    curl -O -L https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.gz
+    tar -zxvf ffmpeg-3.4.2.tar.gz
     cd ffmpeg-3.4.2
     PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libopus --disable-doc
     make $FAST_MAKE -s V=0
@@ -211,8 +209,8 @@ cleanup(){
     cd $LIB_DIR
     rm -r libnice*
     rm -r libsrtp*
-    rm -r fmpeg*
-    rm -r v11*
+    rm -r ffmpeg*
+    #rm -r v11*
     rm -r openssl*
     rm -r opus*
     cd $CURRENT_DIR

--- a/scripts/travisInstallDeps.sh
+++ b/scripts/travisInstallDeps.sh
@@ -132,16 +132,13 @@ install_mediadeps(){
   sudo apt-get -qq install yasm libvpx. libx264.
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    if [ ! -f ./v11.1.tar.gz ]; then
-      curl -O -L https://github.com/libav/libav/archive/v11.1.tar.gz
-      tar -zxvf v11.1.tar.gz
-      cd libav-11.1
-      PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus --disable-doc 
-      make -s V=0
-      make install
-    else
-      echo "libav already installed"
-    fi
+    rm -r libav*
+    curl -O -L https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.bz2
+    tar -zxvf ffmpeg-3.4.2.tar.bz2
+    cd ffmpeg-3.4.2
+    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus --disable-doc 
+    make -s V=0
+    make install
     cd $CURRENT_DIR
   else
     mkdir -p $LIB_DIR
@@ -154,16 +151,13 @@ install_mediadeps_nogpl(){
   sudo apt-get -qq install yasm libvpx.
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    if [ ! -f ./v11.1.tar.gz ]; then
-      curl -O -L https://github.com/libav/libav/archive/v11.1.tar.gz
-      tar -zxvf v11.1.tar.gz
-      cd libav-11.1
-      PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libopus --disable-doc
-      make -s V=0
-      make install
-    else
-      echo "libav already installed"
-    fi
+    rm -r libav*
+    curl -O -L https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.bz2
+    tar -zxvf ffmpeg-3.4.2.tar.bz2
+    cd ffmpeg-3.4.2
+    PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libopus --disable-doc
+    make -s V=0
+    make install
     cd $CURRENT_DIR
   else
     mkdir -p $LIB_DIR

--- a/scripts/travisInstallDeps.sh
+++ b/scripts/travisInstallDeps.sh
@@ -132,9 +132,8 @@ install_mediadeps(){
   sudo apt-get -qq install yasm libvpx. libx264.
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    rm -r libav*
-    curl -O -L https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.bz2
-    tar -zxvf ffmpeg-3.4.2.tar.bz2
+    curl -O -L https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.gz
+    tar -zxvf ffmpeg-3.4.2.tar.gz
     cd ffmpeg-3.4.2
     PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus --disable-doc 
     make -s V=0
@@ -151,9 +150,8 @@ install_mediadeps_nogpl(){
   sudo apt-get -qq install yasm libvpx.
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    rm -r libav*
-    curl -O -L https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.bz2
-    tar -zxvf ffmpeg-3.4.2.tar.bz2
+    curl -O -L https://ffmpeg.org/releases/ffmpeg-3.4.2.tar.gz
+    tar -zxvf ffmpeg-3.4.2.tar.gz
     cd ffmpeg-3.4.2
     PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libopus --disable-doc
     make -s V=0


### PR DESCRIPTION
This is a POC about switching to FFmpeg due to the reasons that @jnoring exposed in the past #232 , plus a couple more that I've tested.

* Experimenting with other kind of Outputs I was able to accomplish tasks with FFmpeg that didn't work with the same code compiling against LibAV (even using edge LibAV).
* When you look for LibAV documentation, examples, discussions, you always end on FFmpeg related docs, forums etc.
* Ubuntu (mayor supporter before) dropped support of LibAV in favor of FFmpeg.
* LibAV 12.3 (latest, Licode uses 11.6) is still behind FFmpeg 3.2.4 which is updated here, while FFmpeg 4.0 was recently released. Please take a look at what changed in each version to see that are not trivial changes/fixes. https://www.ffmpeg.org.

I would like to know if you guys are up to make this change, if so, I will commit myself to work on remove deprecation warnings an rewrite decode/encode parts to following the latest encoding pipeline[0].

[0] https://ffmpeg.org/doxygen/3.3/group__lavc__encdec.html

[NO] It needs and includes Unit Tests

[NO] It includes documentation for these changes in `/doc`.