### PR TITLE
Fix wrong video ssrc in answer when subscribing

### DIFF
--- a/erizo_controller/erizoController/models/Channel.js
+++ b/erizo_controller/erizoController/models/Channel.js
@@ -153,6 +153,10 @@ class Channel extends events.EventEmitter {
     this.socket.disconnect();
   }
 
+  isConnected() {
+    return this.state === CONNECTED;
+  }
+
 }
 
 exports.Channel = Channel;

--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -284,6 +284,19 @@ class Client extends events.EventEmitter {
         return;
     }
 
+    if (stream.status !== PUBLISHER_READY) {
+      log.warn(`Trying to subscribe to a non-ready stream ${options.streamId}, retrying in 100ms`);
+      setTimeout(() => {
+        this.onSubscribe(options, sdp, callback);
+      }, 200);
+      return;
+    }
+
+    if (!this.isConnected()) {
+      log.warn(`Client disconnected while subscribing to ${options.streamId}`);
+      return;
+    }
+
     if (stream.hasData() && options.data !== false) {
         stream.addDataSubscriber(this.id);
     }
@@ -571,6 +584,10 @@ class Client extends events.EventEmitter {
             callback(result);
         });
     }
+  }
+
+  isConnected() {
+    return (this.channel && this.channel.isConnected());
   }
 
 }


### PR DESCRIPTION
It happens that when a publisher publish its own stream, as soon as it's webrtc connection (in erizoController/Client.js) reach the CONN_INITIAL status, the stream is added to the room, but ONLY when reach the READY state is broadcasted to the room.

Bu if a subscriber join the room when the publisher is not READY yet, it has the stream to subscribe in the list that the controller gives to him.
Sometimes, it try to subscribe to it and for a threading concurrency the subscriber has priority over the publisher, so the server giver to him a wrong answer (containing wrong video ssrc, since the publisher has not finished to set remote description yet).

This waits for the publisher stream to be ready.

issue related: 
https://github.com/lynckia/licode/issues/1251

another options would be add the stream to room only when ready that seems the simplest solution but I think that maybe something else could break.

[] It needs and includes Unit Tests
[] It includes documentation for these changes in `/doc`.