### PR TITLE
Fix second temporal layer in vp8 simulcast

### DIFF
--- a/erizo/src/erizo/MediaDefinitions.h
+++ b/erizo/src/erizo/MediaDefinitions.h
@@ -24,19 +24,19 @@ struct DataPacket {
 
   DataPacket(int comp_, const char *data_, int length_, packetType type_, uint64_t received_time_ms_) :
     comp{comp_}, length{length_}, type{type_}, received_time_ms{received_time_ms_}, is_keyframe{false},
-    ending_of_layer_frame{false}, picture_id{-1} {
+    ending_of_layer_frame{false}, picture_id{-1}, tl0_pic_idx{-1} {
       memcpy(data, data_, length_);
   }
 
   DataPacket(int comp_, const char *data_, int length_, packetType type_) :
     comp{comp_}, length{length_}, type{type_}, received_time_ms{ClockUtils::timePointToMs(clock::now())},
-    is_keyframe{false}, ending_of_layer_frame{false}, picture_id{-1} {
+    is_keyframe{false}, ending_of_layer_frame{false}, picture_id{-1}, tl0_pic_idx{-1} {
       memcpy(data, data_, length_);
   }
 
   DataPacket(int comp_, const unsigned char *data_, int length_) :
     comp{comp_}, length{length_}, type{VIDEO_PACKET}, received_time_ms{ClockUtils::timePointToMs(clock::now())},
-    is_keyframe{false}, ending_of_layer_frame{false}, picture_id{-1} {
+    is_keyframe{false}, ending_of_layer_frame{false}, picture_id{-1}, tl0_pic_idx{-1} {
       memcpy(data, data_, length_);
   }
 
@@ -66,6 +66,7 @@ struct DataPacket {
   bool is_keyframe;  // Note: It can be just a keyframe first packet in VP8
   bool ending_of_layer_frame;
   int picture_id;
+  int tl0_pic_idx;
   std::string codec;
   unsigned int clock_rate = 0;
 };

--- a/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
+++ b/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
@@ -93,8 +93,8 @@ void LayerDetectorHandler::parseLayerInfoFromVP8(std::shared_ptr<DataPacket> pac
   packet->compatible_temporal_layers = {};
   switch (payload->tID) {
     case 0: addTemporalLayerAndCalculateRate(packet, 0, payload->beginningOfPartition);
-    case 2: addTemporalLayerAndCalculateRate(packet, 1, payload->beginningOfPartition);
-    case 1: addTemporalLayerAndCalculateRate(packet, 2, payload->beginningOfPartition);
+    case 1: addTemporalLayerAndCalculateRate(packet, 1, payload->beginningOfPartition);
+    case 2: addTemporalLayerAndCalculateRate(packet, 2, payload->beginningOfPartition);
     // case 3 and beyond are not handled because Chrome only
     // supports 3 temporal scalability today (03/15/17)
       break;

--- a/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
+++ b/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
@@ -90,6 +90,9 @@ void LayerDetectorHandler::parseLayerInfoFromVP8(std::shared_ptr<DataPacket> pac
   if (payload->hasPictureID) {
     packet->picture_id = payload->pictureID;
   }
+  if (payload->hasTl0PicIdx) {
+    packet->tl0_pic_idx = payload->tl0PicIdx;
+  }
   packet->compatible_temporal_layers = {};
   switch (payload->tID) {
     case 0: addTemporalLayerAndCalculateRate(packet, 0, payload->beginningOfPartition);

--- a/erizo/src/erizo/rtp/QualityFilterHandler.cpp
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.cpp
@@ -12,13 +12,13 @@ DEFINE_LOGGER(QualityFilterHandler, "rtp.QualityFilterHandler");
 constexpr duration kSwitchTimeout = std::chrono::seconds(3);
 
 QualityFilterHandler::QualityFilterHandler()
-  : stream_{nullptr}, enabled_{true}, initialized_{false},
+  : picture_id_translator_{511, 250, 15}, stream_{nullptr}, enabled_{true}, initialized_{false},
   receiving_multiple_ssrc_{false}, changing_spatial_layer_{false}, is_scalable_{false},
   target_spatial_layer_{0},
   future_spatial_layer_{-1}, target_temporal_layer_{0},
   video_sink_ssrc_{0}, video_source_ssrc_{0}, last_ssrc_received_{0},
   max_video_bw_{0}, last_timestamp_sent_{0}, timestamp_offset_{0},
-  time_change_started_{clock::now()}, picture_id_offset_{0}, last_picture_id_sent_{0} {}
+  time_change_started_{clock::now()}, tl0_pic_idx_offset_{0}, last_tl0_pic_idx_sent_{0} {}
 
 void QualityFilterHandler::enable() {
   enabled_ = true;
@@ -105,12 +105,21 @@ void QualityFilterHandler::detectVideoScalability(const std::shared_ptr<DataPack
   }
 }
 
-void QualityFilterHandler::updatePictureID(const std::shared_ptr<DataPacket> &packet) {
+void QualityFilterHandler::updatePictureID(const std::shared_ptr<DataPacket> &packet, int new_picture_id) {
   if (packet->codec == "VP8") {
     RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
     unsigned char* start_buffer = reinterpret_cast<unsigned char*> (packet->data);
     start_buffer = start_buffer + rtp_header->getHeaderLength();
-    RtpVP8Parser::setVP8PictureID(start_buffer, packet->length - rtp_header->getHeaderLength(), last_picture_id_sent_);
+    RtpVP8Parser::setVP8PictureID(start_buffer, packet->length - rtp_header->getHeaderLength(), new_picture_id);
+  }
+}
+
+void QualityFilterHandler::updateTL0PicIdx(const std::shared_ptr<DataPacket> &packet, uint8_t new_tl0_pic_idx) {
+  if (packet->codec == "VP8") {
+    RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
+    unsigned char* start_buffer = reinterpret_cast<unsigned char*> (packet->data);
+    start_buffer = start_buffer + rtp_header->getHeaderLength();
+    RtpVP8Parser::setVP8TL0PicIdx(start_buffer, packet->length - rtp_header->getHeaderLength(), new_tl0_pic_idx);
   }
 }
 
@@ -140,6 +149,7 @@ void QualityFilterHandler::write(Context *ctx, std::shared_ptr<DataPacket> packe
     uint32_t ssrc = rtp_header->getSSRC();
     uint16_t sequence_number = rtp_header->getSeqNumber();
     int picture_id = packet->picture_id;
+    uint8_t tl0_pic_idx = packet->tl0_pic_idx;
 
     if (last_ssrc_received_ != 0 && ssrc != last_ssrc_received_) {
       receiving_multiple_ssrc_ = true;
@@ -150,6 +160,7 @@ void QualityFilterHandler::write(Context *ctx, std::shared_ptr<DataPacket> packe
     if (!packet->belongsToSpatialLayer(target_spatial_layer_)) {
       if (!receiving_multiple_ssrc_) {
         translator_.get(sequence_number, true);
+        picture_id_translator_.get(picture_id, true);
       }
       return;
     }
@@ -158,21 +169,28 @@ void QualityFilterHandler::write(Context *ctx, std::shared_ptr<DataPacket> packe
 
     if (checkSSRCChange(ssrc)) {
       translator_.reset();
+      picture_id_translator_.reset();
       if (last_timestamp_sent_ > 0) {
         timestamp_offset_ = last_timestamp_sent_ - new_timestamp + 1;
       }
-      if (last_picture_id_sent_ > 0) {
-        picture_id_offset_ = last_picture_id_sent_ - picture_id + 1;
+      if (last_tl0_pic_idx_sent_ > 0) {
+        tl0_pic_idx_offset_ = last_tl0_pic_idx_sent_ - tl0_pic_idx + 1;
       }
     }
 
     if (!packet->belongsToTemporalLayer(target_temporal_layer_)) {
       translator_.get(sequence_number, true);
+      picture_id_translator_.get(picture_id, true);
       return;
     }
 
     SequenceNumber sequence_number_info = translator_.get(sequence_number, false);
     if (sequence_number_info.type != SequenceNumberType::Valid) {
+      return;
+    }
+
+    SequenceNumber picture_id_info = picture_id_translator_.get(picture_id, false);
+    if (picture_id_info.type != SequenceNumberType::Valid) {
       return;
     }
 
@@ -186,13 +204,14 @@ void QualityFilterHandler::write(Context *ctx, std::shared_ptr<DataPacket> packe
     last_timestamp_sent_ = new_timestamp + timestamp_offset_;
     rtp_header->setTimestamp(last_timestamp_sent_);
 
-    last_picture_id_sent_ = picture_id + picture_id_offset_;
-    updatePictureID(packet);
+    updatePictureID(packet, picture_id_info.output & 0x7FFF);
 
-    removeVP8OptionalPayload(packet);
+    last_tl0_pic_idx_sent_ = tl0_pic_idx + tl0_pic_idx_offset_;
+    updateTL0PicIdx(packet, last_tl0_pic_idx_sent_);
+    // removeVP8OptionalPayload(packet);  // TODO(javier): uncomment this line in case of issues with pictureId
   }
 
-  // TODO(javier): Handle SRs and translate Sequence Numbers?
+  // TODO(javier): Handle SRs?
 
   ctx->fireWrite(packet);
 }

--- a/erizo/src/erizo/rtp/QualityFilterHandler.h
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.h
@@ -42,6 +42,7 @@ class QualityFilterHandler: public Handler, public std::enable_shared_from_this<
   void changeSpatialLayerOnKeyframeReceived(const std::shared_ptr<DataPacket> &packet);
   void detectVideoScalability(const std::shared_ptr<DataPacket> &packet);
   void updatePictureID(const std::shared_ptr<DataPacket> &packet);
+  void removeVP8OptionalPayload(const std::shared_ptr<DataPacket> &packet);
 
  private:
   std::shared_ptr<QualityManager> quality_manager_;

--- a/erizo/src/erizo/rtp/QualityFilterHandler.h
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.h
@@ -41,12 +41,14 @@ class QualityFilterHandler: public Handler, public std::enable_shared_from_this<
   bool checkSSRCChange(uint32_t ssrc);
   void changeSpatialLayerOnKeyframeReceived(const std::shared_ptr<DataPacket> &packet);
   void detectVideoScalability(const std::shared_ptr<DataPacket> &packet);
-  void updatePictureID(const std::shared_ptr<DataPacket> &packet);
+  void updatePictureID(const std::shared_ptr<DataPacket> &packet, int new_picture_id);
+  void updateTL0PicIdx(const std::shared_ptr<DataPacket> &packet, uint8_t new_tl0_pic_idx);
   void removeVP8OptionalPayload(const std::shared_ptr<DataPacket> &packet);
 
  private:
   std::shared_ptr<QualityManager> quality_manager_;
   SequenceNumberTranslator translator_;
+  SequenceNumberTranslator picture_id_translator_;
   MediaStream *stream_;
   bool enabled_;
   bool initialized_;
@@ -63,8 +65,8 @@ class QualityFilterHandler: public Handler, public std::enable_shared_from_this<
   uint32_t last_timestamp_sent_;
   uint32_t timestamp_offset_;
   time_point time_change_started_;
-  int picture_id_offset_;
-  int last_picture_id_sent_;
+  uint8_t tl0_pic_idx_offset_;
+  uint8_t last_tl0_pic_idx_sent_;
 };
 }  // namespace erizo
 

--- a/erizo/src/erizo/rtp/RtpUtils.cpp
+++ b/erizo/src/erizo/rtp/RtpUtils.cpp
@@ -1,5 +1,6 @@
 #include "rtp/RtpUtils.h"
 
+#include <cmath>
 #include <memory>
 
 namespace erizo {
@@ -8,8 +9,15 @@ namespace erizo {
 constexpr int kMaxPacketSize = 1500;
 
 bool RtpUtils::sequenceNumberLessThan(uint16_t first, uint16_t last) {
+  return RtpUtils::numberLessThan(first, last, 16);
+}
+
+bool RtpUtils::numberLessThan(uint16_t first, uint16_t last, int bits) {
   uint16_t result = first - last;
-  return result > 0xF000;
+  uint16_t mark = std::pow(2, bits) - 1;
+  result = result & mark;
+  uint16_t threshold = (bits > 4) ? std::pow(2, bits - 4) - 1 : std::pow(2, bits) - 1;
+  return result > threshold;
 }
 
 void RtpUtils::updateREMB(RtcpHeader *chead, uint bitrate) {

--- a/erizo/src/erizo/rtp/RtpUtils.h
+++ b/erizo/src/erizo/rtp/RtpUtils.h
@@ -15,6 +15,8 @@ class RtpUtils {
  public:
   static bool sequenceNumberLessThan(uint16_t first, uint16_t second);
 
+  static bool numberLessThan(uint16_t first, uint16_t last, int bits);
+
   static void forEachRtcpBlock(std::shared_ptr<DataPacket> packet, std::function<void(RtcpHeader*)> f);
 
   static void updateREMB(RtcpHeader *chead, uint bitrate);

--- a/erizo/src/erizo/rtp/RtpVP8Parser.cpp
+++ b/erizo/src/erizo/rtp/RtpVP8Parser.cpp
@@ -188,6 +188,98 @@ void RtpVP8Parser::setVP8PictureID(unsigned char* data, int data_length, int pic
   }
 }
 
+int RtpVP8Parser::removePictureID(unsigned char* data, int data_length) {
+  unsigned char* data_ptr = data;
+  int previous_data_length = data_length;
+
+  bool extension = (*data_ptr & 0x80) ? true : false;  // X bit
+
+  data_ptr++;
+  data_length--;
+
+  if (extension) {
+    if (data_length <= 0) {
+      return previous_data_length;
+    }
+    bool has_picture_id = (*data_ptr & 0x80) ? true : false;  // I bit
+    data_ptr[0] = *data_ptr & 0x7F;  // unset I bit
+    data_ptr++;
+    data_length--;
+
+    if (has_picture_id) {
+      if (data_length <= 0) {
+        return previous_data_length;
+      }
+      int picture_id_len = (*data_ptr & 0x80) ? 2 : 1;
+      if (picture_id_len > data_length) return previous_data_length;
+      memmove(data_ptr, data_ptr + picture_id_len, data_length - picture_id_len);
+      previous_data_length -= picture_id_len;
+    }
+  }
+
+  return previous_data_length;
+}
+
+int RtpVP8Parser::removeTl0PicIdx(unsigned char* data, int data_length) {
+  unsigned char* data_ptr = data;
+  int previous_data_length = data_length;
+
+  bool extension = (*data_ptr & 0x80) ? true : false;  // X bit
+
+  data_ptr++;
+  data_length--;
+
+  if (extension) {
+    if (data_length <= 0) {
+      return previous_data_length;
+    }
+    bool has_tl0_pic_idx = (*data_ptr & 0x40) ? true : false;  // L bit
+    data_ptr[0] = *data_ptr & 0xBF;  // unset L bit
+    data_ptr++;
+    data_length--;
+
+    if (has_tl0_pic_idx) {
+      if (data_length <= 0) {
+        return previous_data_length;
+      }
+      memmove(data_ptr, data_ptr + 1, data_length - 1);
+      previous_data_length--;
+    }
+  }
+  return previous_data_length;
+}
+
+int RtpVP8Parser::removeTIDAndKeyIdx(unsigned char* data, int data_length) {
+  unsigned char* data_ptr = data;
+  int previous_data_length = data_length;
+
+  bool extension = (*data_ptr & 0x80) ? true : false;  // X bit
+
+  data_ptr++;
+  data_length--;
+
+  if (extension) {
+    if (data_length <= 0) {
+      return previous_data_length;
+    }
+    bool has_tid = (*data_ptr & 0x20) ? true : false;  // T bit
+    bool has_key_idx = (*data_ptr & 0x10) ? true : false;  // K bit
+    data_ptr[0] = *data_ptr & 0xDF;  // unset T bit
+    data_ptr[0] = *data_ptr & 0xEF;  // unset T bit
+    data_ptr++;
+    data_length--;
+
+    if (has_tid || has_key_idx) {
+      if (data_length <= 0) {
+        return previous_data_length;
+      }
+      memmove(data_ptr, data_ptr + 1, data_length - 1);
+      previous_data_length--;
+    }
+  }
+  return previous_data_length;
+}
+
 RTPPayloadVP8* RtpVP8Parser::parseVP8(unsigned char* data, int dataLength) {
   // ELOG_DEBUG("Parsing VP8 %d bytes", dataLength);
   RTPPayloadVP8* vp8 = new RTPPayloadVP8;  // = &parsedPacket.info.VP8;

--- a/erizo/src/erizo/rtp/RtpVP8Parser.cpp
+++ b/erizo/src/erizo/rtp/RtpVP8Parser.cpp
@@ -188,6 +188,41 @@ void RtpVP8Parser::setVP8PictureID(unsigned char* data, int data_length, int pic
   }
 }
 
+void RtpVP8Parser::setVP8TL0PicIdx(unsigned char* data, int data_length, uint8_t tl0_pic_idx) {
+  unsigned char* data_ptr = data;
+
+  bool extension = (*data_ptr & 0x80) ? true : false;  // X bit
+
+  data_ptr++;
+  data_length--;
+
+  if (extension) {
+    if (data_length <= 0) {
+      return;
+    }
+    bool has_picture_id = (*data_ptr & 0x80) ? true : false;  // I bit
+    bool has_tl0_pic_idx = (*data_ptr & 0x40) ? true : false;  // L bit
+    data_ptr++;
+    data_length--;
+
+    if (has_picture_id) {
+      if (data_length <= 0) {
+        return;
+      }
+      int picture_id_len = (*data_ptr & 0x80) ? 2 : 1;
+      data_ptr += picture_id_len;
+      data_length -= picture_id_len;
+    }
+
+    if (has_tl0_pic_idx) {
+      if (data_length <= 0) {
+        return;
+      }
+      data_ptr[0] = tl0_pic_idx;
+    }
+  }
+}
+
 int RtpVP8Parser::removePictureID(unsigned char* data, int data_length) {
   unsigned char* data_ptr = data;
   int previous_data_length = data_length;
@@ -233,10 +268,20 @@ int RtpVP8Parser::removeTl0PicIdx(unsigned char* data, int data_length) {
     if (data_length <= 0) {
       return previous_data_length;
     }
+    bool has_picture_id = (*data_ptr & 0x80) ? true : false;  // I bit
     bool has_tl0_pic_idx = (*data_ptr & 0x40) ? true : false;  // L bit
     data_ptr[0] = *data_ptr & 0xBF;  // unset L bit
     data_ptr++;
     data_length--;
+
+    if (has_picture_id) {
+      if (data_length <= 0) {
+        return previous_data_length;
+      }
+      int picture_id_len = (*data_ptr & 0x80) ? 2 : 1;
+      data_ptr += picture_id_len;
+      data_length -= picture_id_len;
+    }
 
     if (has_tl0_pic_idx) {
       if (data_length <= 0) {
@@ -262,12 +307,31 @@ int RtpVP8Parser::removeTIDAndKeyIdx(unsigned char* data, int data_length) {
     if (data_length <= 0) {
       return previous_data_length;
     }
+    bool has_picture_id = (*data_ptr & 0x80) ? true : false;  // I bit
+    bool has_tl0_pic_idx = (*data_ptr & 0x40) ? true : false;  // L bit
     bool has_tid = (*data_ptr & 0x20) ? true : false;  // T bit
     bool has_key_idx = (*data_ptr & 0x10) ? true : false;  // K bit
     data_ptr[0] = *data_ptr & 0xDF;  // unset T bit
     data_ptr[0] = *data_ptr & 0xEF;  // unset T bit
     data_ptr++;
     data_length--;
+
+    if (has_picture_id) {
+      if (data_length <= 0) {
+        return previous_data_length;
+      }
+      int picture_id_len = (*data_ptr & 0x80) ? 2 : 1;
+      data_ptr += picture_id_len;
+      data_length -= picture_id_len;
+    }
+
+    if (has_tl0_pic_idx) {
+      if (data_length <= 0) {
+        return previous_data_length;
+      }
+      data_ptr++;
+      data_length--;
+    }
 
     if (has_tid || has_key_idx) {
       if (data_length <= 0) {

--- a/erizo/src/erizo/rtp/RtpVP8Parser.h
+++ b/erizo/src/erizo/rtp/RtpVP8Parser.h
@@ -37,6 +37,9 @@ class RtpVP8Parser {
   RtpVP8Parser();
   virtual ~RtpVP8Parser();
   static void setVP8PictureID(unsigned char* data, int data_length, int picture_id);
+  static int removePictureID(unsigned char* data, int data_length);
+  static int removeTl0PicIdx(unsigned char* data, int data_length);
+  static int removeTIDAndKeyIdx(unsigned char* data, int data_length);
   erizo::RTPPayloadVP8* parseVP8(unsigned char* data, int datalength);
 };
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/RtpVP8Parser.h
+++ b/erizo/src/erizo/rtp/RtpVP8Parser.h
@@ -37,6 +37,7 @@ class RtpVP8Parser {
   RtpVP8Parser();
   virtual ~RtpVP8Parser();
   static void setVP8PictureID(unsigned char* data, int data_length, int picture_id);
+  static void setVP8TL0PicIdx(unsigned char* data, int data_length, uint8_t tl0_pic_idx);
   static int removePictureID(unsigned char* data, int data_length);
   static int removeTl0PicIdx(unsigned char* data, int data_length);
   static int removeTIDAndKeyIdx(unsigned char* data, int data_length);

--- a/erizo/src/erizo/rtp/SequenceNumberTranslator.h
+++ b/erizo/src/erizo/rtp/SequenceNumberTranslator.h
@@ -31,6 +31,7 @@ class SequenceNumberTranslator: public Service, public std::enable_shared_from_t
 
  public:
   SequenceNumberTranslator();
+  SequenceNumberTranslator(uint16_t max_number_in_buffer, uint16_t max_distance, uint16_t bits);
 
   SequenceNumber get(uint16_t input_sequence_number) const;
   SequenceNumber get(uint16_t input_sequence_number, bool skip);
@@ -44,6 +45,7 @@ class SequenceNumberTranslator: public Service, public std::enable_shared_from_t
   SequenceNumber& internalGet(uint16_t input_sequence_number);
   SequenceNumber& internalReverse(uint16_t output_sequence_number);
   void updateLastOutputSequenceNumber(bool skip, uint16_t output_sequence_number);
+  uint16_t boundedSequenceNumber(const uint16_t& input);
 
  private:
   std::vector<SequenceNumber> in_out_buffer_;
@@ -51,6 +53,10 @@ class SequenceNumberTranslator: public Service, public std::enable_shared_from_t
   uint16_t first_input_sequence_number_;
   uint16_t last_input_sequence_number_;
   uint16_t last_output_sequence_number_;
+  uint16_t max_number_in_buffer_;
+  uint16_t max_distance_;
+  uint16_t bits_;
+  uint32_t mask_;
   uint16_t offset_;
   bool initialized_;
   bool reset_;

--- a/erizo/src/test/rtp/LayerDetectorHandlerTest.cpp
+++ b/erizo/src/test/rtp/LayerDetectorHandlerTest.cpp
@@ -144,11 +144,11 @@ INSTANTIATE_TEST_CASE_P(
     std::make_tuple(kArbitrarySsrc1,   0,                0,      true,                2,     true),
 
     std::make_tuple(kArbitrarySsrc1,   2,                0,      true,                0,    false),
-    std::make_tuple(kArbitrarySsrc1,   2,                0,      true,                1,     true),
+    std::make_tuple(kArbitrarySsrc1,   2,                0,      true,                1,    false),
     std::make_tuple(kArbitrarySsrc1,   2,                0,      true,                2,     true),
 
     std::make_tuple(kArbitrarySsrc1,   1,                0,      true,                0,    false),
-    std::make_tuple(kArbitrarySsrc1,   1,                0,      true,                1,    false),
+    std::make_tuple(kArbitrarySsrc1,   1,                0,      true,                1,     true),
     std::make_tuple(kArbitrarySsrc1,   1,                0,      true,                2,     true),
 
     std::make_tuple(kArbitrarySsrc2,   0,                1,      true,                0,     true),
@@ -157,9 +157,9 @@ INSTANTIATE_TEST_CASE_P(
     std::make_tuple(kArbitrarySsrc2,   0,                1,      true,                2,     true),
 
     std::make_tuple(kArbitrarySsrc2,   2,                1,      true,                0,    false),
-    std::make_tuple(kArbitrarySsrc2,   2,                1,      true,                1,     true),
+    std::make_tuple(kArbitrarySsrc2,   2,                1,      true,                1,    false),
     std::make_tuple(kArbitrarySsrc2,   2,                1,      true,                2,     true),
 
     std::make_tuple(kArbitrarySsrc2,   1,                1,      true,                0,    false),
-    std::make_tuple(kArbitrarySsrc2,   1,                1,      true,                1,    false),
+    std::make_tuple(kArbitrarySsrc2,   1,                1,      true,                1,     true),
     std::make_tuple(kArbitrarySsrc2,   1,                1,      true,                2,     true)));

--- a/erizo/src/test/rtp/SequenceNumberTranslatorTest.cpp
+++ b/erizo/src/test/rtp/SequenceNumberTranslatorTest.cpp
@@ -6,6 +6,7 @@
 #include <MediaDefinitions.h>
 #include <WebRtcConnection.h>
 
+#include <cmath>
 #include <queue>
 #include <string>
 #include <vector>
@@ -78,11 +79,12 @@ TEST_P(SequenceNumberTranslatorTest, shouldReturnRightOutputSequenceNumbers) {
   }
 }
 
-std::vector<Packet> getLongQueue(int size, uint16_t first_seq_num = 0,
+std::vector<Packet> getLongQueue(int size, int bits = 16, uint16_t first_seq_num = 0,
          PacketState state = PacketState::Forward, SequenceNumberType type = SequenceNumberType::Valid) {
   std::vector<Packet> queue;
+  int mask = std::pow(2, bits);
   for (int i = 0; i <= size; i++) {
-    int input_sequence_number = (i + first_seq_num) % 65535;
+    int input_sequence_number = (i + first_seq_num) % mask;
     queue.push_back(Packet{input_sequence_number, state,
                            input_sequence_number, type});
   }
@@ -271,20 +273,251 @@ INSTANTIATE_TEST_CASE_P(
 
     // Support multiple loops with skip packets
     concat({             {     5, PacketState::Forward,               5, SequenceNumberType::Valid}},
-                         concat(getLongQueue(65535 * 2, 6, PacketState::Skip, SequenceNumberType::Skip),
+                         concat(getLongQueue(65536 * 2, 16, 6, PacketState::Skip, SequenceNumberType::Skip),
                         {{     7, PacketState::Forward,               6, SequenceNumberType::Valid}})),
 
     // Support multiple loops with skip and generated packet
     concat({             {     5, PacketState::Forward,               5, SequenceNumberType::Valid}},
-                         concat(getLongQueue(65535 * 2, 6, PacketState::Skip, SequenceNumberType::Skip),
+                         concat(getLongQueue(65536 * 2, 16, 6, PacketState::Skip, SequenceNumberType::Skip),
                         {{     0, PacketState::Generate,              6, SequenceNumberType::Generated},
                          {     7, PacketState::Forward,               7, SequenceNumberType::Valid}})),
 
     // Support multiple loops with generated and a skip packet
     concat({             {     5, PacketState::Forward,               5, SequenceNumberType::Valid}},
-                        concat(getLongQueue(65535 * 2, 0, PacketState::Generate, SequenceNumberType::Generated),
+                        concat(getLongQueue(65535 * 2, 16, 0, PacketState::Generate, SequenceNumberType::Generated),
                         {{     6, PacketState::Skip,                  5, SequenceNumberType::Skip},
                          {     7, PacketState::Forward,               5, SequenceNumberType::Valid}})),
 
     // Support multiple loops with valid packets
-    getLongQueue(65535 * 2)));
+    getLongQueue(65536 * 2)));
+
+
+class PictureIdTranslatorTest : public ::testing::TestWithParam<std::vector<Packet>> {
+ public:
+  PictureIdTranslatorTest() : translator{512, 250, 15} {
+    queue = GetParam();
+  }
+ protected:
+  void SetUp() {
+  }
+
+  void TearDown() {
+  }
+
+  SequenceNumberTranslator translator;
+  std::vector<Packet> queue;
+};
+
+TEST_P(PictureIdTranslatorTest, shouldReturnRightOutputSequenceNumbers) {
+  for (Packet packet : queue) {
+    bool skip = packet.state == PacketState::Skip;
+    SequenceNumber output;
+    if (packet.state == PacketState::Reset) {
+      translator.reset();
+      continue;
+    } else if (packet.state == PacketState::Generate) {
+      output = translator.generate();
+    } else {
+      output = translator.get(packet.sequence_number, skip);
+    }
+    if (output.type == SequenceNumberType::Valid) {
+      EXPECT_THAT(output.output, Eq(packet.expected_output));
+    }
+    EXPECT_THAT(output.type, Eq(packet.expected_type));
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(
+  PictureIdScenarios, PictureIdTranslatorTest, testing::Values(
+    //                     input                        expected_output
+    std::vector<Packet>({{     5, PacketState::Forward,               5, SequenceNumberType::Valid},
+                         {     6, PacketState::Forward,               6, SequenceNumberType::Valid},
+                         {     7, PacketState::Forward,               7, SequenceNumberType::Valid},
+                         {     8, PacketState::Forward,               8, SequenceNumberType::Valid}}),
+
+    // Packet reordering
+    std::vector<Packet>({{     5, PacketState::Forward,               5, SequenceNumberType::Valid},
+                         {     6, PacketState::Forward,               6, SequenceNumberType::Valid},
+                         {     8, PacketState::Forward,               8, SequenceNumberType::Valid},
+                         {     7, PacketState::Forward,               7, SequenceNumberType::Valid}}),
+
+    // Skip packets
+    std::vector<Packet>({{     5, PacketState::Forward,               5, SequenceNumberType::Valid},
+                         {     6, PacketState::Forward,               6, SequenceNumberType::Valid},
+                         {     7, PacketState::Skip,                  7, SequenceNumberType::Skip},
+                         {     8, PacketState::Forward,               7, SequenceNumberType::Valid},
+                         {     9, PacketState::Forward,               8, SequenceNumberType::Valid}}),
+
+    // Discard packets
+    std::vector<Packet>({{     5, PacketState::Forward,               5, SequenceNumberType::Valid},
+                         {     6, PacketState::Forward,               6, SequenceNumberType::Valid},
+                         {     8, PacketState::Forward,               8, SequenceNumberType::Valid},
+                         {     7, PacketState::Skip,                  7, SequenceNumberType::Discard},
+                         {     9, PacketState::Forward,               9, SequenceNumberType::Valid}}),
+
+
+    // Retransmissions
+    std::vector<Packet>({{     5, PacketState::Forward,               5, SequenceNumberType::Valid},
+                         {     6, PacketState::Forward,               6, SequenceNumberType::Valid},
+                         {     7, PacketState::Forward,               7, SequenceNumberType::Valid},
+                         {     8, PacketState::Forward,               8, SequenceNumberType::Valid},
+                         {     7, PacketState::Forward,               7, SequenceNumberType::Valid}}),
+
+    // Retransmissions of skipped packets
+    std::vector<Packet>({{     5, PacketState::Forward,               5, SequenceNumberType::Valid},
+                         {     6, PacketState::Forward,               6, SequenceNumberType::Valid},
+                         {     7, PacketState::Skip,                  7, SequenceNumberType::Skip},
+                         {     8, PacketState::Forward,               7, SequenceNumberType::Valid},
+                         {     7, PacketState::Skip,                  7, SequenceNumberType::Skip}}),
+
+    // Rollover
+    std::vector<Packet>({{ 32767, PacketState::Forward,           32767, SequenceNumberType::Valid},
+                         {     0, PacketState::Forward,               0, SequenceNumberType::Valid}}),
+
+    // Rollover with packets reordering
+    std::vector<Packet>({{ 32767, PacketState::Forward,           32767, SequenceNumberType::Valid},
+                         {     1, PacketState::Forward,               1, SequenceNumberType::Valid},
+                         {     0, PacketState::Forward,               0, SequenceNumberType::Valid}}),
+
+    // Rollover with packets skipped
+    std::vector<Packet>({{ 32767, PacketState::Forward,           32767, SequenceNumberType::Valid},
+                         {     0, PacketState::Skip,                  0, SequenceNumberType::Skip},
+                         {     1, PacketState::Forward,               0, SequenceNumberType::Valid},
+                         {     2, PacketState::Forward,               1, SequenceNumberType::Valid}}),
+
+    // Rollover with packets skipped
+    std::vector<Packet>({{ 32767, PacketState::Forward,           32767, SequenceNumberType::Valid},
+                         {     1, PacketState::Forward,               1, SequenceNumberType::Valid},
+                         {     0, PacketState::Skip,                  0, SequenceNumberType::Discard},
+                         {     2, PacketState::Forward,               2, SequenceNumberType::Valid}}),
+
+    // Reset after having received skipped packets
+    std::vector<Packet>({{  5059, PacketState::Skip,               5059, SequenceNumberType::Skip},
+                         {     0, PacketState::Reset,                 0, SequenceNumberType::Skip},
+                         {  1032, PacketState::Skip,               1032, SequenceNumberType::Skip},
+                         {     0, PacketState::Reset,                 0, SequenceNumberType::Skip},
+                         { 23537, PacketState::Forward,           23537, SequenceNumberType::Valid}}),
+
+
+    // Reset after having received skipped packets
+    std::vector<Packet>({{  5059, PacketState::Skip,               5059, SequenceNumberType::Skip},
+                         {     0, PacketState::Reset,                 0, SequenceNumberType::Skip},
+                         { 23537, PacketState::Forward,           23537, SequenceNumberType::Valid}}),
+
+    // Reset after having received skipped packets
+    std::vector<Packet>({{  5058, PacketState::Forward,            5058, SequenceNumberType::Valid},
+                         {  5059, PacketState::Skip,               5059, SequenceNumberType::Skip},
+                         {     0, PacketState::Reset,                 0, SequenceNumberType::Skip},
+                         { 23537, PacketState::Forward,            5059, SequenceNumberType::Valid}}),
+
+    //                     input                        expected_output
+    std::vector<Packet>({{ 20000, PacketState::Forward,           20000, SequenceNumberType::Valid},
+                         {     0, PacketState::Reset,                 0, SequenceNumberType::Skip},
+                         { 23537, PacketState::Forward,           20001, SequenceNumberType::Valid},
+                         { 23538, PacketState::Forward,           20002, SequenceNumberType::Valid}}),
+
+    //                     input                        expected_output
+    std::vector<Packet>({{     0, PacketState::Generate,              1, SequenceNumberType::Generated},
+                         {     6, PacketState::Forward,               2, SequenceNumberType::Valid},
+                         {     7, PacketState::Forward,               3, SequenceNumberType::Valid},
+                         {     8, PacketState::Forward,               4, SequenceNumberType::Valid}}),
+
+    //                     input                        expected_output
+    std::vector<Packet>({{     6, PacketState::Forward,               6, SequenceNumberType::Valid},
+                         {    10, PacketState::Skip,                 10, SequenceNumberType::Skip},
+                         {     0, PacketState::Reset,                 0, SequenceNumberType::Skip},
+                         {   301, PacketState::Skip,                  7, SequenceNumberType::Skip},
+                         {     0, PacketState::Reset,                 0, SequenceNumberType::Skip},
+                         {   901, PacketState::Forward,               7, SequenceNumberType::Valid}}),
+
+    //                     input                        expected_output
+    std::vector<Packet>({{     6, PacketState::Forward,               6, SequenceNumberType::Valid},
+                         {    10, PacketState::Skip,                 10, SequenceNumberType::Skip},
+                         {     9, PacketState::Forward,               9, SequenceNumberType::Valid},
+                         {     0, PacketState::Reset,                 0, SequenceNumberType::Skip},
+                         {   301, PacketState::Skip,                301, SequenceNumberType::Skip},
+                         {     0, PacketState::Reset,                 0, SequenceNumberType::Skip},
+                         {   901, PacketState::Forward,              10, SequenceNumberType::Valid}}),
+
+    //                     input                        expected_output
+    std::vector<Packet>({{     6, PacketState::Forward,               6, SequenceNumberType::Valid},
+                         {    10, PacketState::Skip,                 10, SequenceNumberType::Skip},
+                         {     0, PacketState::Generate,              7, SequenceNumberType::Generated},
+                         {     0, PacketState::Reset,                 0, SequenceNumberType::Skip},
+                         {   301, PacketState::Skip,                301, SequenceNumberType::Skip},
+                         {     0, PacketState::Reset,                 0, SequenceNumberType::Skip},
+                         {   901, PacketState::Forward,               8, SequenceNumberType::Valid}}),
+
+    //                     input                        expected_output
+    std::vector<Packet>({{  5059, PacketState::Skip,               5059, SequenceNumberType::Skip},
+                         {    30, PacketState::Forward,              30, SequenceNumberType::Valid},
+                         {     0, PacketState::Generate,             31, SequenceNumberType::Generated},
+                         {     0, PacketState::Reset,                 0, SequenceNumberType::Skip},
+                         {     0, PacketState::Generate,             32, SequenceNumberType::Generated},
+                         {     0, PacketState::Reset,                 0, SequenceNumberType::Skip},
+                         {     6, PacketState::Forward,              33, SequenceNumberType::Valid}}),
+
+    //                     input                        expected_output
+    std::vector<Packet>({{  5059, PacketState::Skip,               5059, SequenceNumberType::Skip},
+                         {    30, PacketState::Forward,              30, SequenceNumberType::Valid},
+                         {     0, PacketState::Generate,             31, SequenceNumberType::Generated},
+                         {     0, PacketState::Reset,                 0, SequenceNumberType::Skip},
+                         {     0, PacketState::Generate,             32, SequenceNumberType::Generated},
+                         {     0, PacketState::Reset,                 0, SequenceNumberType::Skip},
+                         {     6, PacketState::Forward,              33, SequenceNumberType::Valid}}),
+
+    //                     input                        expected_output
+    std::vector<Packet>({{     5, PacketState::Forward,               5, SequenceNumberType::Valid},
+                         {     0, PacketState::Generate,              6, SequenceNumberType::Generated},
+                         {     6, PacketState::Forward,               7, SequenceNumberType::Valid},
+                         {     7, PacketState::Forward,               8, SequenceNumberType::Valid}}),
+
+    //                     input                        expected_output
+    std::vector<Packet>({{     5, PacketState::Forward,               5, SequenceNumberType::Valid},
+                         {     0, PacketState::Generate,              6, SequenceNumberType::Generated},
+                         {     6, PacketState::Forward,               7, SequenceNumberType::Valid},
+                         {     7, PacketState::Forward,               8, SequenceNumberType::Valid},
+                         {     0, PacketState::Generate,              9, SequenceNumberType::Generated},
+                         {     8, PacketState::Forward,              10, SequenceNumberType::Valid}}),
+
+    //                     input                        expected_output
+    std::vector<Packet>({{     5, PacketState::Forward,               5, SequenceNumberType::Valid},
+                         {     0, PacketState::Generate,              6, SequenceNumberType::Generated},
+                         {     0, PacketState::Generate,              7, SequenceNumberType::Generated},
+                         {     6, PacketState::Forward,               8, SequenceNumberType::Valid}}),
+
+    //                     input                        expected_output
+    std::vector<Packet>({{     5, PacketState::Forward,               5, SequenceNumberType::Valid},
+                         {     6, PacketState::Skip,                  5, SequenceNumberType::Skip},
+                         {     0, PacketState::Generate,              6, SequenceNumberType::Generated},
+                         {     7, PacketState::Skip,                  6, SequenceNumberType::Skip},
+                         {     8, PacketState::Forward,               7, SequenceNumberType::Valid}}),
+
+    //                     input                        expected_output
+    std::vector<Packet>({{     5, PacketState::Forward,               5, SequenceNumberType::Valid},
+                         {     0, PacketState::Generate,              6, SequenceNumberType::Generated},
+                         {     0, PacketState::Generate,              7, SequenceNumberType::Generated},
+                         {     6, PacketState::Forward,               8, SequenceNumberType::Valid},
+                         {     0, PacketState::Generate,              9, SequenceNumberType::Generated},
+                         {     0, PacketState::Generate,              10, SequenceNumberType::Generated},
+                         {     7, PacketState::Forward,               11, SequenceNumberType::Valid}}),
+
+    // Support multiple loops with skip packets
+    concat({             {     5, PacketState::Forward,               5, SequenceNumberType::Valid}},
+                         concat(getLongQueue(32768 * 2, 15, 6, PacketState::Skip, SequenceNumberType::Skip),
+                        {{     7, PacketState::Forward,               6, SequenceNumberType::Valid}})),
+
+    // Support multiple loops with skip and generated packet
+    concat({             {     5, PacketState::Forward,               5, SequenceNumberType::Valid}},
+                         concat(getLongQueue(32768 * 2, 15, 6, PacketState::Skip, SequenceNumberType::Skip),
+                        {{     0, PacketState::Generate,              6, SequenceNumberType::Generated},
+                         {     7, PacketState::Forward,               7, SequenceNumberType::Valid}})),
+
+    // Support multiple loops with generated and a skip packet
+    concat({             {     5, PacketState::Forward,               5, SequenceNumberType::Valid}},
+                        concat(getLongQueue(32767 * 2, 15, 0, PacketState::Generate, SequenceNumberType::Generated),
+                        {{     6, PacketState::Skip,                  5, SequenceNumberType::Skip},
+                         {     7, PacketState::Forward,               5, SequenceNumberType::Valid}})),
+
+    // Support multiple loops with valid packets
+    getLongQueue(32768 * 2, 15)));


### PR DESCRIPTION
**Description**

There was an issue when filtering the second temporal layer in VP8 Simulcast. We now follow the guidelines in https://groups.google.com/forum/#!topic/discuss-webrtc/gik2VH4hUjk to properly update the payload. 

This PR also fixes the way we detected the temporal layer, which was wrong. And it adds some small fixes for the SequenceNumberTranslator.

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.