### PR TITLE
Updated erizo.js compilation script to respect ES6 syntax

### DIFF
--- a/erizo_controller/erizoClient/src/Socket.js
+++ b/erizo_controller/erizoClient/src/Socket.js
@@ -1,6 +1,6 @@
 /* global */
 
-import io from 'socket.io-client';
+import io from 'socket.io-client'; // eslint-disable-line
 import Logger from './utils/Logger';
 
 import { EventDispatcher, LicodeEvent } from './Events';

--- a/erizo_controller/erizoClient/src/Socket.js
+++ b/erizo_controller/erizoClient/src/Socket.js
@@ -1,6 +1,6 @@
 /* global */
 
-import io from '../lib/socket.io';
+import io from 'socket.io-client';
 import Logger from './utils/Logger';
 
 import { EventDispatcher, LicodeEvent } from './Events';

--- a/erizo_controller/erizoClient/webpack.config.erizo.js
+++ b/erizo_controller/erizoClient/webpack.config.erizo.js
@@ -7,7 +7,7 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     libraryExport: 'default',
     library: 'Erizo',
-    libraryTarget: 'var',
+    libraryTarget: 'umd',
   },
   devtool: 'source-map', // Default development sourcemap
 };

--- a/erizo_controller/installErizo_controller.sh
+++ b/erizo_controller/installErizo_controller.sh
@@ -21,7 +21,7 @@ check_result() {
 echo [erizo_controller] Installing node_modules for erizo_controller
 
 nvm use
-npm install --loglevel error amqp socket.io@2.0.3 log4js@1.0.1 node-getopt uuid@3.1.0 sdp-transform@2.3.0
+npm install --loglevel error amqp socket.io@2.1.0 socket.io-client@2.1.0 log4js@1.0.1 node-getopt uuid@3.1.0 sdp-transform@2.3.0
 
 echo [erizo_controller] Done, node_modules installed
 


### PR DESCRIPTION
**Description**

Hello, I updated client erizo.js script to build it as umd module to respect ES6 syntax and make it importable correctly.
[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not changed

[] It includes documentation for these changes in `/doc`.

I also added socket.io-client npm module installation to replace the socket.io-client version manually downloaded. This approach is more mantainable in the future if we want to update the library.

PS: still don't completely understand the logic of the client build script. I see you introduced webpack, but a lot of stuff regarding erizo.js client is done using gulp whereas can be done using webpack directly. I also don't understand the need to use the `google-closeure-compiler` to compile the lib. Could someoune explain that choice to me?

Let me know if the PR is fine and can be merged.

Thanks.
Simone