### PR TITLE
Fix unpublish and unsubscribe for Single PC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,7 @@ jobs:
       - deploy:
           name: Push Licode Docker image
           command: |
-            FORCE_DOCKER_GENERATION=$(git log --pretty=oneline --abbrev-commit --no-merges -1 | awk '{$1=""; print $0}' | grep "[GENERATE DOCKER]" | wc -w)
-            if [ ${FORCE_DOCKER_GENERATION} -ge 2 ] && [ "${CIRCLE_PROJECT_USERNAME}" == "lynckia" ]; then
+            elif [ "${CIRCLE_BRANCH}" == "experimental" ] && [ "${CIRCLE_PROJECT_USERNAME}" == "lynckia" ]; then
               docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
               echo Pushing to lynckia/licode:experimental
               docker tag lynckia/licode:develop lynckia/licode:experimental

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,9 +49,8 @@ jobs:
       - deploy:
           name: Push Licode Docker image
           command: |
-            git log --pretty=oneline --abbrev-commit --no-merges -1 | awk '{$1=""; print $0}' | grep "[GENERATE DOCKER]"
-            FORCE_DOCKER_GENERATION=$?
-            if [ "${FORCE_DOCKER_GENERATION}" == "1" ] && [ "${CIRCLE_PROJECT_USERNAME}" == "lynckia" ]; then
+            FORCE_DOCKER_GENERATION=$(git log --pretty=oneline --abbrev-commit --no-merges -1 | awk '{$1=""; print $0}' | grep "[GENERATE DOCKER]" | wc -w)
+            if [ ${FORCE_DOCKER_GENERATION} -ge 2 ] && [ "${CIRCLE_PROJECT_USERNAME}" == "lynckia" ]; then
               docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
               echo Pushing to lynckia/licode:experimental
               docker tag lynckia/licode:develop lynckia/licode:experimental

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - deploy:
           name: Push Licode Docker image
           command: |
-            elif [ "${CIRCLE_BRANCH}" == "experimental" ] && [ "${CIRCLE_PROJECT_USERNAME}" == "lynckia" ]; then
+            if [ "${CIRCLE_BRANCH}" == "experimental" ] && [ "${CIRCLE_PROJECT_USERNAME}" == "lynckia" ]; then
               docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
               echo Pushing to lynckia/licode:experimental
               docker tag lynckia/licode:develop lynckia/licode:experimental

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,13 @@ jobs:
       - deploy:
           name: Push Licode Docker image
           command: |
+            git log --pretty=oneline --abbrev-commit --no-merges -1 | awk '{$1=""; print $0}' | grep "[GENERATE DOCKER]"
+            FORCE_DOCKER_GENERATION=$?
+            if [ "$FORCE_DOCKER_GENERATION" == "1" ] && [ "${CIRCLE_PROJECT_USERNAME}" == "lynckia" ]; then
+              docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+              echo Pushing to lynckia/licode:experimental
+              docker tag lynckia/licode:develop lynckia/licode:experimental
+              docker push lynckia/licode:experimental
             if [ "${CIRCLE_BRANCH}" == "master" ] && [ "${CIRCLE_PROJECT_USERNAME}" == "lynckia" ]; then
               SHORT_GIT_HASH="$(echo ${CIRCLE_SHA1} | cut -c -7)"
               docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,12 +51,12 @@ jobs:
           command: |
             git log --pretty=oneline --abbrev-commit --no-merges -1 | awk '{$1=""; print $0}' | grep "[GENERATE DOCKER]"
             FORCE_DOCKER_GENERATION=$?
-            if [ "$FORCE_DOCKER_GENERATION" == "1" ] && [ "${CIRCLE_PROJECT_USERNAME}" == "lynckia" ]; then
+            if [ "${FORCE_DOCKER_GENERATION}" == "1" ] && [ "${CIRCLE_PROJECT_USERNAME}" == "lynckia" ]; then
               docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
               echo Pushing to lynckia/licode:experimental
               docker tag lynckia/licode:develop lynckia/licode:experimental
               docker push lynckia/licode:experimental
