### PR TITLE
 Remove closed singlePC connection in ErizoClient

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -484,7 +484,7 @@ void MediaStream::read(std::shared_ptr<DataPacket> packet) {
   uint32_t recvSSRC = 0;
   if (!chead->isRtcp()) {
     recvSSRC = head->getSSRC();
-  } else if (chead->packettype == RTCP_Sender_PT) {  // Sender Report
+  } else if (chead->packettype == RTCP_Sender_PT || chead->packettype == RTCP_SDES_PT) {  // Sender Report
     recvSSRC = chead->getSSRC();
   }
   // DELIVER FEEDBACK (RR, FEEDBACK PACKETS)

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -227,7 +227,7 @@ std::shared_ptr<SdpInfo> WebRtcConnection::getLocalSdpInfo() {
       return;
     }
     std::vector<uint32_t> video_ssrc_list = std::vector<uint32_t>();
-    if (media_stream->getVideoSinkSSRC() != kDefaultVideoSinkSSRC) {
+    if (media_stream->getVideoSinkSSRC() != kDefaultVideoSinkSSRC && media_stream->getVideoSinkSSRC() != 0) {
       video_ssrc_list.push_back(media_stream->getVideoSinkSSRC());
     }
     ELOG_DEBUG("%s message: getting local SDPInfo, stream_id: %s, audio_ssrc: %u",
@@ -235,7 +235,7 @@ std::shared_ptr<SdpInfo> WebRtcConnection::getLocalSdpInfo() {
     if (!video_ssrc_list.empty()) {
       local_sdp_->video_ssrc_map[media_stream->getLabel()] = video_ssrc_list;
     }
-    if (media_stream->getAudioSinkSSRC() != kDefaultAudioSinkSSRC) {
+    if (media_stream->getAudioSinkSSRC() != kDefaultAudioSinkSSRC && media_stream->getAudioSinkSSRC() != 0) {
       local_sdp_->audio_ssrc_map[media_stream->getLabel()] = media_stream->getAudioSinkSSRC();
     }
   });

--- a/erizo/src/erizo/thread/Worker.cpp
+++ b/erizo/src/erizo/thread/Worker.cpp
@@ -130,7 +130,7 @@ void SimulatedWorker::close() {
 
 std::shared_ptr<ScheduledTaskReference> SimulatedWorker::scheduleFromNow(Task f, duration delta) {
   auto id = std::make_shared<ScheduledTaskReference>();
-  scheduled_tasks_[clock_->now() + delta] =  [this, f, id] {
+  scheduled_tasks_[clock_->now() + delta] =  [f, id] {
       if (id->isCancelled()) {
         return;
       }

--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -181,6 +181,7 @@ class ErizoConnectionManager {
     if (connection.streamsMap.size() === 0) {
       connection.close();
       if (this.ErizoConnectionsMap.get(connection.erizoId) !== undefined) {
+        delete this.ErizoConnectionsMap.get(connection.erizoId)['single-pc'];
         delete this.ErizoConnectionsMap.get(connection.erizoId)[connection.sessionId];
       }
     }

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -219,7 +219,8 @@ exports.ErizoJSController = function (threadPool, ioThreadPool) {
         var publisher = publishers[streamId];
           if (publisher !== undefined) {
               log.info(`message: Removing publisher, id: ${clientId}, streamId: ${streamId}`);
-              for (let subscriberKey in publisher.subscribers) {
+              const subscriberKeys = publisher.subscribers;
+              for (let subscriberKey in subscriberKeys) {
                   let subscriber = publisher.getSubscriber(subscriberKey);
                   log.info('message: Removing subscriber, id: ' + subscriberKey);
                   closeNode(subscriber);


### PR DESCRIPTION
**Description**

We weren't removing singlePC that was previously closed in ErizoClient. I also added some other minor fixes I found while debugging this issue.

[] It needs and includes Unit Tests

Not needed.

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.