### PR TITLE
Stop receiving MediaStream events when subscriber is closed

### DIFF
--- a/erizo_controller/erizoJS/models/Subscriber.js
+++ b/erizo_controller/erizoJS/models/Subscriber.js
@@ -14,8 +14,9 @@ class Subscriber extends NodeClass {
     this.connection.mediaConfiguration = options.mediaConfiguration;
     this.connection.addMediaStream(this.erizoStreamId, options, false);
     this._connectionListener = this._emitStatusEvent.bind(this);
+    this._mediaStreamListener = this._onMediaStreamEvent.bind(this);
     connection.on('status_event', this._connectionListener);
-    connection.on('media_stream_event', this._onMediaStreamEvent.bind(this));
+    connection.on('media_stream_event', this._mediaStreamListener);
     this.mediaStream = connection.getMediaStream(this.erizoStreamId);
     this.publisher = publisher;
     this.ready = false;
@@ -126,6 +127,7 @@ class Subscriber extends NodeClass {
     if (this.connection) {
       this.connection.removeMediaStream(this.mediaStream.id);
       this.connection.removeListener('status_event', this._connectionListener);
+      this.connection.removeListener('media_stream_event', this._mediaStreamListener);
     }
     if (this.mediaStream && this.mediaStream.monitorInterval) {
       clearInterval(this.mediaStream.monitorInterval);


### PR DESCRIPTION
**Description**

We were receiving events in a closed Subscriber because we don't remove the listener.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.