### PR TITLE
New option to print periodic stats as logs

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -207,12 +207,21 @@ void MediaStream::initializeStats() {
   log_stats_->getNode().insertStat("audioPL", CumulativeStat{0});
   log_stats_->getNode().insertStat("audioJitter", CumulativeStat{0});
   log_stats_->getNode().insertStat("audioMuted", CumulativeStat{0});
+  log_stats_->getNode().insertStat("audioNack", CumulativeStat{0});
+  log_stats_->getNode().insertStat("audioRemb", CumulativeStat{0});
 
   log_stats_->getNode().insertStat("videoBitrate", CumulativeStat{0});
   log_stats_->getNode().insertStat("videoFL", CumulativeStat{0});
   log_stats_->getNode().insertStat("videoPL", CumulativeStat{0});
   log_stats_->getNode().insertStat("videoJitter", CumulativeStat{0});
   log_stats_->getNode().insertStat("videoMuted", CumulativeStat{0});
+  log_stats_->getNode().insertStat("slideshow", CumulativeStat{0});
+  log_stats_->getNode().insertStat("videoNack", CumulativeStat{0});
+  log_stats_->getNode().insertStat("videoPli", CumulativeStat{0});
+  log_stats_->getNode().insertStat("videoFir", CumulativeStat{0});
+  log_stats_->getNode().insertStat("videoRemb", CumulativeStat{0});
+  log_stats_->getNode().insertStat("videoErizoRemb", CumulativeStat{0});
+  log_stats_->getNode().insertStat("videoKeyFrames", CumulativeStat{0});
 
   log_stats_->getNode().insertStat("SL0TL0", CumulativeStat{0});
   log_stats_->getNode().insertStat("SL0TL1", CumulativeStat{0});
@@ -238,6 +247,7 @@ void MediaStream::initializeStats() {
   log_stats_->getNode().insertStat("isPublisher", CumulativeStat{is_publisher_});
 
   log_stats_->getNode().insertStat("totalBitrate", CumulativeStat{0});
+  log_stats_->getNode().insertStat("rtxBitrate", CumulativeStat{0});
   log_stats_->getNode().insertStat("paddingBitrate", CumulativeStat{0});
   log_stats_->getNode().insertStat("bwe", CumulativeStat{0});
 
@@ -285,6 +295,8 @@ void MediaStream::printStats() {
     transferMediaStats("audioFL",      audio_ssrc, "fractionLost");
     transferMediaStats("audioJitter",  audio_ssrc, "jitter");
     transferMediaStats("audioMuted",   audio_ssrc, "erizoAudioMute");
+    transferMediaStats("audioNack",    audio_ssrc, "NACK");
+    transferMediaStats("audioRemb",    audio_ssrc, "bandwidth");
   }
   if (video_enabled_) {
     video_ssrc = std::to_string(is_publisher_ ? getVideoSourceSSRC() : getVideoSinkSSRC());
@@ -293,6 +305,13 @@ void MediaStream::printStats() {
     transferMediaStats("videoFL",      video_ssrc, "fractionLost");
     transferMediaStats("videoJitter",  video_ssrc, "jitter");
     transferMediaStats("videoMuted",   audio_ssrc, "erizoVideoMute");
+    transferMediaStats("slideshow",    video_ssrc, "erizoSlideShow");
+    transferMediaStats("videoNack",    video_ssrc, "NACK");
+    transferMediaStats("videoPli",     video_ssrc, "PLI");
+    transferMediaStats("videoFir",     video_ssrc, "FIR");
+    transferMediaStats("videoRemb",    video_ssrc, "bandwidth");
+    transferMediaStats("videoErizoRemb", video_ssrc, "erizoBandwidth");
+    transferMediaStats("videoKeyFrames", video_ssrc, "keyFrames");
   }
 
   for (uint32_t spatial = 0; spatial <= 3; spatial++) {
@@ -307,6 +326,7 @@ void MediaStream::printStats() {
   transferMediaStats("selectedTL", "qualityLayers", "selectedTemporalLayer");
   transferMediaStats("totalBitrate", "total", "bitrateCalculated");
   transferMediaStats("paddingBitrate", "total", "paddingBitrate");
+  transferMediaStats("rtxBitrate", "total", "rtxBitrate");
   transferMediaStats("bwe", "total", "senderBitrateEstimation");
 
   ELOG_INFOT(statsLogger, "%s", log_stats_->getStats());

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -202,6 +202,7 @@ bool MediaStream::setLocalSdp(std::shared_ptr<SdpInfo> sdp) {
 }
 
 void MediaStream::initializeStats() {
+  log_stats_->getNode().insertStat("streamId", StringStat{getId()});
   log_stats_->getNode().insertStat("audioBitrate", CumulativeStat{0});
   log_stats_->getNode().insertStat("audioFL", CumulativeStat{0});
   log_stats_->getNode().insertStat("audioPL", CumulativeStat{0});

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -41,6 +41,9 @@
 
 namespace erizo {
 DEFINE_LOGGER(MediaStream, "MediaStream");
+log4cxx::LoggerPtr MediaStream::statsLogger = log4cxx::Logger::getLogger("StreamStats");
+
+static constexpr auto kStreamStatsPeriod = std::chrono::seconds(30);
 
 MediaStream::MediaStream(std::shared_ptr<Worker> worker,
   std::shared_ptr<WebRtcConnection> connection,
@@ -64,6 +67,7 @@ MediaStream::MediaStream(std::shared_ptr<Worker> worker,
   source_fb_sink_ = this;
   sink_fb_source_ = this;
   stats_ = std::make_shared<Stats>();
+  log_stats_ = std::make_shared<Stats>();
   quality_manager_ = std::make_shared<QualityManager>();
   packet_buffer_ = std::make_shared<PacketBufferService>();
   std::srand(std::time(nullptr));
@@ -187,12 +191,125 @@ bool MediaStream::setRemoteSdp(std::shared_ptr<SdpInfo> sdp) {
 
   initializePipeline();
 
+  initializeStats();
+
   return true;
 }
 
 bool MediaStream::setLocalSdp(std::shared_ptr<SdpInfo> sdp) {
   local_sdp_ = std::move(sdp);
   return true;
+}
+
+void MediaStream::initializeStats() {
+  log_stats_->getNode().insertStat("audioBitrate", CumulativeStat{0});
+  log_stats_->getNode().insertStat("audioFL", CumulativeStat{0});
+  log_stats_->getNode().insertStat("audioPL", CumulativeStat{0});
+  log_stats_->getNode().insertStat("audioJitter", CumulativeStat{0});
+  log_stats_->getNode().insertStat("audioMuted", CumulativeStat{0});
+
+  log_stats_->getNode().insertStat("videoBitrate", CumulativeStat{0});
+  log_stats_->getNode().insertStat("videoFL", CumulativeStat{0});
+  log_stats_->getNode().insertStat("videoPL", CumulativeStat{0});
+  log_stats_->getNode().insertStat("videoJitter", CumulativeStat{0});
+  log_stats_->getNode().insertStat("videoMuted", CumulativeStat{0});
+
+  log_stats_->getNode().insertStat("SL0TL0", CumulativeStat{0});
+  log_stats_->getNode().insertStat("SL0TL1", CumulativeStat{0});
+  log_stats_->getNode().insertStat("SL0TL2", CumulativeStat{0});
+  log_stats_->getNode().insertStat("SL0TL3", CumulativeStat{0});
+  log_stats_->getNode().insertStat("SL1TL0", CumulativeStat{0});
+  log_stats_->getNode().insertStat("SL1TL1", CumulativeStat{0});
+  log_stats_->getNode().insertStat("SL1TL2", CumulativeStat{0});
+  log_stats_->getNode().insertStat("SL1TL3", CumulativeStat{0});
+  log_stats_->getNode().insertStat("SL2TL0", CumulativeStat{0});
+  log_stats_->getNode().insertStat("SL2TL1", CumulativeStat{0});
+  log_stats_->getNode().insertStat("SL2TL2", CumulativeStat{0});
+  log_stats_->getNode().insertStat("SL2TL3", CumulativeStat{0});
+  log_stats_->getNode().insertStat("SL3TL0", CumulativeStat{0});
+  log_stats_->getNode().insertStat("SL3TL1", CumulativeStat{0});
+  log_stats_->getNode().insertStat("SL3TL2", CumulativeStat{0});
+  log_stats_->getNode().insertStat("SL3TL3", CumulativeStat{0});
+
+  log_stats_->getNode().insertStat("maxActiveSL", CumulativeStat{0});
+  log_stats_->getNode().insertStat("maxActiveTL", CumulativeStat{0});
+  log_stats_->getNode().insertStat("selectedSL", CumulativeStat{0});
+  log_stats_->getNode().insertStat("selectedTL", CumulativeStat{0});
+  log_stats_->getNode().insertStat("isPublisher", CumulativeStat{is_publisher_});
+
+  log_stats_->getNode().insertStat("totalBitrate", CumulativeStat{0});
+  log_stats_->getNode().insertStat("paddingBitrate", CumulativeStat{0});
+  log_stats_->getNode().insertStat("bwe", CumulativeStat{0});
+
+  std::weak_ptr<MediaStream> weak_this = shared_from_this();
+  worker_->scheduleEvery([weak_this] () {
+    if (auto stream = weak_this.lock()) {
+      if (stream->sending_) {
+        stream->printStats();
+        return true;
+      }
+    }
+    return false;
+  }, kStreamStatsPeriod);
+}
+
+void MediaStream::transferLayerStats(std::string spatial, std::string temporal) {
+  std::string node = "SL" + spatial + "TL" + temporal;
+  if (stats_->getNode().hasChild("qualityLayers") &&
+      stats_->getNode()["qualityLayers"].hasChild(spatial) &&
+      stats_->getNode()["qualityLayers"][spatial].hasChild(temporal)) {
+    log_stats_->getNode()
+      .insertStat(node, CumulativeStat{stats_->getNode()["qualityLayers"][spatial][temporal].value()});
+  }
+}
+
+void MediaStream::transferMediaStats(std::string target_node, std::string source_parent, std::string source_node) {
+  if (stats_->getNode().hasChild(source_parent) &&
+      stats_->getNode()[source_parent].hasChild(source_node)) {
+    log_stats_->getNode()
+      .insertStat(target_node, CumulativeStat{stats_->getNode()[source_parent][source_node].value()});
+  }
+}
+
+void MediaStream::printStats() {
+  std::string video_ssrc;
+  std::string audio_ssrc;
+
+  log_stats_->getNode().insertStat("audioEnabled", CumulativeStat{audio_enabled_});
+  log_stats_->getNode().insertStat("videoEnabled", CumulativeStat{video_enabled_});
+
+  if (audio_enabled_) {
+    audio_ssrc = std::to_string(is_publisher_ ? getAudioSourceSSRC() : getAudioSinkSSRC());
+    transferMediaStats("audioBitrate", audio_ssrc, "bitrateCalculated");
+    transferMediaStats("audioPL",      audio_ssrc, "packetsLost");
+    transferMediaStats("audioFL",      audio_ssrc, "fractionLost");
+    transferMediaStats("audioJitter",  audio_ssrc, "jitter");
+    transferMediaStats("audioMuted",   audio_ssrc, "erizoAudioMute");
+  }
+  if (video_enabled_) {
+    video_ssrc = std::to_string(is_publisher_ ? getVideoSourceSSRC() : getVideoSinkSSRC());
+    transferMediaStats("videoBitrate", video_ssrc, "bitrateCalculated");
+    transferMediaStats("videoPL",      video_ssrc, "packetsLost");
+    transferMediaStats("videoFL",      video_ssrc, "fractionLost");
+    transferMediaStats("videoJitter",  video_ssrc, "jitter");
+    transferMediaStats("videoMuted",   audio_ssrc, "erizoVideoMute");
+  }
+
+  for (uint32_t spatial = 0; spatial <= 3; spatial++) {
+    for (uint32_t temporal = 0; temporal <= 3; temporal++) {
+      transferLayerStats(std::to_string(spatial), std::to_string(temporal));
+    }
+  }
+
+  transferMediaStats("maxActiveSL", "qualityLayers", "maxActiveSpatialLayer");
+  transferMediaStats("maxActiveTL", "qualityLayers", "maxActiveTemporalLayer");
+  transferMediaStats("selectedSL", "qualityLayers", "selectedSpatialLayer");
+  transferMediaStats("selectedTL", "qualityLayers", "selectedTemporalLayer");
+  transferMediaStats("totalBitrate", "total", "bitrateCalculated");
+  transferMediaStats("paddingBitrate", "total", "paddingBitrate");
+  transferMediaStats("bwe", "total", "senderBitrateEstimation");
+
+  ELOG_INFOT(statsLogger, "%s", log_stats_->getStats());
 }
 
 void MediaStream::initializePipeline() {
@@ -507,6 +624,9 @@ void MediaStream::setFeedbackReports(bool will_send_fb, uint32_t target_bitrate)
 }
 
 void MediaStream::setMetadata(std::map<std::string, std::string> metadata) {
+  for (const auto &item : metadata) {
+    log_stats_->getNode().insertStat("metadata-" + item.first, StringStat{item.second});
+  }
   setLogContext(metadata);
 }
 

--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -50,6 +50,7 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
                         public FeedbackSource, public LogContext, public HandlerManagerListener,
                         public std::enable_shared_from_this<MediaStream>, public Service {
   DECLARE_LOGGER();
+  static log4cxx::LoggerPtr statsLogger;
 
  public:
   typedef typename Handler::Context Context;
@@ -127,6 +128,9 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
 
   void asyncTask(std::function<void(std::shared_ptr<MediaStream>)> f);
 
+  void initializeStats();
+  void printStats();
+
   bool isAudioMuted() { return audio_muted_; }
   bool isVideoMuted() { return video_muted_; }
 
@@ -150,7 +154,7 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   bool isPublisher() { return is_publisher_; }
 
   inline std::string toLog() {
-    return "id: " + stream_id_ + ", role:" + (is_publisher_ ? "publisher" : "subscriber") + " " + printLogContext();
+    return "id: " + stream_id_ + ", role:" + (is_publisher_ ? "publisher" : "subscriber") + ", " + printLogContext();
   }
 
  private:
@@ -160,6 +164,8 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   int deliverFeedback_(std::shared_ptr<DataPacket> fb_packet) override;
   int deliverEvent_(MediaEventPtr event) override;
   void initializePipeline();
+  void transferLayerStats(std::string spatial, std::string temporal);
+  void transferMediaStats(std::string target_node, std::string source_parent, std::string source_node);
 
   void changeDeliverPayloadType(DataPacket *dp, packetType type);
   // parses incoming payload type, replaces occurence in buf
@@ -183,6 +189,7 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
 
   std::shared_ptr<RtcpProcessor> rtcp_processor_;
   std::shared_ptr<Stats> stats_;
+  std::shared_ptr<Stats> log_stats_;
   std::shared_ptr<QualityManager> quality_manager_;
   std::shared_ptr<PacketBufferService> packet_buffer_;
   std::shared_ptr<HandlerManager> handler_manager_;

--- a/erizo/src/test/log4cxx.properties
+++ b/erizo/src/test/log4cxx.properties
@@ -16,6 +16,7 @@ log4j.logger.TimeoutChecker=ERROR
 log4j.logger.SdpInfo=ERROR
 log4j.logger.SrtpChannel=ERROR
 log4j.logger.Stats=ERROR
+log4j.logger.StreamStats=ERROR
 log4j.logger.WebRtcConnection=ERROR
 
 log4j.logger.dtls.DtlsSocket=ERROR

--- a/erizo_controller/erizoAgent/log4cxx.properties
+++ b/erizo_controller/erizoAgent/log4cxx.properties
@@ -16,6 +16,7 @@ log4j.logger.DtlsTransport=DEBUG
 log4j.logger.LibNiceConnection=DEBUG
 log4j.logger.NicerConnection=DEBUG
 log4j.logger.MediaStream=WARN
+log4j.logger.StreamStats=INFO
 log4j.logger.OneToManyProcessor=WARN
 log4j.logger.TimeoutChecker=WARN
 log4j.logger.SdpInfo=WARN


### PR DESCRIPTION
**Description**

This PR adds the option to print periodic stats every 30 seconds into the logs. The stats follow this format:

```bash
[erizo-150ad5ee-6c6e-1941-bf9b-839c2e7e9739] 2018-07-27 10:05:24,473  - INFO [0x70000a9c8000] StreamStats - {"SL0TL0":0,"SL0TL1":0,"SL0TL2":0,"SL0TL3":0,"SL1TL0":0,"SL1TL1":0,"SL1TL2":0,"SL1TL3":0,"SL2TL0":0,"SL2TL1":0,"SL2TL2":0,"SL2TL3":0,"SL3TL0":0,"SL3TL1":0,"SL3TL2":0,"SL3TL3":0,"audioBitrate":40359,"audioFL":0,"audioJitter":0,"audioMuted":0,"audioPL":0,"bwe":0,"isPublisher":1,"maxActiveSL":0,"maxActiveTL":0,"metadata":{"type":"publisher"},"paddingBitrate":0,"selectedSL":0,"selectedTL":0,"totalBitrate":523814,"videoBitrate":162561,"videoFL":0,"videoJitter":0,"videoMuted":0,"videoPL":0}
```
[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.