### PR TITLE
Add maxVideoBW to stats

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -251,6 +251,8 @@ void MediaStream::initializeStats() {
   log_stats_->getNode().insertStat("paddingBitrate", CumulativeStat{0});
   log_stats_->getNode().insertStat("bwe", CumulativeStat{0});
 
+  log_stats_->getNode().insertStat("maxVideoBW", CumulativeStat{0});
+
   std::weak_ptr<MediaStream> weak_this = shared_from_this();
   worker_->scheduleEvery([weak_this] () {
     if (auto stream = weak_this.lock()) {
@@ -287,6 +289,8 @@ void MediaStream::printStats() {
 
   log_stats_->getNode().insertStat("audioEnabled", CumulativeStat{audio_enabled_});
   log_stats_->getNode().insertStat("videoEnabled", CumulativeStat{video_enabled_});
+
+  log_stats_->getNode().insertStat("maxVideoBW", CumulativeStat{getMaxVideoBW()});
 
   if (audio_enabled_) {
     audio_ssrc = std::to_string(is_publisher_ ? getAudioSourceSSRC() : getAudioSinkSSRC());


### PR DESCRIPTION
**Description**

By looking at stats it's usually hard to understand if bitrate is low due to network issues or some constraint given by settings, so I added maxVideoBW to the stats.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.