### PR TITLE
Enable last padding packet again to avoid sticky bitrates

### DIFF
--- a/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.cpp
@@ -110,9 +110,9 @@ void RtpPaddingGeneratorHandler::onPacketWithMarkerSet(std::shared_ptr<DataPacke
   for (uint i = 0; i < number_of_full_padding_packets_; i++) {
     sendPaddingPacket(packet, kMaxPaddingSize);
   }
-  // Temporary fix since https://bugzilla.mozilla.org/show_bug.cgi?id=1435025 is fixed
-  // Only send full rtp padding packet as suggested also in webrtc code.
-  // sendPaddingPacket(packet, last_padding_packet_size_);
+
+  sendPaddingPacket(packet, last_padding_packet_size_);
+
   std::weak_ptr<RtpPaddingGeneratorHandler> weak_this = shared_from_this();
   scheduled_task_ = stream_->getWorker()->scheduleFromNow([packet, weak_this] {
     if (auto this_ptr = weak_this.lock()) {


### PR DESCRIPTION
**Description**

This PRs rolls back a temporary fix for Firefox clients which is already fixed in this browser. It seems to be affecting our production environment in some cases.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.