### PR TITLE
Force codecs client side

### DIFF
--- a/doc/client_api.md
+++ b/doc/client_api.md
@@ -321,6 +321,12 @@ Typical Room initialization would be:
 var room = Erizo.Room({token:'213h8012hwduahd-321ueiwqewq'});
 ```
 
+You can also pass an optional parameter which will force the codecs specified in createroom also in p2p (default is false)
+
+```
+var room = Erizo.Room({token:'213h8012hwduahd-321ueiwqewq', forceCodecs: true});
+```
+
 It will create the room object by passing the token this users have previously received from your service. This token is has to be retreived using the [Server API](/server_api), because it is a user access token. But you need to call to the connect function we will see later in order to connect to the room.
 
 You can access some variables like:
@@ -396,8 +402,8 @@ room.publish(localStream, {forceTurn: true});
 ```
 
 There are two options that allow advance control of video bitrate in Chrome:
-- `startVideoBW`: Configures Chrome to start sending video at the specified bitrate instead of the default one. 
-- `hardMinVideoBW`: Configures a hard limit for the minimum video bitrate. 
+- `startVideoBW`: Configures Chrome to start sending video at the specified bitrate instead of the default one.
+- `hardMinVideoBW`: Configures a hard limit for the minimum video bitrate.
 
 ```
 room.publish(localStream, {startVideoBW: 1000, hardMinVideoBW:500});

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -31,6 +31,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   that.roomID = '';
   that.state = DISCONNECTED;
   that.p2p = false;
+  that.forceCodecs = spec.forceCodecs || false;
   that.ConnectionHelpers =
     altConnectionHelpers === undefined ? ConnectionHelpers : altConnectionHelpers;
 
@@ -114,6 +115,8 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       limitMaxAudioBW: spec.maxAudioBW,
       limitMaxVideoBW: spec.maxVideoBW,
       forceTurn: stream.forceTurn,
+      mediaConfiguration: that.mediaConfiguration,
+      forceCodecs: that.forceCodecs,
       p2p: true,
     };
     return options;
@@ -177,6 +180,8 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       label: stream.getLabel(),
       iceServers: that.iceServers,
       forceTurn: stream.forceTurn,
+      mediaConfiguration: that.mediaConfiguration,
+      forceCodecs: that.forceCodecs,
       p2p: false,
     };
     if (!isRemote) {
@@ -573,7 +578,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   // It stablishes a connection to the room.
   // Once it is done it throws a RoomEvent("room-connected")
   that.connect = (options = {}) => {
-    const token = Base64.decodeBase64(spec.token);
+    const token = JSON.parse(Base64.decodeBase64(spec.token));
 
     if (that.state !== DISCONNECTED) {
       Logger.warning('Room already connected');
@@ -581,7 +586,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
 
     // 1- Connect to Erizo-Controller
     that.state = CONNECTING;
-    socket.connect(JSON.parse(token), options, (response) => {
+    socket.connect(token, options, (response) => {
       let stream;
       const streamList = [];
       const streams = response.streams || [];
@@ -590,6 +595,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       that.p2p = response.p2p;
       that.iceServers = response.iceServers;
       that.state = CONNECTED;
+      that.mediaConfiguration = token.mediaConfiguration;
       spec.singlePC = response.singlePC;
       spec.defaultVideoBW = response.defaultVideoBW;
       spec.maxVideoBW = response.maxVideoBW;

--- a/erizo_controller/erizoClient/src/utils/SdpHelpers.js
+++ b/erizo_controller/erizoClient/src/utils/SdpHelpers.js
@@ -62,4 +62,24 @@ SdpHelpers.setParamForCodecs = (sdpInfo, mediaType, paramName, value) => {
   });
 };
 
+SdpHelpers.forceCodecs = (sdp, codecs) => {
+  const video = sdp.getMedia('video');
+  const audio = sdp.getMedia('audio');
+  if (video) {
+    video.getCodecs().forEach((codec, index) => {
+      if (codec.codec.toLowerCase() !== codecs.video.toLowerCase()) {
+        sdp.getMedia('video').getCodecs().delete(index);
+      }
+    });
+  }
+  if (audio) {
+    audio.getCodecs().forEach((codec, index) => {
+      if (codec.codec.toLowerCase() !== codecs.audio.toLowerCase()) {
+        sdp.getMedia('audio').getCodecs().delete(index);
+      }
+    });
+  }
+};
+
+
 export default SdpHelpers;

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -16,6 +16,22 @@ const BaseStack = (specInput) => {
   let isNegotiating = false;
   let latestSessionVersion = -1;
 
+  const parseMediaConfiguration = () => {
+    const codecs = { audio: null, video: null };
+    switch (specBase.mediaConfiguration) {
+      case 'default':
+        codecs.video = 'VP8';
+        codecs.audio = 'OPUS';
+        break;
+      default:
+        codecs.video = specBase.mediaConfiguration.split('_AND_')[0];
+        codecs.audio = specBase.mediaConfiguration.split('_AND_')[1];
+    }
+    return codecs;
+  };
+
+  const codecs = parseMediaConfiguration();
+
   Logger.info('Starting Base stack', specBase);
 
   that.pcConfig = {
@@ -96,6 +112,9 @@ const BaseStack = (specInput) => {
       localDesc.sdp = that.enableSimulcast(localDesc.sdp);
     }
     localSdp = SemanticSdp.SDPInfo.processString(localDesc.sdp);
+    if (specBase.forceCodecs) {
+      SdpHelpers.forceCodecs(localSdp, codecs);
+    }
     SdpHelpers.setMaxBW(localSdp, specBase);
     localDesc.sdp = localSdp.toString();
     that.localSdp = localSdp;
@@ -110,6 +129,9 @@ const BaseStack = (specInput) => {
   const setLocalDescForAnswerp2p = (sessionDescription) => {
     localDesc = sessionDescription;
     localSdp = SemanticSdp.SDPInfo.processString(localDesc.sdp);
+    if (specBase.forceCodecs) {
+      SdpHelpers.forceCodecs(localSdp, codecs);
+    }
     SdpHelpers.setMaxBW(localSdp, specBase);
     localDesc.sdp = localSdp.toString();
     that.localSdp = localSdp;
@@ -126,6 +148,9 @@ const BaseStack = (specInput) => {
     // Its an offer, we assume its p2p
     const msg = message;
     remoteSdp = SemanticSdp.SDPInfo.processString(msg.sdp);
+    if (specBase.forceCodecs) {
+      SdpHelpers.forceCodecs(remoteSdp, codecs);
+    }
     SdpHelpers.setMaxBW(remoteSdp, specBase);
     msg.sdp = remoteSdp.toString();
     that.remoteSdp = remoteSdp;
@@ -147,6 +172,9 @@ const BaseStack = (specInput) => {
     Logger.info('Set remote and local description');
     latestSessionVersion = sessionVersion;
 
+    if (specBase.forceCodecs) {
+      SdpHelpers.forceCodecs(remoteSdp, codecs);
+    }
     SdpHelpers.setMaxBW(remoteSdp, specBase);
     that.setStartVideoBW(remoteSdp);
     that.setHardMinVideoBW(remoteSdp);
@@ -265,6 +293,9 @@ const BaseStack = (specInput) => {
       }
 
       localSdp = SemanticSdp.SDPInfo.processString(localDesc.sdp);
+      if (specBase.forceCodecs) {
+        SdpHelpers.forceCodecs(localSdp, codecs);
+      }
       SdpHelpers.setMaxBW(localSdp, specBase);
       localDesc.sdp = localSdp.toString();
       that.localSdp = localSdp;
@@ -274,6 +305,9 @@ const BaseStack = (specInput) => {
         that.peerConnection.setLocalDescription(localDesc)
           .then(() => {
             remoteSdp = SemanticSdp.SDPInfo.processString(remoteDesc.sdp);
+            if (specBase.forceCodecs) {
+              SdpHelpers.forceCodecs(remoteSdp, codecs);
+            }
             SdpHelpers.setMaxBW(remoteSdp, specBase);
             remoteDesc.sdp = remoteSdp.toString();
             that.remoteSdp = remoteSdp;

--- a/nuve/nuveAPI/resource/tokensResource.js
+++ b/nuve/nuveAPI/resource/tokensResource.js
@@ -31,7 +31,8 @@ var getTokenString = function (id, token) {
             tokenId: id,
             host: token.host,
             secure: token.secure,
-            signature: signed
+            signature: signed,
+            mediaConfiguration: token.mediaConfiguration
         },
         tokenS = (new Buffer(JSON.stringify(tokenJ))).toString('base64');
 


### PR DESCRIPTION
**Description**
Proposal to force codecs also in client side.
This is useful for example when the room is in p2p and smartphones are involved.
if android and chrome are signaling, they both decide to use vp8 but his is way more inefficient in smartphones than h264 (especially if we are creating a p2p star configuration). So we may want to force h264 in the creation of the room.

**Changes in Client or Server public APIs**

[ YES ] It includes documentation for these changes in `/doc`.