### PR TITLE
Fix some random bugs in cpp tests

### DIFF
--- a/erizo/src/test/LibNiceConnectionTest.cpp
+++ b/erizo/src/test/LibNiceConnectionTest.cpp
@@ -351,16 +351,16 @@ TEST_F(LibNiceConnectionTest, queuePacket_QueuedPackets_Can_Be_getPacket_When_Re
   nice_connection->updateIceState(erizo::IceState::READY);
   EXPECT_CALL(*nice_listener, onPacketReceived(_)).WillOnce(SaveArg<0>(&packet));
 
-  nice_connection->onData(0, test_packet, sizeof(test_packet));
+  nice_connection->onData(0, test_packet, strlen(test_packet));
 
   ASSERT_THAT(packet.get(), Not(Eq(nullptr)));
-  EXPECT_EQ(static_cast<unsigned int>(packet->length), sizeof(test_packet));
+  EXPECT_EQ(static_cast<unsigned int>(packet->length), strlen(test_packet));
   EXPECT_EQ(0, strcmp(test_packet, packet->data));
 }
 
 TEST_F(LibNiceConnectionTest, sendData_Succeed_When_Ice_Ready) {
   const unsigned int kCompId = 1;
-  const int kLength = sizeof(test_packet);
+  const int kLength = strlen(test_packet);
 
   EXPECT_CALL(*nice_listener, updateIceState(erizo::IceState::READY , _)).Times(1);
   nice_connection->updateIceState(erizo::IceState::READY);
@@ -370,7 +370,7 @@ TEST_F(LibNiceConnectionTest, sendData_Succeed_When_Ice_Ready) {
 
 TEST_F(LibNiceConnectionTest, sendData_Fail_When_Ice_Not_Ready) {
   const unsigned int kCompId = 1;
-  const unsigned int kLength = sizeof(test_packet);
+  const unsigned int kLength = strlen(test_packet);
 
   EXPECT_CALL(*libnice, NiceAgentSend(_, _, kCompId, kLength, _)).Times(0);
   EXPECT_EQ(-1, nice_connection->sendData(kCompId, test_packet, kLength));

--- a/erizo/src/test/NicerConnectionTest.cpp
+++ b/erizo/src/test/NicerConnectionTest.cpp
@@ -358,16 +358,16 @@ TEST_F(NicerConnectionTest, queuePacket_QueuedPackets_Can_Be_getPacket_When_Read
   nicer_connection->updateIceState(erizo::IceState::READY);
   EXPECT_CALL(*nicer_listener, onPacketReceived(_)).WillOnce(SaveArg<0>(&packet));
 
-  nicer_connection->onData(0, test_packet, sizeof(test_packet));
+  nicer_connection->onData(0, test_packet, strlen(test_packet));
 
   ASSERT_THAT(packet.get(), Not(Eq(nullptr)));
-  EXPECT_EQ(static_cast<unsigned int>(packet->length), sizeof(test_packet));
+  EXPECT_EQ(static_cast<unsigned int>(packet->length), strlen(test_packet));
   EXPECT_EQ(0, strcmp(test_packet, packet->data));
 }
 
 TEST_F(NicerConnectionTest, sendData_Succeed_When_Ice_Ready) {
   const unsigned int kCompId = 1;
-  const int kLength = sizeof(test_packet);
+  const int kLength = strlen(test_packet);
 
   EXPECT_CALL(*nicer_listener, updateIceState(erizo::IceState::READY , _)).Times(1);
   nicer_connection->updateIceState(erizo::IceState::READY);
@@ -377,7 +377,7 @@ TEST_F(NicerConnectionTest, sendData_Succeed_When_Ice_Ready) {
 
 TEST_F(NicerConnectionTest, sendData_Fail_When_Ice_Not_Ready) {
   const unsigned int kCompId = 1;
-  const unsigned int kLength = sizeof(test_packet);
+  const unsigned int kLength = strlen(test_packet);
 
   EXPECT_CALL(*nicer, IceMediaStreamSend(_, _, kCompId, _, kLength)).Times(0);
   EXPECT_EQ(-1, nicer_connection->sendData(kCompId, test_packet, kLength));


### PR DESCRIPTION
**Bug is related to NicerConnectionTest and LibNiceConnectionTest**

It was found out in the CI of the PR https://github.com/lynckia/licode/pull/1287
Basically the problem was in calculating the memory used by a string using sizeof().
It works only with memory allocation to stack like "char var[DEFAULT_SIZE];", in this case sizeof(var) == DEFAULT_SIZE.
With dynamic memory allocation like "char* var = new char[DEFAULT_SIZE];" or "char* var = (char*)malloc(DEFAULT_SIZE);" the sizeof(var) == sizeof(void*) and it can be bigger then the actual memory allocated leading to a bad memory access.
