### PR TITLE
Fix maxVideoBw on p2p subscriber

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -783,6 +783,9 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
         stream.forceTurn = options.forceTurn;
 
         if (that.p2p) {
+          const streamToSubscribe = remoteStreams.get(stream.getID());
+          streamToSubscribe.maxAudioBW = options.maxAudioBW;
+          streamToSubscribe.maxVideoBW = options.maxVideoBW;
           socket.sendSDP('subscribe', { streamId: stream.getID(), metadata: options.metadata });
           callback(true);
         } else {


### PR DESCRIPTION
When setting a maxVideoBw in p2p subscriber mode, this is ignored.
This is because the stream is populated at the first offer received from the other side.

[] It needs and includes Unit Tests
[] It includes documentation for these changes in `/doc`.