### PR TITLE
Added mute stream event

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -319,11 +319,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   // We receive an event of new data in one of the streams
   const socketOnMuteStream = (arg) => {
     const stream = remoteStreams.get(arg.id);
-    const evt = StreamEvent({ type: 'stream-mute-event',
-      attrs: arg.attrs.muteStream,
-      stream });
     stream.updateMuteAttributes(arg.attrs);
-    stream.dispatchEvent(evt);
   };
 
   // We receive an event of a stream removed from the room

--- a/erizo_controller/erizoClient/src/Socket.js
+++ b/erizo_controller/erizoClient/src/Socket.js
@@ -83,6 +83,9 @@ const Socket = (newIo) => {
     // We receive an event of new data in one of the streams
     socket.on('onUpdateAttributeStream', emit.bind(that, 'onUpdateAttributeStream'));
 
+    // We receive an event of new data in one of the streams
+    socket.on('onUpdateMuteConfig', emit.bind(that, 'onUpdateMuteConfig'));
+
     // We receive an event of a stream removed from the room
     socket.on('onRemoveStream', emit.bind(that, 'onRemoveStream'));
 

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -28,8 +28,16 @@ const Stream = (altConnectionHelpers, specInput) => {
   that.videoFrameRate = spec.videoFrameRate;
   that.extensionId = spec.extensionId;
   that.desktopStreamId = spec.desktopStreamId;
-  that.audioMuted = spec.audioMuted || false;
-  that.videoMuted = spec.videoMuted || false;
+  that.muted = {
+    audio: {
+      local: false,
+      remote: spec.audioMuted || false,
+    },
+    video: {
+      local: false,
+      remote: spec.videoMuted || false,
+    },
+  };
   that.p2p = false;
   that.ConnectionHelpers =
     altConnectionHelpers === undefined ? ConnectionHelpers : altConnectionHelpers;
@@ -95,8 +103,12 @@ const Stream = (altConnectionHelpers, specInput) => {
   };
 
   that.updateMuteAttributes = (attrs) => {
-    that.audioMuted = attrs.muteStream.audio;
-    that.videoMuted = attrs.muteStream.video;
+    that.muted.audio.remote = attrs.muteStream.audio;
+    that.muted.video.remote = attrs.muteStream.video;
+    const evt = StreamEvent({ type: 'stream-mute-event',
+      attrs: that.muted,
+      stream: that });
+    that.dispatchEvent(evt);
   };
 
   // Indicates if the stream has audio activated
@@ -370,34 +382,38 @@ const Stream = (altConnectionHelpers, specInput) => {
     }
   };
 
-  const muteStream = () => {
+  const muteStream = (callback = () => {}) => {
     if (that.stream) {
       for (let index = 0; index < that.stream.getVideoTracks().length; index += 1) {
         const track = that.stream.getVideoTracks()[index];
-        track.enabled = !that.videoMuted;
+        track.enabled = !that.muted.video.local;
       }
       for (let index = 0; index < that.stream.getAudioTracks().length; index += 1) {
         const track = that.stream.getAudioTracks()[index];
-        track.enabled = !that.audioMuted;
+        track.enabled = !that.muted.audio.local;
       }
     }
     if (that.room) {
-      const config = { muteStream: { audio: that.audioMuted, video: that.videoMuted } };
+      const config = { muteStream: { audio: that.muted.audio.local,
+        video: that.muted.video.local } };
       that.checkOptions(config, true);
       that.emit(StreamEvent({ type: 'internal-mute-event', stream: that, attrs: config }));
+      if (!that.room.p2p && that.pc) {
+        that.pc.updateSpec(config, that.getID(), callback);
+        return;
+      }
     }
+    callback(true);
   };
 
-  that.muteAudio = (isMuted) => {
-    const thisMuted = typeof isMuted === 'undefined' ? !that.audioMuted : isMuted;
-    that.audioMuted = thisMuted;
-    muteStream();
+  that.muteAudio = (isMuted, callback = () => {}) => {
+    that.muted.audio.local = typeof isMuted === 'undefined' ? !that.muted.audio.local : isMuted;
+    muteStream(callback);
   };
 
-  that.muteVideo = (isMuted) => {
-    const thisMuted = typeof isMuted === 'undefined' ? !that.videoMuted : isMuted;
-    that.videoMuted = thisMuted;
-    muteStream();
+  that.muteVideo = (isMuted, callback = () => {}) => {
+    that.muted.video.local = typeof isMuted === 'undefined' ? !that.muted.video.local : isMuted;
+    muteStream(callback);
   };
 
   // eslint-disable-next-line no-underscore-dangle

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -366,31 +366,43 @@ const Stream = (altConnectionHelpers, specInput) => {
   };
 
   const muteStream = (callback = () => {}) => {
-    if (that.room && that.room.p2p) {
-      Logger.warning('muteAudio/muteVideo are not implemented in p2p streams');
-      callback('error');
-      return;
-    }
+    // if (that.room && that.room.p2p) {
+    //   Logger.warning('muteAudio/muteVideo are not implemented in p2p streams');
+    //   callback('error');
+    //   return;
+    // }
     if (that.stream) {
       for (let index = 0; index < that.stream.getVideoTracks().length; index += 1) {
         const track = that.stream.getVideoTracks()[index];
         track.enabled = !that.videoMuted;
       }
+      for (let index = 0; index < that.stream.getAudioTracks().length; index += 1) {
+        const track = that.stream.getAudioTracks()[index];
+        track.enabled = !that.audioMuted;
+      }
     }
-    const config = { muteStream: { audio: that.audioMuted, video: that.videoMuted } };
-    that.checkOptions(config, true);
-    if (that.pc) {
-      that.pc.updateSpec(config, that.getID(), callback);
+    if (that.room) {
+      const config = { muteStream: { audio: that.audioMuted, video: that.videoMuted } };
+      that.checkOptions(config, true);
+      if (that.room.p2p) {
+        that.pc.forEach((pc) => {
+          pc.updateSpec(config, that.getID(), callback);
+        });
+      } else if (that.pc) {
+        that.pc.updateSpec(config, that.getID(), callback);
+      }
     }
   };
 
   that.muteAudio = (isMuted, callback = () => {}) => {
-    that.audioMuted = isMuted;
+    const thisMuted = typeof isMuted === 'undefined' ? !that.audioMuted : isMuted;
+    that.audioMuted = thisMuted;
     muteStream(callback);
   };
 
   that.muteVideo = (isMuted, callback = () => {}) => {
-    that.videoMuted = isMuted;
+    const thisMuted = typeof isMuted === 'undefined' ? !that.videoMuted : isMuted;
+    that.videoMuted = thisMuted;
     muteStream(callback);
   };
 

--- a/erizo_controller/erizoClient/src/views/Speaker.js
+++ b/erizo_controller/erizoClient/src/views/Speaker.js
@@ -16,7 +16,7 @@ const Speaker = (spec) => {
     that.media.muted = true;
     that.icon.setAttribute('src', `${that.url}/assets/mute48.png`);
     if (that.stream.local) {
-      that.stream.stream.getAudioTracks()[0].enabled = false;
+      that.stream.muteAudio(true);
     } else {
       lastVolume = that.picker.value;
       that.picker.value = 0;
@@ -28,7 +28,7 @@ const Speaker = (spec) => {
     that.media.muted = false;
     that.icon.setAttribute('src', `${that.url}/assets/sound48.png`);
     if (that.stream.local) {
-      that.stream.stream.getAudioTracks()[0].enabled = true;
+      that.stream.muteAudio(false);
     } else {
       that.picker.value = lastVolume;
       that.media.volume = that.picker.value / 100;

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -293,10 +293,12 @@ const BaseStack = (specInput) => {
         config.minVideoBW ||
         (config.slideShowMode !== undefined) ||
         (config.qualityLayer !== undefined) ||
+        (config.muteStream !== undefined) ||
         (config.minLayer !== undefined) ||
         (config.video !== undefined)) {
       Logger.debug('MaxVideoBW Changed to ', config.maxVideoBW);
       Logger.debug('MinVideo Changed to ', config.minVideoBW);
+      Logger.debug('MuteStream Changed to ', config.muteStream);
       Logger.debug('SlideShowMode Changed to ', config.slideShowMode);
       Logger.debug('Video Constraints', config.video);
       specBase.callback({ type: 'updatestream', config }, streamId);

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -292,14 +292,12 @@ const BaseStack = (specInput) => {
     if (shouldSendMaxVideoBWInOptions ||
         config.minVideoBW ||
         (config.slideShowMode !== undefined) ||
-        (config.muteStream !== undefined) ||
         (config.qualityLayer !== undefined) ||
         (config.minLayer !== undefined) ||
         (config.video !== undefined)) {
       Logger.debug('MaxVideoBW Changed to ', config.maxVideoBW);
       Logger.debug('MinVideo Changed to ', config.minVideoBW);
       Logger.debug('SlideShowMode Changed to ', config.slideShowMode);
-      Logger.debug('muteStream changed to ', config.muteStream);
       Logger.debug('Video Constraints', config.video);
       specBase.callback({ type: 'updatestream', config }, streamId);
     }

--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -12,6 +12,7 @@ function listenToSocketEvents(client) {
   client.channel.socketOn('sendDataStream', client.onSendDataStream.bind(client));
   client.channel.socketOn('signaling_message', client.onSignalingMessage.bind(client));
   client.channel.socketOn('updateStreamAttributes', client.onUpdateStreamAttributes.bind(client));
+  client.channel.socketOn('updateMuteConfig', client.onUpdateMuteConfig.bind(client));
   client.channel.socketOn('publish', client.onPublish.bind(client));
   client.channel.socketOn('subscribe', client.onSubscribe.bind(client));
   client.channel.socketOn('startRecorder', client.onStartRecorder.bind(client));
@@ -129,6 +130,28 @@ class Client extends events.EventEmitter {
     }
   }
 
+  onUpdateMuteConfig(message) {
+    const stream = this.room.getStreamById(message.id);
+    if  (stream === undefined) {
+      log.warn('message: Update attributes to a uninitialized stream, ' +
+               logger.objectToLog(message));
+      return;
+    }
+
+    stream.onUpdateMuteConfig(message);
+    const clients = stream.getDataSubscribers();
+
+    for (const index in clients) {
+      const clientId = clients[index];
+      const client = this.room.getClientById(clientId);
+      if (client) {
+            log.debug('message: Sending new attributes, ' +
+                      'clientId: ' + clientId + ', streamId: ' + message.id);
+            client.sendMessage('onUpdateMuteConfig', message);
+        }
+    }
+  }
+
   onPublish(options, sdp, callback) {
     if (this.user === undefined || !this.user.permissions[Permission.PUBLISH]) {
         callback(null, 'Unauthorized');
@@ -165,7 +188,9 @@ class Client extends events.EventEmitter {
                                     video: options.video,
                                     data: options.data,
                                     label: options.label,
-                                    attributes: options.attributes});
+                                    attributes: options.attributes,
+                                    audioMuted: false,
+                                    videoMuted: false});
                 st.status = PUBLISHER_READY;
                 this.streams.push(id);
                 this.room.streams.set(id, st);
@@ -193,7 +218,9 @@ class Client extends events.EventEmitter {
                                     data: options.data,
                                     label: options.label,
                                     screen: options.screen,
-                                    attributes: options.attributes});
+                                    attributes: options.attributes,
+                                    audioMuted: false,
+                                    videoMuted: false});
                 this.streams.push(id);
                 this.room.streams.set(id, st);
                 st.status = PUBLISHER_INITAL;
@@ -212,7 +239,9 @@ class Client extends events.EventEmitter {
                                                stream: id,
                                                timestamp: timeStamp.getTime(),
                                                agent: signMess.agentId,
-                                               attributes: options.attributes});
+                                               attributes: options.attributes,
+                                               audioMuted: false,
+                                               videoMuted: false});
                 }
             } else if (signMess.type === 'failed'){
                 log.warn('message: addPublisher ICE Failed, ' +
@@ -256,7 +285,9 @@ class Client extends events.EventEmitter {
                             data: options.data,
                             label: options.label,
                             screen: options.screen,
-                            attributes: options.attributes});
+                            attributes: options.attributes,
+                            audioMuted: false,
+                            videoMuted: false});
         this.streams.push(id);
         this.room.streams.set(id, st);
         st.status = PUBLISHER_READY;

--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -145,7 +145,7 @@ class Client extends events.EventEmitter {
       const clientId = clients[index];
       const client = this.room.getClientById(clientId);
       if (client) {
-            log.debug('message: Sending new attributes, ' +
+            log.debug('message: Sending mute event, ' +
                       'clientId: ' + clientId + ', streamId: ' + message.id);
             client.sendMessage('onUpdateMuteConfig', message);
         }

--- a/erizo_controller/erizoController/models/Stream.js
+++ b/erizo_controller/erizoController/models/Stream.js
@@ -70,8 +70,15 @@ exports.Stream = function (spec) {
                 data: spec.data,
                 label: spec.label,
                 screen: spec.screen,
-                attributes: spec.attributes};
+                attributes: spec.attributes,
+                audioMuted: spec.audioMuted,
+                videoMuted: spec.videoMuted};
     };
+
+    that.onUpdateMuteConfig = function(config) {
+        spec.audioMuted = config.attrs.muteStream.audio;
+        spec.videoMuted = config.attrs.muteStream.video;
+    }
 
     return that;
 };

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -107,6 +107,9 @@ window.onload = function () {
         if (localStream.getID() !== stream.getID()) {
           room.subscribe(stream, {slideShowMode: slideShowMode, metadata: {type: 'subscriber'}});
           stream.addEventListener('bandwidth-alert', cb);
+          stream.addEventListener('stream-mute-event', (evt) => {
+            console.log('Stream mute event: ', evt.attrs);
+          });
         }
       }
     };


### PR DESCRIPTION
**Description**
Currently the mute event is not well implemented and there are some differences between p2p and Erizo.
This PR keeps in sync the mute state of a stream, locally and remotely.

This is very important since in the frontend we may need to replace the "black screen" with messages informing the client that the local/remote stream is muted and cannot be displayed.

I also thought to use the current updatespec event to propagate this information but there are lots of complications (for example it is not propagated to the controller if a peerconnection does not exist), so I preferred to make a dedicated event

[] It needs and includes Unit Tests
[X] It includes documentation for these changes in `/doc`.