### PR TITLE
Fix crashes in addRemoteCandidate when subscriber is not removed from publisher

### DIFF
--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -223,6 +223,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
                   let subscriber = publisher.getSubscriber(subscriberKey);
                   log.info('message: Removing subscriber, id: ' + subscriberKey);
                   closeNode(subscriber);
+                  publisher.removeSubscriber(subscriberKey);
               }
               publisher.removeExternalOutputs().then(function() {
                 closeNode(publisher);


### PR DESCRIPTION
In high concurrency, call connection.addRemoteCandidate may crash(because connection has close) in function that.processSignaling

<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

<!--
Add a short description here, please.
If the contribution needs and includes Unit Tests check the box below.
-->

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.