### PR TITLE
When closing streams, also unbind from all events.

### DIFF
--- a/erizo_controller/erizoClient/src/Events.js
+++ b/erizo_controller/erizoClient/src/Events.js
@@ -49,6 +49,7 @@ const EventDispatcher = () => {
   that.on = that.addEventListener;
   that.off = that.removeEventListener;
   that.emit = that.dispatchEvent;
+  that.unbindEvents = () => { dispatcher.eventListeners = {}; };
 
   return that;
 };

--- a/erizo_controller/erizoClient/src/Events.js
+++ b/erizo_controller/erizoClient/src/Events.js
@@ -33,6 +33,11 @@ const EventDispatcher = () => {
     }
   };
 
+  // It removes all listeners
+  that.removeAllListeners = () => {
+    dispatcher.eventListeners = {};
+  };
+
   // It dispatch a new event to the event listeners, based on the type
   // of event. All events are intended to be LicodeEvents.
   that.dispatchEvent = (event) => {
@@ -49,7 +54,6 @@ const EventDispatcher = () => {
   that.on = that.addEventListener;
   that.off = that.removeEventListener;
   that.emit = that.dispatchEvent;
-  that.unbindEvents = () => { dispatcher.eventListeners = {}; };
 
   return that;
 };

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -242,7 +242,7 @@ const Stream = (altConnectionHelpers, specInput) => {
         pc.off('ice-state-change', spec.onICEConnectionStateChange);
       });
     }
-    that.unbindEvents();
+    that.removeAllListeners();
   };
 
   that.play = (elementID, optionsInput) => {

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -242,6 +242,7 @@ const Stream = (altConnectionHelpers, specInput) => {
         pc.off('ice-state-change', spec.onICEConnectionStateChange);
       });
     }
+    that.unbindEvents();
   };
 
   that.play = (elementID, optionsInput) => {


### PR DESCRIPTION
**Description**

When closing a stream we are currently NOT unbinding from this:

https://github.com/lynckia/licode/blob/18c5562a312b080468f6fdc5f8a0ccec1abbcf54/erizo_controller/erizoClient/src/Room.js#L126

Steps to reproduce:
tab 1) Publisher 
tab 2) subscriber. Subscribe to remote stream, then unsubscribe, then subscribe again. 2 stream added events are fired


[] It needs and includes Unit Testsì
**Changes in Client or Server public APIs**
[] It includes documentation for these changes in `/doc`.