### PR TITLE
[POC] Add support for ssrc multiplexing (RTX)

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -365,7 +365,7 @@ void MediaStream::initializePipeline() {
   pipeline_->addFront(std::make_shared<LayerDetectorHandler>());
   pipeline_->addFront(std::make_shared<OutgoingStatsHandler>());
   pipeline_->addFront(std::make_shared<PacketCodecParser>());
-
+  pipeline_->addFront(std::make_shared<RtxPacketTranslator>());
   pipeline_->addFront(std::make_shared<PacketWriter>(this));
   pipeline_->finalize();
   pipeline_initialized_ = true;

--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -24,6 +24,7 @@
 #include "pipeline/Service.h"
 #include "rtp/QualityManager.h"
 #include "rtp/PacketBufferService.h"
+#include "rtp/RtxPacketTranslator.h"
 
 namespace erizo {
 
@@ -73,6 +74,12 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   void syncClose();
   bool setRemoteSdp(std::shared_ptr<SdpInfo> sdp);
   bool setLocalSdp(std::shared_ptr<SdpInfo> sdp);
+  std::shared_ptr<SdpInfo> getRemoteSdp() const {
+    return remote_sdp_;
+  }
+  std::shared_ptr<SdpInfo> getLocalSdp() const {
+    return local_sdp_;
+  }
 
   /**
    * Sends a PLI Packet

--- a/erizo/src/erizo/SdpInfo.h
+++ b/erizo/src/erizo/SdpInfo.h
@@ -123,6 +123,7 @@ struct RtpMap {
   unsigned int channels;
   std::vector<std::string> feedback_types;
   std::map<std::string, std::string> format_parameters;
+  unsigned int rtx_payload_type;
 };
 /**
  * A RTP extmap description

--- a/erizo/src/erizo/rtp/RtxPacketTranslator.cpp
+++ b/erizo/src/erizo/rtp/RtxPacketTranslator.cpp
@@ -1,0 +1,60 @@
+#include "RtxPacketTranslator.h"
+#include "RtpHeaders.h"
+
+namespace erizo
+{
+DEFINE_LOGGER(RtxPacketTranslator, "rtp.RtxPacketTranslator");
+
+void RtxPacketTranslator::read(Context *ctx, std::shared_ptr<DataPacket> packet) {
+    auto *rtcp = reinterpret_cast<RtcpHeader *>(packet->data);
+    if (!rtcp->isRtcp()) {
+        auto *rtp = reinterpret_cast<RtpHeader *>(packet->data);
+        auto ssrc = rtp->getSSRC();
+        auto item = std::find_if(rtx_map.begin(), rtx_map.end(), [ssrc](std::pair<uint32_t, uint32_t> pair) {
+            return pair.second == ssrc;
+        });
+        if (item != rtx_map.end()) {
+            rtp->setSSRC(item->first);
+
+            // https://tools.ietf.org/html/rfc4588#section-4
+            int header_len = 0;
+            char *data = packet->data;
+            data += sizeof(RtpHeader) - 8;
+            header_len += sizeof(RtpHeader) - 8;
+            if (rtp->getExtension()) {
+                data += (rtp->getExtLength() + 1) * 4;
+                header_len += (rtp->getExtLength() + 1) * 4;
+            }
+            header_len += 2; // OSN SIZE
+            uint16_t original_seqnum;
+            memcpy(&original_seqnum, data, 2);
+            original_seqnum = ntohs(original_seqnum);
+
+            rtp->setSeqNumber(original_seqnum);
+            rtp->setPayloadType(96);
+
+            memmove(data, data + 2, packet->length - header_len);
+            packet->length -= 2;
+        }
+    }
+    ctx->fireRead(std::move(packet));
+}
+
+void RtxPacketTranslator::notifyUpdate() {
+    if (initialized_) {
+        return;
+    }
+    auto pipeline = getContext()->getPipelineShared();
+    if (pipeline && !stream_) {
+        stream_ = pipeline->getService<MediaStream>().get();
+    }
+    if (!stream_) {
+        return;
+    }
+    rtx_map = stream_->getRemoteSdp()->video_rtx_ssrc_map[stream_->getLabel()];
+    for (auto value : rtx_map) {
+        ELOG_DEBUG("Setting Rtx Mapping for ssrc %u: %u", value.first, value.second);
+    }
+    initialized_ = true;
+}
+} // namespace erizo

--- a/erizo/src/erizo/rtp/RtxPacketTranslator.h
+++ b/erizo/src/erizo/rtp/RtxPacketTranslator.h
@@ -1,0 +1,32 @@
+#ifndef ERIZO_SRC_ERIZO_RTP_RTXPACKETTRANSLATOR_H_
+#define ERIZO_SRC_ERIZO_RTP_RTXPACKETTRANSLATOR_H_
+
+#include "pipeline/Handler.h"
+#include "./logger.h"
+#include "MediaStream.h"
+
+namespace erizo {
+class MediaStream;
+
+class RtxPacketTranslator : public InboundHandler {
+  DECLARE_LOGGER();
+ public:
+  void enable() override {}
+  void disable() override {}
+
+  std::string getName() override {
+     return "rtx_packet_translator";
+  }
+
+  void read(Context *ctx, std::shared_ptr<DataPacket> packet) override;
+  void notifyUpdate() override;
+
+private:
+    std::map<uint32_t, uint32_t> rtx_map;
+    bool initialized_;
+    MediaStream* stream_;
+};
+
+}
+
+#endif

--- a/erizoAPI/ConnectionDescription.cc
+++ b/erizoAPI/ConnectionDescription.cc
@@ -71,6 +71,9 @@ NAN_MODULE_INIT(ConnectionDescription::Init) {
   Nan::SetPrototypeMethod(tpl, "setVideoSsrcList", setVideoSsrcList);
   Nan::SetPrototypeMethod(tpl, "getVideoSsrcMap", getVideoSsrcMap);
 
+  Nan::SetPrototypeMethod(tpl, "setVideoFIDMap", setVideoFIDMap);
+  Nan::SetPrototypeMethod(tpl, "getVideoFIDMap", getVideoFIDMap);
+
   Nan::SetPrototypeMethod(tpl, "setVideoDirection", setVideoDirection);
   Nan::SetPrototypeMethod(tpl, "setAudioDirection", setAudioDirection);
   Nan::SetPrototypeMethod(tpl, "getDirection", getDirection);
@@ -322,6 +325,39 @@ NAN_METHOD(ConnectionDescription::getVideoSsrcMap) {
       Nan::Set(array, index++, Nan::New(ssrc));
     }
     video_ssrc_map->Set(Nan::New(video_ssrcs.first.c_str()).ToLocalChecked(), array);
+  }
+  info.GetReturnValue().Set(video_ssrc_map);
+}
+
+NAN_METHOD(ConnectionDescription::setVideoFIDMap) {
+  GET_SDP();
+  std::string stream_id = getString(info[0]);
+  v8::Local<v8::Array> video_fid_array = v8::Local<v8::Array>::Cast(info[1]);
+  std::map<uint32_t, uint32_t> video_fid_map;
+
+  for (unsigned int i = 0; i < video_fid_array->Length(); i++) {
+    v8::Local<v8::Array> tempArray = v8::Local<v8::Array>::Cast(video_fid_array->Get(i));
+    unsigned int key = tempArray->Get(0)->IntegerValue();
+    unsigned int value = tempArray->Get(1)->IntegerValue();
+    video_fid_map[key] = value;
+  }
+
+  sdp->video_rtx_ssrc_map[stream_id] = video_fid_map;
+}
+
+NAN_METHOD(ConnectionDescription::getVideoFIDMap) {
+  GET_SDP();
+  Local<v8::Object> video_ssrc_map = Nan::New<v8::Object>();
+  for (auto const& video_fid_ssrc : sdp->video_rtx_ssrc_map) {
+    v8::Local<v8::Array> array = Nan::New<v8::Array>(video_fid_ssrc.second.size());
+    uint index = 0;
+    for (auto const& video_fid : video_fid_ssrc.second) {
+      v8::Local<v8::Array> temparray = Nan::New<v8::Array>(2);
+      Nan::Set(temparray, 0, Nan::New(video_fid.first));
+      Nan::Set(temparray, 1, Nan::New(video_fid.second));
+      Nan::Set(array, index++, temparray);
+    }
+    video_ssrc_map->Set(Nan::New(video_fid_ssrc.first.c_str()).ToLocalChecked(), array);
   }
   info.GetReturnValue().Set(video_ssrc_map);
 }
@@ -616,6 +652,7 @@ NAN_METHOD(ConnectionDescription::getCodecs) {
   for (erizo::RtpMap &pt : media_pts) {
     v8::Local<v8::Object> codec = Nan::New<v8::Object>();
     Nan::Set(codec, Nan::New("type").ToLocalChecked(), Nan::New(pt.payload_type));
+    Nan::Set(codec, Nan::New("rtx").ToLocalChecked(), Nan::New(pt.rtx_payload_type));
     Nan::Set(codec, Nan::New("name").ToLocalChecked(),
                                 Nan::New(pt.encoding_name.c_str()).ToLocalChecked());
     Nan::Set(codec, Nan::New("rate").ToLocalChecked(), Nan::New(pt.clock_rate));
@@ -679,12 +716,14 @@ NAN_METHOD(ConnectionDescription::addPt) {
   std::string codec_name = getString(info[1]);
   unsigned int parsed_clock = info[2]->IntegerValue();
   erizo::MediaType media = getMediaType(getString(info[3]));
+  unsigned int rtx_pt = info[4]->IntegerValue();
 
   erizo::RtpMap new_mapping;
   new_mapping.payload_type = pt;
   new_mapping.encoding_name = codec_name;
   new_mapping.clock_rate = parsed_clock;
   new_mapping.media_type = media;
+  new_mapping.rtx_payload_type = rtx_pt;
   sdp->payload_parsed_map_[pt] = new_mapping;
 }
 

--- a/erizoAPI/ConnectionDescription.h
+++ b/erizoAPI/ConnectionDescription.h
@@ -49,6 +49,9 @@ class ConnectionDescription : public Nan::ObjectWrap {
     static NAN_METHOD(getAudioSsrcMap);
     static NAN_METHOD(getVideoSsrcMap);
 
+    static NAN_METHOD(setVideoFIDMap);
+    static NAN_METHOD(getVideoFIDMap);
+    
     static NAN_METHOD(setVideoDirection);
     static NAN_METHOD(setAudioDirection);
     static NAN_METHOD(getDirection);

--- a/erizo_controller/erizoAgent/log4cxx.properties
+++ b/erizo_controller/erizoAgent/log4cxx.properties
@@ -71,3 +71,4 @@ log4j.logger.rtp.LayerDetectorHandler=WARN
 log4j.logger.rtp.PliPacerHandler=WARN
 log4j.logger.rtp.RtpPaddingGeneratorHandler=WARN
 log4j.logger.rtp.PacketCodecParser=WARN
+log4j.logger.rtp.RtxPacketTranslator=WARN


### PR DESCRIPTION
This PR aims to make Licode works when the publisher negotiates RTX with FID fields.

This was not useful until now because all the supported browsers, when we answered with no rtx fmtp, they did the retransmission only in the main ssrc when requesting nack.

But Edge, as you can see in my answer from fippo, only support RTX in separate rtx ssrc channel, so, we implemented a module that translates the rtx packets as it was with a single ssrc, so for Licode it's transparent.
This is a first step to better support other browsers in the future

Note that now also chrome and firefox will send rtx in separate channel.

It just works but I noticed that in SdpInfo.cpp there was already present some logic for rtx but it doesn't work (probably due to the parsing method of ConnectionDescription or some other javascript code).

So I made this PR as a POC because I need to know what do you think @jcague @lodoyun and if we can better adjust the javascript code or if you like what I've done.

Currently no test are provided.