### PR TITLE
Fix/ice tests and small performance improvements

### DIFF
--- a/erizo/src/erizo/IceConnection.h
+++ b/erizo/src/erizo/IceConnection.h
@@ -100,7 +100,7 @@ class IceConnection : public LogContext {
   virtual void setRemoteCredentials(const std::string& username, const std::string& password) = 0;
   virtual int sendData(unsigned int component_id, const void* buf, int len) = 0;
 
-  virtual void onData(unsigned int component_id, char* buf, int len) = 0;
+  virtual void onData(unsigned int component_id, const void* buf, int len) = 0;
   virtual CandidatePair getSelectedPair() = 0;
   virtual void setReceivedLastCandidate(bool hasReceived) = 0;
   virtual void close() = 0;

--- a/erizo/src/erizo/LibNiceConnection.h
+++ b/erizo/src/erizo/LibNiceConnection.h
@@ -55,7 +55,7 @@ class LibNiceConnection : public IceConnection {
   int sendData(unsigned int component_id, const void* buf, int len) override;
 
   void updateComponentState(unsigned int component_id, IceState state);
-  void onData(unsigned int component_id, char* buf, int len) override;
+  void onData(unsigned int component_id, const void* buf, int len) override;
   CandidatePair getSelectedPair() override;
   void setReceivedLastCandidate(bool hasReceived) override;
   void close() override;
@@ -75,7 +75,7 @@ class LibNiceConnection : public IceConnection {
 
   boost::thread m_Thread_;
   boost::mutex close_mutex_;
-  boost::condition_variable cond_;
+//  boost::condition_variable cond_;
 
   bool receivedLastCandidate_;
   boost::shared_ptr<std::vector<CandidateInfo> > local_candidates;

--- a/erizo/src/erizo/MediaDefinitions.h
+++ b/erizo/src/erizo/MediaDefinitions.h
@@ -25,19 +25,25 @@ struct DataPacket {
   DataPacket(int comp_, const char *data_, int length_, packetType type_, uint64_t received_time_ms_) :
     comp{comp_}, length{length_}, type{type_}, received_time_ms{received_time_ms_}, is_keyframe{false},
     ending_of_layer_frame{false}, picture_id{-1}, tl0_pic_idx{-1} {
-      memcpy(data, data_, length_);
+    if(length_ > 0) {
+      memcpy(data, data_, std::min((size_t)length_, sizeof(data)));
+    }
   }
 
   DataPacket(int comp_, const char *data_, int length_, packetType type_) :
     comp{comp_}, length{length_}, type{type_}, received_time_ms{ClockUtils::timePointToMs(clock::now())},
     is_keyframe{false}, ending_of_layer_frame{false}, picture_id{-1}, tl0_pic_idx{-1} {
-      memcpy(data, data_, length_);
+    if (length_ > 0) {
+      memcpy(data, data_, std::min((size_t) length_, sizeof(data)));
+    }
   }
 
   DataPacket(int comp_, const unsigned char *data_, int length_) :
     comp{comp_}, length{length_}, type{VIDEO_PACKET}, received_time_ms{ClockUtils::timePointToMs(clock::now())},
     is_keyframe{false}, ending_of_layer_frame{false}, picture_id{-1}, tl0_pic_idx{-1} {
-      memcpy(data, data_, length_);
+    if (length_ > 0) {
+      memcpy(data, data_, std::min((size_t) length_, sizeof(data)));
+    }
   }
 
   bool belongsToSpatialLayer(int spatial_layer_) {

--- a/erizo/src/erizo/NicerConnection.cpp
+++ b/erizo/src/erizo/NicerConnection.cpp
@@ -568,7 +568,7 @@ void NicerConnection::close() {
   }
 }
 
-void NicerConnection::onData(unsigned int component_id, char* buf, int len) {
+void NicerConnection::onData(unsigned int component_id, const void* buf, int len) {
   IceState state;
   {
     boost::mutex::scoped_lock lock(close_mutex_);

--- a/erizo/src/erizo/NicerConnection.h
+++ b/erizo/src/erizo/NicerConnection.h
@@ -54,7 +54,7 @@ class NicerConnection : public IceConnection, public std::enable_shared_from_thi
   void setRemoteCredentials(const std::string& username, const std::string& password) override;
   int sendData(unsigned int component_id, const void* buf, int len) override;
 
-  void onData(unsigned int component_id, char* buf, int len) override;
+  void onData(unsigned int component_id, const void* buf, int len) override;
   CandidatePair getSelectedPair() override;
   void setReceivedLastCandidate(bool hasReceived) override;
   void close() override;

--- a/erizo/src/test/LibNiceConnectionTest.cpp
+++ b/erizo/src/test/LibNiceConnectionTest.cpp
@@ -351,16 +351,16 @@ TEST_F(LibNiceConnectionTest, queuePacket_QueuedPackets_Can_Be_getPacket_When_Re
   nice_connection->updateIceState(erizo::IceState::READY);
   EXPECT_CALL(*nice_listener, onPacketReceived(_)).WillOnce(SaveArg<0>(&packet));
 
-  nice_connection->onData(0, test_packet, sizeof(test_packet));
+  nice_connection->onData(0, test_packet, strlen(test_packet));
 
   ASSERT_THAT(packet.get(), Not(Eq(nullptr)));
-  EXPECT_EQ(static_cast<unsigned int>(packet->length), sizeof(test_packet));
+  EXPECT_EQ(static_cast<unsigned int>(packet->length), strlen(test_packet));
   EXPECT_EQ(0, strcmp(test_packet, packet->data));
 }
 
 TEST_F(LibNiceConnectionTest, sendData_Succeed_When_Ice_Ready) {
   const unsigned int kCompId = 1;
-  const int kLength = sizeof(test_packet);
+  const int kLength = strlen(test_packet);
 
   EXPECT_CALL(*nice_listener, updateIceState(erizo::IceState::READY , _)).Times(1);
   nice_connection->updateIceState(erizo::IceState::READY);
@@ -370,7 +370,7 @@ TEST_F(LibNiceConnectionTest, sendData_Succeed_When_Ice_Ready) {
 
 TEST_F(LibNiceConnectionTest, sendData_Fail_When_Ice_Not_Ready) {
   const unsigned int kCompId = 1;
-  const unsigned int kLength = sizeof(test_packet);
+  const unsigned int kLength = strlen(test_packet);
 
   EXPECT_CALL(*libnice, NiceAgentSend(_, _, kCompId, kLength, _)).Times(0);
   EXPECT_EQ(-1, nice_connection->sendData(kCompId, test_packet, kLength));

--- a/erizo/src/test/LibNiceConnectionTest.cpp
+++ b/erizo/src/test/LibNiceConnectionTest.cpp
@@ -355,7 +355,7 @@ TEST_F(LibNiceConnectionTest, queuePacket_QueuedPackets_Can_Be_getPacket_When_Re
 
   ASSERT_THAT(packet.get(), Not(Eq(nullptr)));
   EXPECT_EQ(static_cast<unsigned int>(packet->length), strlen(test_packet));
-  EXPECT_EQ(0, strcmp(test_packet, packet->data));
+  EXPECT_EQ(0, strncmp(test_packet, packet->data, strlen(test_packet)));
 }
 
 TEST_F(LibNiceConnectionTest, sendData_Succeed_When_Ice_Ready) {

--- a/erizo/src/test/NicerConnectionTest.cpp
+++ b/erizo/src/test/NicerConnectionTest.cpp
@@ -362,7 +362,7 @@ TEST_F(NicerConnectionTest, queuePacket_QueuedPackets_Can_Be_getPacket_When_Read
 
   ASSERT_THAT(packet.get(), Not(Eq(nullptr)));
   EXPECT_EQ(static_cast<unsigned int>(packet->length), strlen(test_packet));
-  EXPECT_EQ(0, strcmp(test_packet, packet->data));
+  EXPECT_EQ(0, strncmp(test_packet, packet->data, strlen(test_packet)));
 }
 
 TEST_F(NicerConnectionTest, sendData_Succeed_When_Ice_Ready) {

--- a/erizo/src/test/NicerConnectionTest.cpp
+++ b/erizo/src/test/NicerConnectionTest.cpp
@@ -358,16 +358,16 @@ TEST_F(NicerConnectionTest, queuePacket_QueuedPackets_Can_Be_getPacket_When_Read
   nicer_connection->updateIceState(erizo::IceState::READY);
   EXPECT_CALL(*nicer_listener, onPacketReceived(_)).WillOnce(SaveArg<0>(&packet));
 
-  nicer_connection->onData(0, test_packet, sizeof(test_packet));
+  nicer_connection->onData(0, test_packet, strlen(test_packet));
 
   ASSERT_THAT(packet.get(), Not(Eq(nullptr)));
-  EXPECT_EQ(static_cast<unsigned int>(packet->length), sizeof(test_packet));
+  EXPECT_EQ(static_cast<unsigned int>(packet->length), strlen(test_packet));
   EXPECT_EQ(0, strcmp(test_packet, packet->data));
 }
 
 TEST_F(NicerConnectionTest, sendData_Succeed_When_Ice_Ready) {
   const unsigned int kCompId = 1;
-  const int kLength = sizeof(test_packet);
+  const int kLength = strlen(test_packet);
 
   EXPECT_CALL(*nicer_listener, updateIceState(erizo::IceState::READY , _)).Times(1);
   nicer_connection->updateIceState(erizo::IceState::READY);
@@ -377,7 +377,7 @@ TEST_F(NicerConnectionTest, sendData_Succeed_When_Ice_Ready) {
 
 TEST_F(NicerConnectionTest, sendData_Fail_When_Ice_Not_Ready) {
   const unsigned int kCompId = 1;
-  const unsigned int kLength = sizeof(test_packet);
+  const unsigned int kLength = strlen(test_packet);
 
   EXPECT_CALL(*nicer, IceMediaStreamSend(_, _, kCompId, _, kLength)).Times(0);
   EXPECT_EQ(-1, nicer_connection->sendData(kCompId, test_packet, kLength));


### PR DESCRIPTION
This PR fixes issues in NicerConnectionTest.cpp and LibNiceConnectionTest.cpp: using strcmp may be unsafe in not null terminating strings, it's preferable to use strncmp().

It includes also some small performance improvements.