### PR TITLE
Avoid server side retry and move logic to client

### DIFF
--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -232,7 +232,7 @@ class Client extends events.EventEmitter {
             } else if (signMess === 'timeout-erizojs') {
                 log.error('message: addPublisher timeout when contacting ErizoJS, ' +
                           'streamId: ' + id + ', clientId: ' + this.id);
-                callback(null, null, 'ErizoJS is not reachable');
+                callback(null, null, 'JSTimeout');
                 return;
             } else if (signMess === 'timeout-agent'){
                 log.error('message: addPublisher timeout when contacting Agent, ' +
@@ -339,7 +339,7 @@ class Client extends events.EventEmitter {
                     log.error('message: addSubscriber timeout when contacting ErizoJS, ' +
                               'streamId: ', options.streamId, ', ' +
                               'clientId: ' + this.id);
-                    callback(null, null, 'ErizoJS is not reachable');
+                    callback(null, null, 'JSTimeout');
                     return;
                 }
 

--- a/erizo_controller/test/erizoController/erizoController.js
+++ b/erizo_controller/test/erizoController/erizoController.js
@@ -477,7 +477,7 @@ describe('Erizo Controller / Erizo Controller', function() {
 
                 onPublish(options, sdp, callback);
 
-                expect(callback.withArgs(null, null, 'ErizoJS is not reachable').callCount)
+                expect(callback.withArgs(null, null, 'JSTimeout').callCount)
                       .to.equal(1);
               });
 
@@ -633,7 +633,7 @@ describe('Erizo Controller / Erizo Controller', function() {
 
                     onSubscribe(subscriberOptions, subscriberSdp, callback);
 
-                    expect(callback.withArgs(null, null, 'ErizoJS is not reachable').callCount)
+                    expect(callback.withArgs(null, null, 'JSTimeout').callCount)
                           .to.equal(1);
                   });
                 });

--- a/erizo_controller/test/erizoController/roomController.js
+++ b/erizo_controller/test/erizoController/roomController.js
@@ -171,9 +171,6 @@ describe('Erizo Controller / Room Controller', function() {
       expect(amqperMock.callRpc.args[0][1]).to.equal('addPublisher');
 
       amqperMock.callRpc.args[0][3].callback('timeout');
-      amqperMock.callRpc.args[1][3].callback('timeout');  // First retry
-      amqperMock.callRpc.args[2][3].callback('timeout');  // Second retry
-      amqperMock.callRpc.args[3][3].callback('timeout');  // Third retry
 
       expect(callback.callCount).to.equal(1);
       expect(callback.args[0][0]).to.equal('timeout-erizojs');
@@ -186,9 +183,6 @@ describe('Erizo Controller / Room Controller', function() {
       controller.addPublisher(kArbitraryClientId, kArbitraryStreamId, kArbitraryOptions, callback);
 
       amqperMock.callRpc.args[0][3].callback('timeout');
-      amqperMock.callRpc.args[1][3].callback('timeout');  // First retry
-      amqperMock.callRpc.args[2][3].callback('timeout');  // Second retry
-      amqperMock.callRpc.args[3][3].callback('timeout');  // Third retry
 
       controller.removePublisher(kArbitraryClientId, kArbitraryStreamId);
 
@@ -253,9 +247,6 @@ describe('Erizo Controller / Room Controller', function() {
       expect(amqperMock.callRpc.args[1][1]).to.equal('addSubscriber');
 
       amqperMock.callRpc.args[1][3].callback('timeout');
-      amqperMock.callRpc.args[2][3].callback('timeout');  // First retry
-      amqperMock.callRpc.args[3][3].callback('timeout');  // Second retry
-      amqperMock.callRpc.args[4][3].callback('timeout');  // Third retry
 
       expect(callback.callCount).to.equal(1);
       expect(callback.args[0][0]).to.equal('timeout');


### PR DESCRIPTION
**Description**

REF https://github.com/lynckia/licode/pull/988

Move the retry logic of the addPublisher or addSubscriber clientside.
This avoid an inconsistent state on the server if during retry the client disconnects. (the server continues thinking forever that there's a connected client and this prevents the JS to shutdown and restart when empty)

I fixed the current unit tests.