### PR TITLE
add support for capturing system sound (chrome-windows only)

### DIFF
--- a/erizo_controller/erizoClient/src/utils/ConnectionHelpers.js
+++ b/erizo_controller/erizoClient/src/utils/ConnectionHelpers.js
@@ -39,6 +39,14 @@ const GetUserMedia = (config, callback = () => {}, error = () => {}) => {
         screenConfig.video.mandatory = config.video.mandatory || {};
         screenConfig.video.mandatory.chromeMediaSource = 'desktop';
         screenConfig.video.mandatory.chromeMediaSourceId = config.desktopStreamId;
+        if (config.audio) {
+          screenConfig.audio = {
+            mandatory: {
+              chromeMediaSource: 'system',
+              chromeMediaSourceId: config.desktopStreamId,
+            },
+          };
+        }
         getUserMedia(screenConfig, callback, error);
         break;
       case 'mozilla':
@@ -66,6 +74,14 @@ const GetUserMedia = (config, callback = () => {}, error = () => {}) => {
           screenConfig.video.mandatory = screenConfig.video.mandatory || {};
           screenConfig.video.mandatory.chromeMediaSource = 'desktop';
           screenConfig.video.mandatory.chromeMediaSourceId = config.desktopStreamId;
+          if (config.audio) {
+            screenConfig.audio = {
+              mandatory: {
+                chromeMediaSource: 'system',
+                chromeMediaSourceId: config.desktopStreamId,
+              },
+            };
+          }
           getUserMedia(screenConfig, callback, error);
         } else {
           // Default extensionId - this extension is only usable in our server,
@@ -94,6 +110,14 @@ const GetUserMedia = (config, callback = () => {}, error = () => {}) => {
                 } else {
                   screenConfig = { video: { mandatory: { chromeMediaSource: 'desktop',
                     chromeMediaSourceId: theId } } };
+                }
+                if (response.audio) {
+                  screenConfig.audio = {
+                    mandatory: {
+                      chromeMediaSource: 'system',
+                      chromeMediaSourceId: config.theId,
+                    },
+                  };
                 }
                 getUserMedia(screenConfig, callback, error);
               });


### PR DESCRIPTION
This patch enables to capture also system audio when capturing screen. You need to pass audio as source ([described here](https://developer.chrome.com/extensions/desktopCapture#method-chooseDesktopMedia)):
```
chrome.desktopCapture.chooseDesktopMedia(
  ['screen', 'window', 'tab', 'audio'],
  sender.tab,
  (streamId, options) => {
    callback({ streamId, audio: options.canRequestAudioTrack });
  }
);
```
As result an audio checkbox will appear on the sharing screen dialog:
![image](https://user-images.githubusercontent.com/859377/43684046-dcc91f5a-98ad-11e8-840f-a23b36320319.png)

This feature only works in Chrome for Windows and Chrome OS as [discussed here](https://bugs.chromium.org/p/chromium/issues/detail?id=223639).

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.