### PR TITLE
Add RTX translator

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -364,6 +364,7 @@ void MediaStream::initializePipeline() {
   pipeline_->addFront(std::make_shared<SenderBandwidthEstimationHandler>());
   pipeline_->addFront(std::make_shared<LayerDetectorHandler>());
   pipeline_->addFront(std::make_shared<OutgoingStatsHandler>());
+  pipeline_->addFront(std::make_shared<RtxPacketTranslator>());
   pipeline_->addFront(std::make_shared<PacketCodecParser>());
 
   pipeline_->addFront(std::make_shared<PacketWriter>(this));

--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -24,6 +24,7 @@
 #include "pipeline/Service.h"
 #include "rtp/QualityManager.h"
 #include "rtp/PacketBufferService.h"
+#include "rtp/RtxPacketTranslator.h"
 
 namespace erizo {
 
@@ -73,7 +74,6 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   void syncClose();
   bool setRemoteSdp(std::shared_ptr<SdpInfo> sdp);
   bool setLocalSdp(std::shared_ptr<SdpInfo> sdp);
-
   /**
    * Sends a PLI Packet
    * @return the size of the data sent

--- a/erizo/src/erizo/SdpInfo.h
+++ b/erizo/src/erizo/SdpInfo.h
@@ -259,7 +259,7 @@ class SdpInfo {
    */
   std::map<std::string, unsigned int> audio_ssrc_map;
   std::map<std::string, std::vector<uint32_t>> video_ssrc_map;
-  std::map<std::string, std::map<uint32_t, uint32_t>> video_rtx_ssrc_map;
+  std::map<std::string, std::map<uint32_t, uint32_t>> fid_ssrc_map;
   /**
   * Is it Bundle
   */

--- a/erizo/src/erizo/rtp/RtxPacketTranslator.cpp
+++ b/erizo/src/erizo/rtp/RtxPacketTranslator.cpp
@@ -1,0 +1,74 @@
+#include "RtxPacketTranslator.h"
+#include "RtpHeaders.h"
+
+namespace erizo {
+DEFINE_LOGGER(RtxPacketTranslator, "rtp.RtxPacketTranslator");
+
+void RtxPacketTranslator::read(Context *ctx, std::shared_ptr<DataPacket> packet) {
+    auto *rtcp = reinterpret_cast<RtcpHeader *>(packet->data);
+    if (!rtcp->isRtcp()) {
+        auto *rtp = reinterpret_cast<RtpHeader *>(packet->data);
+        auto ssrc = rtp->getSSRC();
+        auto seq_num = rtp->getSeqNumber();
+        auto pt = rtp->getPayloadType();
+        auto apt_mapping = apt_translator.find(rtp->getPayloadType());
+        if (apt_mapping == apt_translator.end()) {
+            ctx->fireRead(std::move(packet));
+            return;
+        }
+        auto fid_mapping = std::find_if(fid_map.begin(), fid_map.end(), [ssrc](std::pair<uint32_t, uint32_t> pair) {
+            return pair.second == ssrc;
+        });
+        if (fid_mapping != fid_map.end()) {
+            rtp->setSSRC(fid_mapping->first);
+            // https://tools.ietf.org/html/rfc4588#section-4
+            int header_len = 0;
+            char *data = packet->data;
+            data += sizeof(RtpHeader) - 8;
+            header_len += sizeof(RtpHeader) - 8;
+            if (rtp->getExtension()) {
+                data += (rtp->getExtLength() + 1) * 4;
+                header_len += (rtp->getExtLength() + 1) * 4;
+            }
+            header_len += 2;  // OSN SIZE
+            uint16_t original_seqnum;
+            memcpy(&original_seqnum, data, 2);
+            original_seqnum = ntohs(original_seqnum);
+
+            rtp->setSeqNumber(original_seqnum);
+            rtp->setPayloadType(apt_mapping->second);
+
+            memmove(data, data + 2, packet->length - header_len);
+            packet->length -= 2;
+            ELOG_DEBUG("%s Rewriting rtx packet from ssrc: %u to: %u, original_seqnum: %u to: %u, original_pt: %u to: %u", stream_->toLog(), ssrc, fid_mapping->first, seq_num, original_seqnum, pt, apt_mapping->second);
+        }
+    }
+    ctx->fireRead(std::move(packet));
+}
+
+void RtxPacketTranslator::notifyUpdate() {
+    if (initialized_) {
+        return;
+    }
+    auto pipeline = getContext()->getPipelineShared();
+    if (pipeline && !stream_) {
+        stream_ = pipeline->getService<MediaStream>().get();
+    }
+    if (!stream_) {
+        return;
+    }
+    for (const auto &params : stream_->getRemoteSdpInfo()->payload_parsed_map_) {
+        for (const auto &param : params.second.format_parameters) {
+            if (param.first == "apt") {
+                apt_translator[params.first] = stoi(param.second);
+                ELOG_DEBUG("%s Mapping apt %u to %u", stream_->toLog(), params.first, apt_translator[params.first]);
+            }
+        }
+    }
+    fid_map = stream_->getRemoteSdpInfo()->fid_ssrc_map[stream_->getLabel()];
+    for (auto value : fid_map) {
+        ELOG_DEBUG("%s Setting Rtx Mapping for ssrc %u: %u", stream_->toLog(), value.first, value.second);
+    }
+    initialized_ = true;
+}
+}  // namespace erizo

--- a/erizo/src/erizo/rtp/RtxPacketTranslator.cpp
+++ b/erizo/src/erizo/rtp/RtxPacketTranslator.cpp
@@ -40,7 +40,8 @@ void RtxPacketTranslator::read(Context *ctx, std::shared_ptr<DataPacket> packet)
 
             memmove(data, data + 2, packet->length - header_len);
             packet->length -= 2;
-            ELOG_DEBUG("%s Rewriting rtx packet from ssrc: %u to: %u, original_seqnum: %u to: %u, original_pt: %u to: %u", stream_->toLog(), ssrc, fid_mapping->first, seq_num, original_seqnum, pt, apt_mapping->second);
+            ELOG_DEBUG("%s Rewriting rtx packet from ssrc: %u to: %u, orig_seqnum: %u to: %u, orig_pt: %u to: %u",
+                stream_->toLog(), ssrc, fid_mapping->first, seq_num, original_seqnum, pt, apt_mapping->second);
         }
     }
     ctx->fireRead(std::move(packet));

