### PR TITLE
Room is not assigned to remote streams when receiving stream list in room connect evt

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -610,6 +610,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
           label: arg.label,
           screen: arg.screen,
           attributes: arg.attributes });
+        stream.room = that;
         streamList.push(stream);
         remoteStreams.add(arg.id, stream);
       }


### PR DESCRIPTION
**Description**
ATM we are assigning the room only when the stream is added after the room connect (socketOnAddStream).

this will also assign the room to the stream object when connecting to the room

[] It needs and includes Unit Tests
[] It includes documentation for these changes in `/doc`.