### PR TITLE
Handle client disconnection when retrying to assign an Erizo

### DIFF
--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -247,6 +247,7 @@ class Client extends events.EventEmitter {
             } else if (signMess === 'client-left') {
                 log.info('message: Abort publishing, client: ' + 
                 this.id + ' left while publishing');
+                return;
             }
             log.debug('Sending message back to the client', id);
             this.sendMessage('signaling_message_erizo', {mess: signMess, streamId: id});
@@ -347,6 +348,7 @@ class Client extends events.EventEmitter {
                 } else if (signMess === 'client-left') {
                     log.info('message: Abort subscription, client: ' + 
                     this.id + ' left while subscribing');
+                    return;
                 }
 
                 this.sendMessage('signaling_message_erizo', {mess: signMess,
@@ -577,6 +579,10 @@ class Client extends events.EventEmitter {
             callback(result);
         });
     }
+  }
+
+  isConnected() {
+      return (this.channel && this.channel.isConnected());
   }
 
 }


### PR DESCRIPTION
*** Description ***
This PR aims to fix some inconsistence in the data structure when the rpc of addPublisher and addSubscribe return AFTER the client disconnected.

In the actual state, if a client connects, try to publish, the agent respond but the JS goes in timeout state at the addPublisher rpc, the roomController's that.addPublisher function call itself recursively. 

But IF the client close the tab during this process of retry, the ondisconnect method in Cient.js is called and removes all the streams (BUT the streams are added in the array only when the state === 'initializing'), and when the JS is ready, it sends back to the client,js the initializing message, the stream is added to the array AFTER the client is gone and remains here forever. This cause also the ErizoJS to think that there's always someone connected and never close itself.
