### PR TITLE
Sanitise token signature checking

### DIFF
--- a/erizo_controller/erizoController/models/Channel.js
+++ b/erizo_controller/erizoController/models/Channel.js
@@ -63,7 +63,7 @@ class Channel extends events.EventEmitter {
   onToken(options, callback) {
     const token = options.token;
     log.debug('message: token received');
-    if (checkSignature(token, NUVE_KEY)) {
+    if (token && checkSignature(token, NUVE_KEY)) {
       this.nuve.deleteToken(token.tokenId).then(tokenDB => {
         if (token.host === tokenDB.host) {
           this.state = CONNECTED;


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR fixes a crash in erizo controller when checking the signature of the token.
If for any reason, the token is not present in the `options` attribute, the script execution crashes due to an unhandled exception in the function which checks the signature.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.