### PR TITLE
unsafe under high concurrency

### DIFF
--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -227,11 +227,11 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
               }
               publisher.removeExternalOutputs().then(function() {
                 closeNode(publisher);
+                delete publishers[streamId];
                 publisher.muxer.close(function(message) {
                     log.info('message: muxer closed succesfully, ' +
                              'id: ' + streamId + ', ' +
                              logger.objectToLog(message));
-                    delete publishers[streamId];
                     var count = 0;
                     for (var k in publishers) {
                         if (publishers.hasOwnProperty(k)) {


### PR DESCRIPTION
after wrtc.close(), need update publishers immediately

<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

<!--
Add a short description here, please.
If the contribution needs and includes Unit Tests check the box below.
-->

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.