### PR TITLE
Fix for mishandling of videoOpt in Stream.js

### DIFF
--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -148,7 +148,7 @@ const Stream = (altConnectionHelpers, specInput) => {
         Logger.info('Requested access to local media');
         let videoOpt = spec.video;
         if (videoOpt === true || spec.screen === true) {
-          videoOpt = videoOpt === true ? {} : videoOpt;
+          videoOpt = videoOpt === true || videoOpt === null ? {} : videoOpt;
           if (that.videoSize !== undefined) {
             videoOpt.width = {
               min: that.videoSize[0],


### PR DESCRIPTION


<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

In screen sharing (spec.screen == true), video may be passed as null. When it's null and video size is defined, a null reference exception occurs.
This PR should solve issue #1253 .

<!--
Add a short description here, please.
If the contribution needs and includes Unit Tests check the box below.
-->

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**
No change

[] It includes documentation for these changes in `/doc`.