### PR TITLE
Disable padding on capped bitrates

### DIFF
--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -195,9 +195,10 @@ void QualityManager::selectLayer(bool try_higher_layers) {
 
     // TODO(javier): should we wait for the actual spatial switch?
     // should we disable padding temporarily to avoid congestion (old padding + new bitrate)?
-    setPadding(!isInMaxLayer() && !layer_capped_by_constraints);
+
     ELOG_DEBUG("message: Is padding enabled, padding_enabled_: %d", padding_enabled_);
   }
+  setPadding(!isInMaxLayer() && !layer_capped_by_constraints);
 }
 
 void QualityManager::calculateMaxActiveLayer() {


### PR DESCRIPTION
**Description**

We were not disabling padding in some cases where layers where capped by API.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.