### PR TITLE
Update to Ubuntu 16.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 MAINTAINER Lynckia
 

--- a/doc/from_source.md
+++ b/doc/from_source.md
@@ -2,12 +2,12 @@
 This guide will guide you through the basics of getting a Licode instance with a basic videoconferencing application up and running.
 
 # Prerequisites
-We **only** officially support **Ubuntu 14.04** for production environments.
+We **only** officially support **Ubuntu 16.04** for production environments.
 
 We do maintain compatibility with **Mac OS X** for **development and testing purposes**.
 
 
-|Ubuntu 14.04 | Mac OS X > 10.11 |
+|Ubuntu 16.04 | Mac OS X > 10.11 |
 |-------------|------------------|
 |git|Xcode Command Line Tools|
 |   |git|

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -14,6 +14,12 @@ LIB_DIR=$BUILD_DIR/libdeps
 PREFIX_DIR=$LIB_DIR/build/
 FAST_MAKE=''
 
+check_sudo(){
+  if [ -z `command -v sudo` ]; then
+    echo 'sudo is not available, will install it.'
+    apt-get install sudo
+  fi
+}
 
 parse_arguments(){
   while [ "$1" != "" ]; do
@@ -71,6 +77,7 @@ install_apt_deps(){
   npm install
   npm install -g node-gyp
   npm install gulp@3.9.1 gulp-eslint@3 run-sequence@2.2.1 webpack-stream@4.0.0 google-closure-compiler-js@20170521.0.0 del@3.0.0 gulp-sourcemaps@2.6.4 script-loader@0.7.2 expose-loader@0.7.5
+  sudo apt-get update -y
   sudo apt-get install -qq python-software-properties -y
   sudo apt-get install -qq software-properties-common -y
   sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
@@ -157,10 +164,10 @@ install_mediadeps(){
   sudo apt-get -qq install yasm libvpx. libx264.
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    if [ ! -f ./v11.1.tar.gz ]; then
-      curl -O -L https://github.com/libav/libav/archive/v11.1.tar.gz
-      tar -zxvf v11.1.tar.gz
-      cd libav-11.1
+    if [ ! -f ./v11.9.tar.gz ]; then
+      curl -O -L https://github.com/libav/libav/archive/v11.9.tar.gz
+      tar -zxvf v11.9.tar.gz
+      cd libav-11.9
       PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libx264 --enable-libopus --disable-doc
       make $FAST_MAKE -s V=0
       make install
@@ -180,11 +187,11 @@ install_mediadeps_nogpl(){
   sudo apt-get -qq install yasm libvpx.
   if [ -d $LIB_DIR ]; then
     cd $LIB_DIR
-    if [ ! -f ./v11.1.tar.gz ]; then
-      curl -O -L https://github.com/libav/libav/archive/v11.1.tar.gz
-      tar -zxvf v11.1.tar.gz
-      cd libav-11.1
-      PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-gpl --enable-libvpx --enable-libopus --disable-doc
+    if [ ! -f ./v11.9.tar.gz ]; then
+      curl -O -L https://github.com/libav/libav/archive/v11.9.tar.gz
+      tar -zxvf v11.9.tar.gz
+      cd libav-11.9
+      PKG_CONFIG_PATH=${PREFIX_DIR}/lib/pkgconfig ./configure --prefix=$PREFIX_DIR --enable-shared --enable-libvpx --enable-libopus --disable-doc
       make $FAST_MAKE -s V=0
       make install
     else
@@ -229,6 +236,7 @@ parse_arguments $*
 
 mkdir -p $PREFIX_DIR
 
+check_sudo
 install_apt_deps
 check_proxy
 install_openssl


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR fixes a compatibility issue with Ubuntu 16.04 and sets it as the default for the docker builds.
Once this PR is merged, all our tests will be run with the new docker image so Ubuntu 16.04 will be our supported Ubuntu version - this PR also updates the docs accordingly

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

 [X] It includes documentation for these changes in `/doc`.