### PR TITLE
Fix the way ICE propagates connection state events

### DIFF
--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -65,7 +65,8 @@ class ErizoConnection extends EventEmitterConst {
         this.emit(ConnectionEvent({ type: 'remove-stream', stream: evt.stream }));
       };
 
-      this.stack.peerConnection.oniceconnectionstatechange = (state) => {
+      this.stack.peerConnection.oniceconnectionstatechange = () => {
+        const state = this.stack.peerConnection.iceConnectionState;
         this.emit(ConnectionEvent({ type: 'ice-state-change', state }));
       };
     }

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -125,7 +125,8 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       getP2PConnectionOptions(stream, peerSocket)));
     stream.on('added', dispatchStreamSubscribed.bind(null, stream));
     stream.on('icestatechanged', (evt) => {
-      if (evt.state === 'failed') {
+      Logger.info(`${stream.getID()} - iceConnectionState: ${evt.msg.state}`);
+      if (evt.msg.state === 'failed') {
         onStreamFailed(stream);
       }
     });
@@ -139,7 +140,8 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     stream.addPC(connection, peerSocket);
 
     stream.on('icestatechanged', (evt) => {
-      if (evt.state === 'failed') {
+      Logger.info(`${stream.getID()} - iceConnectionState: ${evt.msg.state}`);
+      if (evt.msg.state === 'failed') {
         stream.pc.get(peerSocket).close();
         stream.pc.remove(peerSocket);
       }
@@ -193,7 +195,8 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       getErizoConnectionOptions(stream, options, true), erizoId, spec.singlePC));
     stream.on('added', dispatchStreamSubscribed.bind(null, stream));
     stream.on('icestatechanged', (evt) => {
-      if (evt.state === 'failed') {
+      Logger.info(`${stream.getID()} - iceConnectionState: ${evt.msg.state}`);
+      if (evt.msg.state === 'failed') {
         onStreamFailed(stream);
       }
     });
@@ -206,7 +209,8 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       getErizoConnectionOptions(stream, options), erizoId, spec.singlePC));
 
     stream.on('icestatechanged', (evt) => {
-      if (evt.state === 'failed') {
+      Logger.info(`${stream.getID()} - iceConnectionState: ${evt.msg.state}`);
+      if (evt.msg.state === 'failed') {
         onStreamFailed(stream);
       }
     });

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -45,8 +45,8 @@ const Stream = (altConnectionHelpers, specInput) => {
     }
   };
 
-  const onICEConnectionStateChange = (state) => {
-    that.emit(StreamEvent({ type: 'icestatechanged', msg: state }));
+  const onICEConnectionStateChange = (msg) => {
+    that.emit(StreamEvent({ type: 'icestatechanged', msg }));
   };
 
   if (that.videoSize !== undefined &&


### PR DESCRIPTION
**Description**

Seems that with the single pc refactor something went lost.
oniceconnectionstatechange was not propagated successfully so no one was receiving the failed state