### PR TITLE
Check if the handler is initialized before reading or processing

### DIFF
--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
@@ -88,6 +88,9 @@ void BandwidthEstimationHandler::notifyUpdate() {
 }
 
 void BandwidthEstimationHandler::process() {
+  if (!initialized_) {
+    return;
+  }
   rbe_->Process();
   std::weak_ptr<BandwidthEstimationHandler> weak_ptr = shared_from_this();
   worker_->scheduleFromNow([weak_ptr]() {
@@ -143,6 +146,9 @@ void BandwidthEstimationHandler::updateExtensionMap(bool is_video, std::array<RT
 }
 
 void BandwidthEstimationHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet) {
+  if (!initialized_) {
+    return;
+  }
   if (initialized_ && !running_) {
     process();
     running_ = true;

--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
@@ -88,9 +88,6 @@ void BandwidthEstimationHandler::notifyUpdate() {
 }
 
 void BandwidthEstimationHandler::process() {
-  if (!initialized_) {
-    return;
-  }
   rbe_->Process();
   std::weak_ptr<BandwidthEstimationHandler> weak_ptr = shared_from_this();
   worker_->scheduleFromNow([weak_ptr]() {
@@ -147,6 +144,7 @@ void BandwidthEstimationHandler::updateExtensionMap(bool is_video, std::array<RT
 
 void BandwidthEstimationHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet) {
   if (!initialized_) {
+    ctx->fireRead(std::move(packet));
     return;
   }
   if (initialized_ && !running_) {


### PR DESCRIPTION


**Description**
This PR prevents `BandwidthEstimationHandler ` from reading packets or processing data if it hasn't been initialized before.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.