### PR TITLE
Do not check if room param is NaN in basic example server.

### DIFF
--- a/extras/basic_example/basicServer.js
+++ b/extras/basic_example/basicServer.js
@@ -154,7 +154,7 @@ app.post('/createToken/', function(req, res) {
 
     let room = defaultRoomName, type, roomId, mediaConfiguration;
 
-    if (req.body.room && !isNaN(req.body.room)) room = req.body.room;
+    if (req.body.room) room = req.body.room;
     if (req.body.type) type = req.body.type;
     if (req.body.roomId) roomId = req.body.roomId;
     if (req.body.mediaConfiguration) mediaConfiguration = req.body.mediaConfiguration;


### PR DESCRIPTION
isNaN('inputRoomName') returns true. Given a string of specific room name,
original implementation never assigns the specific room name to the
variable, resulting in generating new token of default room.

Remove the isNaN() call and simply check if the input value is truthy just
like what we do on other parameters.

<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

<!--
Add a short description here, please.
If the contribution needs and includes Unit Tests check the box below.
-->

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.