### PR TITLE
Rework client reconnection

### DIFF
--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -301,6 +301,19 @@ var listen = function () {
 
         let channel = new Channel(socket, nuve);
 
+        let clientId = socket.handshake.query.clientId;
+
+        if (clientId) {
+            rooms.forEachRoom(room => {
+                const client = room.getClientById(clientId);
+                if (client !== undefined) {
+                    client.setNewChannel(channel);
+                }
+            });
+            channel.reconnected();
+            return;
+        }
+
         channel.on('connected', (token, options, callback) => {
           options = options || {};
           try {
@@ -333,15 +346,6 @@ var listen = function () {
           } catch(e) {
             log.warn('message: error creating Room or Client, error:', e);
           }
-        });
-
-        channel.on('reconnected', clientId => {
-          rooms.forEachRoom(room => {
-            const client = room.getClientById(clientId);
-            if (client !== undefined) {
-              client.setNewChannel(channel);
-            }
-          });
         });
 
         socket.channel = channel;

--- a/erizo_controller/erizoController/models/Channel.js
+++ b/erizo_controller/erizoController/models/Channel.js
@@ -28,7 +28,6 @@ const checkSignature = (token, key) => {
 
 function listenToSocketHandshakeEvents(channel) {
   channel.socket.on('token', channel.onToken.bind(channel));
-  channel.socket.on('reconnected', channel.onReconnected.bind(channel));
   channel.socket.on('disconnect', channel.onDisconnect.bind(channel));
 }
 
@@ -114,11 +113,6 @@ class Channel extends events.EventEmitter {
     this.socket.on(eventName, listener);
   }
 
-  onReconnected(clientId) {
-    this.state = CONNECTED;
-    this.emit('reconnected',  clientId);
-  }
-
   sendMessage(type, arg) {
     if (this.state === RECONNECTING) {
       this.addToBuffer(type, arg);
@@ -151,6 +145,10 @@ class Channel extends events.EventEmitter {
     this.state = DISCONNECTED;
     clearTimeout(this.disconnecting);
     this.socket.disconnect();
+  }
+
+  reconnected() {
+    this.state = CONNECTED;
   }
 
 }


### PR DESCRIPTION
I didn't get the point of the closeCode hack in the client.
I mean, serverside makes sense, but client doesn't.

The problem is that that workaround doesn't behave equally in all browsers and os.
for example, firefox 60 in windows 10, when whe disconnect the ethernet adapter it immediately send a transport_error and generates a disconnect from the room.
the same test done in chrome, generates a transport_close and it properly tries to re establish the connection.

So in a few words, the events emitted from socket.io are completely different (and in a different order) among browsers.

With this simple rework we should have a consistent result.

Also, if you like the approach, would be great if you help me with the tests

[ X ] it needs and DOES NOT include tests