### PR TITLE
throw error when trying to subscribe when socket is not authenticated

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -762,6 +762,10 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
 
   // It subscribe to a remote stream and draws it inside the HTML tag given by the ID='elementID'
   that.subscribe = (streamInput, optionsInput = {}, callback = () => {}) => {
+    if (socket.state !== socket.CONNECTED) {
+      callback(undefined, 'You are not authenticated');
+      return;
+    }
     const stream = streamInput;
     const options = optionsInput;
 


### PR DESCRIPTION
**Description**

During HEAVY stress test with spine, it happens sometimes that stream-added (of another stream in the room) is fired on client before the client token callback (which sets the socket.state = CONNECTED).

So the client try to subscribe to this stream but the function sendSDP return since the socket is still in != CONNECTED state and no errors are thrown (only a log.error)