-            if [ "${CIRCLE_BRANCH}" == "master" ] && [ "${CIRCLE_PROJECT_USERNAME}" == "lynckia" ]; then
+            elif [ "${CIRCLE_BRANCH}" == "master" ] && [ "${CIRCLE_PROJECT_USERNAME}" == "lynckia" ]; then
               SHORT_GIT_HASH="$(echo ${CIRCLE_SHA1} | cut -c -7)"
               docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
               echo Tagging to lynckia/licode:${SHORT_GIT_HASH}

--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -96,6 +96,9 @@ class ErizoConnection extends EventEmitterConst {
       Logger.warning(`message: Cannot remove stream not in map, streamId: ${streamId}`);
       return;
     }
+    if (stream.local) {
+      this.stack.removeStream(stream.stream);
+    }
     this.streamsMap.remove(streamId);
   }
 

--- a/erizo_controller/erizoClient/src/Events.js
+++ b/erizo_controller/erizoClient/src/Events.js
@@ -33,6 +33,10 @@ const EventDispatcher = () => {
     }
   };
 
+  that.removeAllListeners = () => {
+    dispatcher.eventListeners = {};
+  };
+
   // It dispatch a new event to the event listeners, based on the type
   // of event. All events are intended to be LicodeEvents.
   that.dispatchEvent = (event) => {

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -45,7 +45,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   // Private functions
   const removeStream = (streamInput) => {
     const stream = streamInput;
-    if (stream.stream && !stream.local) {
+    if (stream.stream) {
       // Remove HTML element
       stream.hide();
 

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -51,7 +51,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       stream.pc.removeStream(stream);
     }
 
-    Logger.warning('Removed stream');
+    Logger.debug('Removed stream');
     if (stream.stream) {
       // Remove HTML element
       stream.hide();

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -47,6 +47,20 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     const stream = streamInput;
     stream.removeAllListeners();
 
+    if (stream.pc && !that.p2p) {
+      stream.pc.removeStream(stream);
+    }
+
+    Logger.warning('Removed stream');
+    if (stream.stream) {
+      // Remove HTML element
+      stream.hide();
+
+      stream.stop();
+      stream.close();
+      delete stream.stream;
+    }
+
     // Close PC stream
     if (stream.pc) {
       if (stream.local && that.p2p) {
@@ -55,18 +69,9 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
           stream.pc.remove(id);
         });
       } else {
-        stream.pc.removeStream(stream);
         that.erizoConnectionManager.maybeCloseConnection(stream.pc);
         delete stream.pc;
       }
-    }
-    if (stream.stream) {
-      // Remove HTML element
-      stream.hide();
-
-      stream.stop();
-      stream.close();
-      delete stream.stream;
     }
   };
 

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -741,7 +741,9 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       Logger.info('Stream unpublished');
       stream.room = undefined;
       if (stream.hasMedia() && !stream.isExternal()) {
-        removeStream(stream);
+        const localStream = localStreams.has(stream.getID()) ?
+                              localStreams.get(stream.getID()) : stream;
+        removeStream(localStream);
       }
       localStreams.remove(stream.getID());
 

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -45,7 +45,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   // Private functions
   const removeStream = (streamInput) => {
     const stream = streamInput;
-    if (stream.stream) {
+    if (stream.stream && !stream.local) {
       // Remove HTML element
       stream.hide();
 
@@ -53,6 +53,8 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       stream.close();
       delete stream.stream;
     }
+
+    stream.removeAllListeners();
 
     // Close PC stream
     if (stream.pc) {
@@ -226,7 +228,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       return;
     }
     const stream = Stream(that.Connection, { streamID: arg.id,
-      local: false,
+      local: localStreams.has(arg.id),
       audio: arg.audio,
       video: arg.video,
       data: arg.data,
@@ -733,10 +735,10 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
         }
 
         delete stream.failed;
-
-        Logger.info('Stream unpublished');
         callback(true);
       });
+
+      Logger.info('Stream unpublished');
       stream.room = undefined;
       if (stream.hasMedia() && !stream.isExternal()) {
         removeStream(stream);
@@ -817,7 +819,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   // It unsubscribes from the stream, removing the HTML element.
   that.unsubscribe = (streamInput, callback = () => {}) => {
     const stream = streamInput;
-    // Unsubscribe from stream stream
+    // Unsubscribe from stream
     if (socket !== undefined) {
       if (stream && !stream.local) {
         socket.sendMessage('unsubscribe', stream.getID(), (result, error) => {

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -45,15 +45,6 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   // Private functions
   const removeStream = (streamInput) => {
     const stream = streamInput;
-    if (stream.stream) {
-      // Remove HTML element
-      stream.hide();
-
-      stream.stop();
-      stream.close();
-      delete stream.stream;
-    }
-
     stream.removeAllListeners();
 
     // Close PC stream
@@ -68,6 +59,14 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
         that.erizoConnectionManager.maybeCloseConnection(stream.pc);
         delete stream.pc;
       }
+    }
+    if (stream.stream) {
+      // Remove HTML element
+      stream.hide();
+
+      stream.stop();
+      stream.close();
+      delete stream.stream;
     }
   };
 

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -232,14 +232,14 @@ const Stream = (altConnectionHelpers, specInput) => {
       that.stream = undefined;
     }
     if (that.pc && !that.p2p) {
-      that.pc.off('add-stream', spec.onStreamAddedToPC);
-      that.pc.off('remove-stream', spec.onStreamRemovedFroPC);
-      that.pc.off('ice-state-change', spec.onICEConnectionStateChange);
+      that.pc.off('add-stream', onStreamAddedToPC);
+      that.pc.off('remove-stream', onStreamRemovedFroPC);
+      that.pc.off('ice-state-change', onICEConnectionStateChange);
     } else if (that.pc && that.p2p) {
       that.pc.forEach((pc) => {
-        pc.off('add-stream', spec.onStreamAddedToPC);
-        pc.off('remove-stream', spec.onStreamRemovedFroPC);
-        pc.off('ice-state-change', spec.onICEConnectionStateChange);
+        pc.off('add-stream', onStreamAddedToPC);
+        pc.off('remove-stream', onStreamRemovedFroPC);
+        pc.off('ice-state-change', onICEConnectionStateChange);
       });
     }
   };

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -130,7 +130,7 @@ const BaseStack = (specInput) => {
       sdp: localDesc.sdp,
       config: { maxVideoBW: specBase.maxVideoBW },
     });
-    Logger.info('Setting local description p2p', localDesc);
+    Logger.info('Setting local description', localDesc);
     that.peerConnection.setLocalDescription(localDesc).then(() => {
       isNegotiating = false;
       checkOfferQueue();

--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -439,21 +439,26 @@ class Client extends events.EventEmitter {
         return;
     }
 
-    this.room.sendMessage('onRemoveStream', {id: streamId});
-
     if (stream.hasAudio() || stream.hasVideo() || stream.hasScreen()) {
-
         this.state = 'sleeping';
         if (!this.room.p2p) {
-            this.room.controller.removePublisher(this.id, streamId);
-            if (global.config.erizoController.report.session_events) {  // jshint ignore:line
-                var timeStamp = new Date();
-                this.room.amqper.broadcast('event', {room: this.room.id,
-                                           user: this.id,
-                                           type: 'unpublish',
-                                           stream: streamId,
-                                           timestamp: timeStamp.getTime()});
-            }
+            this.room.controller.removePublisher(this.id, streamId, function(result) {
+              if (global.config.erizoController.report.session_events) {  // jshint ignore:line
+                  var timeStamp = new Date();
+                  this.room.amqper.broadcast('event', {room: this.room.id,
+                                             user: this.id,
+                                             type: 'unpublish',
+                                             stream: streamId,
+                                             timestamp: timeStamp.getTime()});
+              }
+              this.room.sendMessage('onRemoveStream', {id: streamId});
+
+              callback(result);
+            }.bind(this));
+        } else {
+          this.room.sendMessage('onRemoveStream', {id: streamId});
+
+          callback(true);
         }
     }
 
@@ -483,19 +488,22 @@ class Client extends events.EventEmitter {
             const clientId = stream.getClient();
             const client = this.room.getClientById(clientId);
             client.sendMessage('unpublish_me', {streamId: stream.getID(), peerSocket: this.id});
+            callback(true);
         } else {
-            this.room.controller.removeSubscriber(this.id, to);
-            if (global.config.erizoController.report.session_events) {  // jshint ignore:line
-                var timeStamp = new Date();
-                this.room.amqper.broadcast('event', {room: this.room.id,
-                                           user: this.id,
-                                           type: 'unsubscribe',
-                                           stream: to,
-                                           timestamp: timeStamp.getTime()});
-            }
+            this.room.controller.removeSubscriber(this.id, to, function(result) {
+              if (global.config.erizoController.report.session_events) {  // jshint ignore:line
+                  var timeStamp = new Date();
+                  this.room.amqper.broadcast('event', {room: this.room.id,
+                                             user: this.id,
+                                             type: 'unsubscribe',
+                                             stream: to,
+                                             timestamp: timeStamp.getTime()});
+              }
+              callback(result);
+            }.bind(this));
         }
     }
-    callback(true);
+
   }
 
   onDisconnect() {

--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -442,7 +442,7 @@ class Client extends events.EventEmitter {
     if (stream.hasAudio() || stream.hasVideo() || stream.hasScreen()) {
         this.state = 'sleeping';
         if (!this.room.p2p) {
-            this.room.controller.removePublisher(this.id, streamId, function(result) {
+            this.room.controller.removePublisher(this.id, streamId, function() {
               if (global.config.erizoController.report.session_events) {  // jshint ignore:line
                   var timeStamp = new Date();
                   this.room.amqper.broadcast('event', {room: this.room.id,
@@ -452,13 +452,10 @@ class Client extends events.EventEmitter {
                                              timestamp: timeStamp.getTime()});
               }
               this.room.sendMessage('onRemoveStream', {id: streamId});
-
-              callback(result);
+              callback(true);
             }.bind(this));
         } else {
           this.room.sendMessage('onRemoveStream', {id: streamId});
-
-          callback(true);
         }
     }
 
@@ -467,7 +464,9 @@ class Client extends events.EventEmitter {
         this.streams.splice(index, 1);
     }
     this.room.removeStream(streamId);
-    callback(true);
+    if (this.room.p2p) {
+      callback(true);
+    }
   }
 
   onUnsubscribe(to, callback) {

--- a/erizo_controller/erizoController/roomController.js
+++ b/erizo_controller/erizoController/roomController.js
@@ -375,7 +375,9 @@ exports.RoomController = function (spec) {
                 log.debug('message: removedPublisher, ' +
                           'streamId: ' + streamId + ', ' +
                           'publishersLeft: ' + Object.keys(publishers).length );
-                callback && callback(true);
+                if (callback) {
+                  callback(true);
+                }
             }.bind(this)});
 
         }

--- a/erizo_controller/erizoController/roomController.js
+++ b/erizo_controller/erizoController/roomController.js
@@ -349,7 +349,7 @@ exports.RoomController = function (spec) {
     /*
      * Removes a publisher from the room. This also deletes the associated OneToManyProcessor.
      */
-    that.removePublisher = function (clientId, streamId) {
+    that.removePublisher = function (clientId, streamId, callback) {
 
         if (subscribers[streamId] !== undefined && publishers[streamId]!== undefined) {
             log.info('message: removePublisher, ' +
@@ -357,23 +357,27 @@ exports.RoomController = function (spec) {
                      'erizoId: ' + getErizoQueue(streamId));
 
             var args = [clientId, streamId];
-            amqper.callRpc(getErizoQueue(streamId), 'removePublisher', args, undefined);
-            const erizo = erizos.findById(publishers[streamId]);
+            amqper.callRpc(getErizoQueue(streamId), 'removePublisher', args, {
+              callback: function() {
+                const erizo = erizos.findById(publishers[streamId]);
 
-            if (erizo) {
-                var index = erizo.publishers.indexOf(streamId);
-                erizo.publishers.splice(index, 1);
-            } else {
-                log.warn('message: removePublisher was already removed, ' +
-                         'streamId: ' + streamId + ', ' +
-                         'erizoId: ' + getErizoQueue(streamId));
-            }
+                if (erizo) {
+                    var index = erizo.publishers.indexOf(streamId);
+                    erizo.publishers.splice(index, 1);
+                } else {
+                    log.warn('message: removePublisher was already removed, ' +
+                             'streamId: ' + streamId + ', ' +
+                             'erizoId: ' + getErizoQueue(streamId));
+                }
 
-            delete subscribers[streamId];
-            delete publishers[streamId];
-            log.debug('message: removedPublisher, ' +
-                      'streamId: ' + streamId + ', ' +
-                      'publishersLeft: ' + Object.keys(publishers).length );
+                delete subscribers[streamId];
+                delete publishers[streamId];
+                log.debug('message: removedPublisher, ' +
+                          'streamId: ' + streamId + ', ' +
+                          'publishersLeft: ' + Object.keys(publishers).length );
+                callback && callback(true);
+            }.bind(this)});
+
         }
     };
 
@@ -381,7 +385,7 @@ exports.RoomController = function (spec) {
      * Removes a subscriber from the room.
      * This also removes it from the associated OneToManyProcessor.
      */
-    that.removeSubscriber = function (subscriberId, streamId) {
+    that.removeSubscriber = function (subscriberId, streamId, callback) {
         if(subscribers[streamId]!==undefined){
             var index = subscribers[streamId].indexOf(subscriberId);
             if (index !== -1) {
@@ -390,9 +394,11 @@ exports.RoomController = function (spec) {
                          'streamId: ' + streamId);
 
                 var args = [subscriberId, streamId];
-                amqper.callRpc(getErizoQueue(streamId), 'removeSubscriber', args, undefined);
-
-                subscribers[streamId].splice(index, 1);
+                amqper.callRpc(getErizoQueue(streamId), 'removeSubscriber', args, {
+                  callback: function() {
+                    subscribers[streamId].splice(index, 1);
+                    callback(true);
+                }.bind(this)});
             }
         } else {
             log.warn('message: removeSubscriber not found, ' +

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -214,7 +214,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
     /*
      * Removes a publisher from the room. This also deletes the associated OneToManyProcessor.
      */
-    that.removePublisher = function (clientId, streamId) {
+    that.removePublisher = function (clientId, streamId, callback = () => {}) {
       return new Promise(function(resolve) {
         var publisher = publishers[streamId];
           if (publisher !== undefined) {
@@ -239,6 +239,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
                         }
                     }
                     log.debug('message: remaining publishers, publisherCount: ' + count);
+                    callback('callback', true);
                     resolve();
                     if (count === 0)  {
                         log.info('message: Removed all publishers. Killing process.');
@@ -259,7 +260,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
      * Removes a subscriber from the room.
      * This also removes it from the associated OneToManyProcessor.
      */
-    that.removeSubscriber = function (clientId, streamId) {
+    that.removeSubscriber = function (clientId, streamId, callback = () => {}) {
         const publisher = publishers[streamId];
         if (publisher && publisher.hasSubscriber(clientId)) {
             let subscriber = publisher.getSubscriber(clientId);
@@ -268,6 +269,7 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
             closeNode(subscriber);
             publisher.removeSubscriber(clientId);
         }
+        callback('callback', true);
     };
 
     /*

--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -103,7 +103,7 @@ class Connection extends events.EventEmitter {
     this.emit('media_stream_event', streamEvent);
   }
 
-  _maybeSendAnswer(evt, streamId) {
+  _maybeSendAnswer(evt, streamId, forceOffer = false) {
     if (this.isProcessingRemoteSdp) {
       return;
     }
@@ -115,7 +115,7 @@ class Connection extends events.EventEmitter {
     let message = sdp.toString();
     message = message.replace(this.options.privateRegexp, this.options.publicIP);
 
-    const info = {type: this.options.createOffer ? 'offer' : 'answer', sdp: message};
+    const info = {type: this.options.createOffer || forceOffer ? 'offer' : 'answer', sdp: message};
     log.debug(`message: _maybeSendAnswer sending event, type: ${info.type}, streamId: ${streamId}`);
     this.emit('status_event', info, evt, streamId);
   }
@@ -198,6 +198,7 @@ class Connection extends events.EventEmitter {
       this.mediaStreams.get(id).close();
       this.mediaStreams.delete(id);
       log.debug(`removed mediaStreamId ${id}, remaining size ${this.getNumMediaStreams()}`);
+      this._maybeSendAnswer(CONN_SDP, id, true);
     } else {
       log.error(`message: Trying to remove mediaStream not found, id: ${id}`);
     }

--- a/erizo_controller/erizoJS/models/Subscriber.js
+++ b/erizo_controller/erizoJS/models/Subscriber.js
@@ -66,7 +66,7 @@ class Subscriber extends NodeClass {
 
   _onMediaStreamEvent(mediaStreamEvent) {
     if (mediaStreamEvent.type === 'slideshow_fallback_update') {
-      this.publisher.setSlideShow(mediaStreamEvent.message === 
+      this.publisher.setSlideShow(mediaStreamEvent.message ===
         'false'? false: true, this.clientId, true);
     }
   }
@@ -124,8 +124,8 @@ class Subscriber extends NodeClass {
     log.debug(`msg: Closing subscriber, streamId:${this.streamId}`);
     this.publisher = undefined;
     if (this.connection) {
-      this.connection.removeListener('status_event', this._connectionListener);
       this.connection.removeMediaStream(this.mediaStream.id);
+      this.connection.removeListener('status_event', this._connectionListener);
     }
     if (this.mediaStream && this.mediaStream.monitorInterval) {
       clearInterval(this.mediaStream.monitorInterval);

--- a/erizo_controller/test/erizoController/erizoController.js
+++ b/erizo_controller/test/erizoController/erizoController.js
@@ -779,7 +779,8 @@ describe('Erizo Controller / Erizo Controller', function() {
 
                     onUnsubscribe(streamId, callback);
 
-                    expect(mocks.roomControllerInstance.removeSubscriber.callCount).to.equal(1);
+                    mocks.roomControllerInstance.removeSubscriber.firstCall.callArgWith(2, true);
+
                     expect(callback.withArgs(true).callCount).to.equal(1);
                   });
 
@@ -793,6 +794,7 @@ describe('Erizo Controller / Erizo Controller', function() {
                     onUnsubscribe(streamId, callback);
 
                     expect(mocks.roomControllerInstance.removeSubscriber.callCount).to.equal(1);
+                    mocks.roomControllerInstance.removeSubscriber.firstCall.callArgWith(2, true);
                     expect(callback.withArgs(true).callCount).to.equal(1);
                   });
 
@@ -806,6 +808,7 @@ describe('Erizo Controller / Erizo Controller', function() {
                     onUnsubscribe(streamId, callback);
 
                     expect(mocks.roomControllerInstance.removeSubscriber.callCount).to.equal(1);
+                    mocks.roomControllerInstance.removeSubscriber.firstCall.callArgWith(2, true);
                     expect(callback.withArgs(true).callCount).to.equal(1);
                   });
 
@@ -819,6 +822,7 @@ describe('Erizo Controller / Erizo Controller', function() {
                     onUnsubscribe(streamId, callback);
 
                     expect(mocks.roomControllerInstance.removeSubscriber.callCount).to.equal(1);
+                    mocks.roomControllerInstance.removeSubscriber.firstCall.callArgWith(2, true);
                     expect(callback.withArgs(true).callCount).to.equal(1);
                   });
 
@@ -885,6 +889,8 @@ describe('Erizo Controller / Erizo Controller', function() {
                     expect(mocks.roomControllerInstance.removePublisher
                             .withArgs(client.id, streamId)
                             .callCount).to.equal(1);
+                    mocks.roomControllerInstance.removePublisher
+                      .withArgs(client.id, streamId).callArgWith(2, true);
                     expect(mocks.socketInstance.emit.withArgs('onRemoveStream').callCount)
                           .to.equal(1);
                     expect(callback.withArgs(true).callCount).to.equal(1);
@@ -902,6 +908,8 @@ describe('Erizo Controller / Erizo Controller', function() {
                     expect(mocks.roomControllerInstance
                           .removePublisher.withArgs(client.id, streamId)
                           .callCount).to.equal(1);
+                    mocks.roomControllerInstance.removePublisher
+                      .withArgs(client.id, streamId).callArgWith(2, true);
                     expect(mocks.socketInstance.emit.withArgs('onRemoveStream').callCount)
                           .to.equal(1);
                     expect(callback.withArgs(true).callCount).to.equal(1);
@@ -919,6 +927,8 @@ describe('Erizo Controller / Erizo Controller', function() {
                     expect(mocks.roomControllerInstance.removePublisher
                           .withArgs(client.id, streamId)
                           .callCount).to.equal(1);
+                    mocks.roomControllerInstance.removePublisher
+                      .withArgs(client.id, streamId).callArgWith(2, true);
                     expect(mocks.socketInstance.emit.withArgs('onRemoveStream').callCount)
                             .to.equal(1);
                     expect(callback.withArgs(true).callCount).to.equal(1);
@@ -936,6 +946,8 @@ describe('Erizo Controller / Erizo Controller', function() {
                     expect(mocks.roomControllerInstance.removePublisher
                           .withArgs(client.id, streamId)
                           .callCount).to.equal(1);
+                    mocks.roomControllerInstance.removePublisher
+                      .withArgs(client.id, streamId).callArgWith(2, true);
                     expect(mocks.socketInstance.emit.withArgs('onRemoveStream').callCount)
                             .to.equal(1);
                     expect(callback.withArgs(true).callCount).to.equal(1);

--- a/erizo_controller/test/erizoController/roomController.js
+++ b/erizo_controller/test/erizoController/roomController.js
@@ -121,6 +121,10 @@ describe('Erizo Controller / Room Controller', function() {
 
       it('should fail if publisher does not exist', function() {
         controller.removePublisher(kArbitraryId, kArbitraryId);
+        expect(amqperMock.callRpc.withArgs('ErizoJS_erizoId', 'removePublisher').callCount, 1);
+        var cb = amqperMock.callRpc.withArgs('ErizoJS_erizoId', 'removePublisher')
+                    .args[0][3].callback;
+        cb(true);
 
         var callback = sinon.stub();
         controller.removeExternalOutput(kArbitraryUrl, callback);


### PR DESCRIPTION
**Description**

There was some issues in Single Peer Connection when trying to unsubscribe or unpublish streams because we were not negotiating the SDP again. This PR adds such negotiation and it also introduces some minor fixes.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.