### PR TITLE
Use fixed values for bw estimation when slideshow is enabled

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -88,6 +88,7 @@ MediaStream::~MediaStream() {
 
 uint32_t MediaStream::getMaxVideoBW() {
   uint32_t bitrate = rtcp_processor_ ? rtcp_processor_->getMaxVideoBW() : 0;
+  bitrate = slide_show_mode_ ? kSlideshowMaxVideoBW : bitrate;
   return bitrate;
 }
 

--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -27,6 +27,8 @@
 
 namespace erizo {
 
+constexpr uint32_t kSlideshowMaxVideoBW = 40;  // kbps
+
 class MediaStreamStatsListener {
  public:
     virtual ~MediaStreamStatsListener() {


### PR DESCRIPTION
**Description**

Use fixed values for bw estimation in Single PC when the stream is in slideshow mode.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.