### PR TITLE
Add flag to not check request timestamp

### DIFF
--- a/nuve/nuveAPI/auth/nuveAuthenticator.js
+++ b/nuve/nuveAPI/auth/nuveAuthenticator.js
@@ -9,6 +9,10 @@ var logger = require('./../logger').logger;
 var log = logger.getLogger('NuveAuthenticator');
 
 var cache = {};
+var checkTimestampRequired = true;
+if (process.env.NUVE_AUTH_CHECK_TIMESTAMP === 'false') {
+    checkTimestampRequired = false;
+}
 
 var checkTimestamp = function (ser, params) {
     var lastParams = cache[ser.name],
@@ -75,7 +79,7 @@ exports.authenticate = function (req, res, next) {
             var key = serv.key;
 
             // Check if timestam and cnonce are valids in order to avoid duplicate requests.
-            if (!checkTimestamp(serv, params)) {
+            if (checkTimestampRequired && !checkTimestamp(serv, params)) {
                 log.info('message: authenticate fail - Invalid timestamp or cnonce');
                 res.status(401).send({'WWW-Authenticate': challengeReq});
                 return;

--- a/nuve/nuveAPI/test/auth/nuveAuthenticator.sh
+++ b/nuve/nuveAPI/test/auth/nuveAuthenticator.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+export NUVE_AUTH_CHECK_TIMESTAMP="false";
+mocha nuveAuthenticatorNoCheckTimestamp.js;
+export NUVE_AUTH_CHECK_TIMESTAMP="";
+
+mocha nuveAuthenticator.js;

--- a/nuve/nuveAPI/test/auth/nuveAuthenticatorNoCheckTimestamp.js
+++ b/nuve/nuveAPI/test/auth/nuveAuthenticatorNoCheckTimestamp.js
@@ -1,0 +1,71 @@
+/*global require, describe, it, beforeEach, afterEach*/
+'use strict';
+var mocks = require('../utils');
+var request = require('supertest');
+var express = require('express');
+var sinon = require('sinon');
+var expect  = require('chai').expect;
+var async = require('async');
+
+var kArbitraryServiceInfo = {key: '1'};
+
+describe('Nuve Authenticator', function() {
+  var app,
+      nextStep,
+      serviceRegistryMock,
+      nuveAuthenticator;
+
+  beforeEach(function() {
+    mocks.start(mocks.licodeConfig);
+    serviceRegistryMock = mocks.start(mocks.serviceRegistry);
+
+    nuveAuthenticator = require('../../auth/nuveAuthenticator');
+
+    var onRequest = function(req, res) {
+      res.send('OK');
+    };
+    nextStep = sinon.spy(onRequest);
+
+    app = express();
+    app.all('*', nuveAuthenticator.authenticate);
+    app.get('/arbitraryFunction', nextStep);
+
+    serviceRegistryMock.getService = sinon.stub().callsArgWith(1, kArbitraryServiceInfo);
+  });
+
+  afterEach(function() {
+    mocks.stop(mocks.licodeConfig);
+    mocks.stop(serviceRegistryMock);
+    mocks.deleteRequireCache();
+  });
+
+  it('should pass if we send old timestamp when timestamp is not checked', function(done) {
+    var header = 'MAuth realm="",mauth_serviceid=1,mauth_signature_method=HMAC_SHA1,';
+    async.series([
+      function(next) {
+        request(app)
+          .get('/arbitraryFunction')
+          .set('Authorization', header + ',mauth_timestamp=2,mauth_cnonce=1,' +
+                      'mauth_signature=OGM3NDQ1MTliNDI1OTUyMmQyY2YwYjQ1ZjJhNzdhYzBiNjBkNDM4Mg==')
+          .end(function(err) {
+            if (err) throw err;
+            next();
+          });
+      },
+      function(next) {
+        request(app)
+          .get('/arbitraryFunction')
+          .set('Authorization', header + ',mauth_timestamp=1,mauth_cnonce=1,' +
+                      'mauth_signature=NDg2YTMzNjQ4OThhOTA1ZmY5MWM3OTcwZjY2MWVmZDdhN2RhZTI1Mw==')
+          .expect(200, 'OK')
+          .end(function(err) {
+            if (err) throw err;
+            next();
+          });
+      }
+    ], function() {
+      expect(nextStep.calledTwice).to.be.true;  // jshint ignore:line
+      done();
+    });
+  });
+});


### PR DESCRIPTION
This update is to get around async parallel requests
producing 401 Unauthorized errors. For more info see
https://github.com/lynckia/licode/issues/362

**Description**

This update blocks this issue: https://github.com/lynckia/licode/issues/362 from occurring. The default behavior of nuve authentication is still the same. By default the request timestamps are verified. This update checks the value of an environment variable 'NUVE_AUTH_CHECK_TIMESTAMP' and if the env var is set to 'false' then the timestamp from the request is not verified.

[x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

No changes in the public API are needed. The system under which licode runs would need to set the env var as stated above for this code update to have effect.

[] It includes documentation for these changes in `/doc`.