### PR TITLE
Add support to Screensharing and h264 simulcast

### DIFF
--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -62,6 +62,7 @@ namespace erizo {
     videoSdpMLine = -1;
     audioSdpMLine = -1;
     videoBandwidth = 0;
+    google_conference_flag_set = "";
   }
 
   SdpInfo::~SdpInfo() {
@@ -513,6 +514,7 @@ namespace erizo {
     this->bundleTags = offerSdp->bundleTags;
     this->extMapVector = offerSdp->extMapVector;
     this->rids_ = offerSdp->rids();
+    this->google_conference_flag_set = offerSdp->google_conference_flag_set;
     for (auto& rid : rids_) {
       rid.direction = reverse(rid.direction);
     }

--- a/erizo/src/erizo/SdpInfo.h
+++ b/erizo/src/erizo/SdpInfo.h
@@ -325,6 +325,7 @@ class SdpInfo {
   std::map<unsigned int, RtpMap> payload_parsed_map_;
   std::vector<ExtMap> supported_ext_map_;
   std::vector<Rid> rids_;
+  std::string google_conference_flag_set;
 
  private:
   bool processSdp(const std::string& sdp, const std::string& media);

--- a/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
+++ b/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
@@ -191,6 +191,10 @@ void LayerDetectorHandler::parseLayerInfoFromH264(std::shared_ptr<DataPacket> pa
     packet->is_keyframe = false;
   }
 
+  addTemporalLayerAndCalculateRate(packet, 0, payload->start_bit);
+
+  notifyLayerInfoChangedEventMaybe();
+
   delete payload;
 }
 

--- a/erizoAPI/ConnectionDescription.cc
+++ b/erizoAPI/ConnectionDescription.cc
@@ -83,6 +83,9 @@ NAN_MODULE_INIT(ConnectionDescription::Init) {
   Nan::SetPrototypeMethod(tpl, "setVideoBandwidth", setVideoBandwidth);
   Nan::SetPrototypeMethod(tpl, "getVideoBandwidth", getVideoBandwidth);
 
+  Nan::SetPrototypeMethod(tpl, "setXGoogleFlag", setXGoogleFlag);
+  Nan::SetPrototypeMethod(tpl, "getXGoogleFlag", getXGoogleFlag);
+
   Nan::SetPrototypeMethod(tpl, "addCandidate", addCandidate);
   Nan::SetPrototypeMethod(tpl, "addCryptoInfo", addCryptoInfo);
   Nan::SetPrototypeMethod(tpl, "setICECredentials", setICECredentials);
@@ -424,6 +427,16 @@ NAN_METHOD(ConnectionDescription::setVideoBandwidth) {
 NAN_METHOD(ConnectionDescription::getVideoBandwidth) {
   GET_SDP();
   info.GetReturnValue().Set(Nan::New(sdp->videoBandwidth));
+}
+
+NAN_METHOD(ConnectionDescription::setXGoogleFlag) {
+  GET_SDP();
+  sdp->google_conference_flag_set = getString(info[0]);
+}
+
+NAN_METHOD(ConnectionDescription::getXGoogleFlag) {
+  GET_SDP();
+  info.GetReturnValue().Set(Nan::New(sdp->google_conference_flag_set.c_str()).ToLocalChecked());
 }
 
 NAN_METHOD(ConnectionDescription::addCandidate) {

--- a/erizoAPI/ConnectionDescription.h
+++ b/erizoAPI/ConnectionDescription.h
@@ -61,6 +61,9 @@ class ConnectionDescription : public Nan::ObjectWrap {
     static NAN_METHOD(setVideoBandwidth);
     static NAN_METHOD(getVideoBandwidth);
 
+    static NAN_METHOD(setXGoogleFlag);
+    static NAN_METHOD(getXGoogleFlag);
+
     static NAN_METHOD(addCandidate);
     static NAN_METHOD(addCryptoInfo);
     static NAN_METHOD(setICECredentials);

--- a/erizo_controller/erizoJS/models/SessionDescription.js
+++ b/erizo_controller/erizoJS/models/SessionDescription.js
@@ -154,7 +154,7 @@ function getMediaInfoFromDescription(info, sdp, mediaType) {
       simulcast.setSimulcastPlainString(direction + ' rid=' + ridsData.join(';'));
       media.simulcast_03 = simulcast;
     }
-    if (info.getXGoogleFlag() && info.getXGoogleFlag() !== "") {
+    if (info.getXGoogleFlag() && info.getXGoogleFlag() !== '') {
       media.setXGoogleFlag(info.getXGoogleFlag());
     }
   }
@@ -332,7 +332,7 @@ class SessionDescription {
         info.addExtension(value, uri, media.getType());
       });
 
-      if (media.getXGoogleFlag() && media.getXGoogleFlag() !== "") {
+      if (media.getXGoogleFlag() && media.getXGoogleFlag() !== '') {
         info.setXGoogleFlag(media.getXGoogleFlag());
       }
     });

--- a/erizo_controller/erizoJS/models/SessionDescription.js
+++ b/erizo_controller/erizoJS/models/SessionDescription.js
@@ -154,7 +154,9 @@ function getMediaInfoFromDescription(info, sdp, mediaType) {
       simulcast.setSimulcastPlainString(direction + ' rid=' + ridsData.join(';'));
       media.simulcast_03 = simulcast;
     }
-
+    if (info.getXGoogleFlag() && info.getXGoogleFlag() !== "") {
+      media.setXGoogleFlag(info.getXGoogleFlag());
+    }
   }
   return media;
 }
@@ -329,6 +331,10 @@ class SessionDescription {
       media.getExtensions().forEach((uri, value) => {
         info.addExtension(value, uri, media.getType());
       });
+
+      if (media.getXGoogleFlag() && media.getXGoogleFlag() !== "") {
+        info.setXGoogleFlag(media.getXGoogleFlag());
+      }
     });
     info.setAudioAndVideo(audio !== undefined, video !== undefined);
 


### PR DESCRIPTION
**Description**

There are new experimental features in Chrome that enable Simulcast for Screensharing and h.264 Streams. This PR fix some issues I found in the first tests I run.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.