--- a/erizo/src/erizo/rtp/RtxPacketTranslator.h
+++ b/erizo/src/erizo/rtp/RtxPacketTranslator.h
@@ -11,7 +11,7 @@ class MediaStream;
 class RtxPacketTranslator : public InboundHandler {
     DECLARE_LOGGER();
 
-   public:
+ public:
     void enable() override {}
     void disable() override {}
 
@@ -22,7 +22,7 @@ class RtxPacketTranslator : public InboundHandler {
     void read(Context* ctx, std::shared_ptr<DataPacket> packet) override;
     void notifyUpdate() override;
 
-   private:
+ private:
     std::map<uint32_t, uint32_t> fid_map;
     std::map<unsigned, unsigned> apt_translator;
     bool initialized_;
@@ -31,4 +31,4 @@ class RtxPacketTranslator : public InboundHandler {
 
 }  // namespace erizo
 
-#endif
+#endif  // ERIZO_SRC_ERIZO_RTP_RTXPACKETTRANSLATOR_H_

--- a/erizo/src/erizo/rtp/RtxPacketTranslator.h
+++ b/erizo/src/erizo/rtp/RtxPacketTranslator.h
@@ -1,0 +1,34 @@
+#ifndef ERIZO_SRC_ERIZO_RTP_RTXPACKETTRANSLATOR_H_
+#define ERIZO_SRC_ERIZO_RTP_RTXPACKETTRANSLATOR_H_
+
+#include "./logger.h"
+#include "MediaStream.h"
+#include "pipeline/Handler.h"
+
+namespace erizo {
+class MediaStream;
+
+class RtxPacketTranslator : public InboundHandler {
+    DECLARE_LOGGER();
+
+   public:
+    void enable() override {}
+    void disable() override {}
+
+    std::string getName() override {
+        return "rtx_packet_translator";
+    }
+
+    void read(Context* ctx, std::shared_ptr<DataPacket> packet) override;
+    void notifyUpdate() override;
+
+   private:
+    std::map<uint32_t, uint32_t> fid_map;
+    std::map<unsigned, unsigned> apt_translator;
+    bool initialized_;
+    MediaStream* stream_;
+};
+
+}  // namespace erizo
+
+#endif

--- a/erizoAPI/ConnectionDescription.h
+++ b/erizoAPI/ConnectionDescription.h
@@ -48,6 +48,8 @@ class ConnectionDescription : public Nan::ObjectWrap {
     static NAN_METHOD(setVideoSsrcList);
     static NAN_METHOD(getAudioSsrcMap);
     static NAN_METHOD(getVideoSsrcMap);
+    static NAN_METHOD(setVideoFIDMap);
+    static NAN_METHOD(getVideoFIDMap);
 
     static NAN_METHOD(setVideoDirection);
     static NAN_METHOD(setAudioDirection);

--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -140,10 +140,8 @@ NAN_METHOD(WebRtcConnection::New) {
         if (it.value()["clockRate"].is_number()) {
           rtp_map.clock_rate = it.value()["clockRate"];
         }
-        if (rtp_map.media_type == erizo::AUDIO_TYPE) {
-          if (it.value()["channels"].is_number()) {
-            rtp_map.channels = it.value()["channels"];
-          }
+        if (it.value()["channels"].is_number()) {
+          rtp_map.channels = it.value()["channels"];
         }
         if (it.value()["formatParameters"].is_object()) {
           json format_params_json = it.value()["formatParameters"];

--- a/erizo_controller/common/semanticSdp/MediaInfo.js
+++ b/erizo_controller/common/semanticSdp/MediaInfo.js
@@ -74,8 +74,8 @@ class MediaInfo {
     this.codecs.forEach((codec) => {
       plain.codecs.push(codec.plain());
     });
-    this.extensions.forEach((extension) => {
-      plain.extensions.push(extension.plain());
+    this.extensions.forEach((extension, key) => {
+      plain.extensions[key] = extension;
     });
     this.rids.forEach((rid) => {
       plain.rids.push(rid.plain());

--- a/erizo_controller/common/semanticSdp/SDPInfo.js
+++ b/erizo_controller/common/semanticSdp/SDPInfo.js
@@ -519,8 +519,6 @@ class SDPInfo {
 }
 
 function getFormats(mediaInfo, md) {
-  const apts = new Map();
-
   md.rtp.forEach((fmt) => {
     const type = fmt.payload;
     const codec = fmt.codec;
@@ -546,18 +544,7 @@ function getFormats(mediaInfo, md) {
         }
       });
     }
-    if (codec.toUpperCase() === 'RTX') {
-      apts.set(parseInt(params.apt, 10), type);
-    } else {
-      mediaInfo.addCodec(new CodecInfo(codec, type, rate, encoding, params, feedback));
-    }
-  });
-
-  apts.forEach((apt, id) => {
-    const codecInfo = mediaInfo.getCodecForType(id);
-    if (codecInfo) {
-      codecInfo.setRTX(apt);
-    }
+    mediaInfo.addCodec(new CodecInfo(codec, type, rate, encoding, params, feedback));
   });
 }
 

--- a/erizo_controller/erizoAgent/log4cxx.properties
+++ b/erizo_controller/erizoAgent/log4cxx.properties
@@ -71,3 +71,4 @@ log4j.logger.rtp.LayerDetectorHandler=WARN
 log4j.logger.rtp.PliPacerHandler=WARN
 log4j.logger.rtp.RtpPaddingGeneratorHandler=WARN
 log4j.logger.rtp.PacketCodecParser=WARN
+log4j.logger.rtp.RtxPacketTranslator=WARN


### PR DESCRIPTION
This PR enables support for the rtx payload.
If rtx is added to rtp_media_config.json 
`  default: { rtpMappings: { vp8, opus, rtx }, extMappings },
`
It will generate an answer sdp from licode with the support for retransmission in different ssrc.

```
DEBUG:  Remote Description v=0
o=- 0 0 IN IP4 127.0.0.1
s=LicodeMCU
t=0 0
a=msid-semantic: WMS *
a=group:BUNDLE audio video
m=audio 9 UDP/TLS/RTP/SAVPF 111
c=IN IP4 0.0.0.0
a=rtpmap:111 opus/48000/2
a=rtcp:1 IN IP4 0.0.0.0
a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
a=setup:active
a=mid:audio
a=sendonly
a=ice-ufrag:pCLB
a=ice-pwd:eskupOQk52+Y0y8CS2UUDD
a=fingerprint:sha-256 F4:3E:28:69:92:B4:92:C5:FE:01:5C:E7:40:21:4D:1A:29:87:37:21:EE:28:F5:9E:AA:26:74:A6:B0:3B:97:17
a=candidate:2 1 udp 2013266431 192.168.3.134 57049 typ host generation 0
a=end-of-candidates
a=ssrc:2548844439 cname:erizo
a=ssrc:2548844439 msid:TYTgd1e06IR8u5ulY60zgEoMahm7yJLTYCqM TYTgd1e06IR8u5ulY60zgEoMahm7yJLTYCqMaudio
a=ssrc:2548844439 mslabel:TYTgd1e06IR8u5ulY60zgEoMahm7yJLTYCqM
a=ssrc:2548844439 label:audio
a=rtcp-mux
m=video 9 UDP/TLS/RTP/SAVPF 96 97
c=IN IP4 0.0.0.0
a=rtpmap:96 VP8/90000/1
a=rtpmap:97 rtx/90000
a=fmtp:97 apt=96
a=rtcp:1 IN IP4 0.0.0.0
a=rtcp-fb:96 ccm fir
a=rtcp-fb:96 nack
a=rtcp-fb:96 nack pli
a=rtcp-fb:96 goog-remb
a=extmap:2 urn:ietf:params:rtp-hdrext:toffset
a=extmap:3 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
a=extmap:4 urn:3gpp:video-orientation
a=extmap:6 http://www.webrtc.org/experiments/rtp-hdrext/playout-delay
a=setup:active
a=mid:video
a=sendonly
a=ice-ufrag:pCLB
a=ice-pwd:eskupOQk52+Y0y8CS2UUDD
a=fingerprint:sha-256 F4:3E:28:69:92:B4:92:C5:FE:01:5C:E7:40:21:4D:1A:29:87:37:21:EE:28:F5:9E:AA:26:74:A6:B0:3B:97:17
a=candidate:2 1 udp 2013266431 192.168.3.134 57049 typ host generation 0
a=end-of-candidates
a=ssrc:4023768948 cname:erizo
a=ssrc:4023768948 msid:TYTgd1e06IR8u5ulY60zgEoMahm7yJLTYCqM TYTgd1e06IR8u5ulY60zgEoMahm7yJLTYCqMvideo
a=ssrc:4023768948 mslabel:TYTgd1e06IR8u5ulY60zgEoMahm7yJLTYCqM
a=ssrc:4023768948 label:video
a=rtcp-mux
```

If the rtx mapping is missing in the config file, licode works as it worked until now (expect nacks on the same ssrc).

When rtx is enabled, RTP packets will flow into the RtpRtxTranslator, which is a new module in the pipeline which handle the translation of the retransmitted packets (payload, sequence_number and ssrc) as per draft: [RFC4588.4](https://tools.ietf.org/html/rfc4588#section-4)

This is transparent for all other modules in Licode and transparent for the subscriber, since it will do this only in ingress streams.

This is a step towards supporting more browsers. Everything started from the discovery that EDGE will reply to nacks only in a separate SSRC. [fippo@github](https://github.com/webrtcHacks/adapter/issues/871#issuecomment-419457546)

So we implemented this for ourselves but seemed nice to share with you!

[It doesn't include tests]
