### PR TITLE
Avoid race conditions while running a sort function in the new bw distributor

### DIFF
--- a/erizo/src/erizo/bandwidth/TargetVideoBWDistributor.h
+++ b/erizo/src/erizo/bandwidth/TargetVideoBWDistributor.h
@@ -7,6 +7,16 @@ namespace erizo {
 
 class MediaStream;
 
+struct MediaStreamInfo {
+ public:
+  std::shared_ptr<MediaStream> stream;
+  bool is_simulcast;
+  bool is_slideshow;
+  uint32_t bitrate_sent;
+  uint32_t max_video_bw;
+  uint32_t bitrate_from_max_quality_layer;
+};
+
 class TargetVideoBWDistributor : public BandwidthDistributionAlgorithm {
  public:
   TargetVideoBWDistributor() {}
@@ -14,7 +24,7 @@ class TargetVideoBWDistributor : public BandwidthDistributionAlgorithm {
   void distribute(uint32_t remb, uint32_t ssrc, std::vector<std::shared_ptr<MediaStream>> streams,
                   Transport *transport) override;
  private:
-  uint32_t getTargetVideoBW(const std::shared_ptr<MediaStream> &stream);
+  uint32_t getTargetVideoBW(const MediaStreamInfo &stream);
 };
 
 }  // namespace erizo


### PR DESCRIPTION
**Description**

With this change we will avoid having race conditions within the bw distributor.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.