### PR TITLE
copy sdpInfo when passed to and from WebRtcConnection

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -159,7 +159,7 @@ bool MediaStream::setRemoteSdp(std::shared_ptr<SdpInfo> sdp) {
   if (!sending_) {
     return true;
   }
-  remote_sdp_ = sdp;
+  remote_sdp_ =  std::make_shared<SdpInfo>(*sdp.get());
   if (remote_sdp_->videoBandwidth != 0) {
     ELOG_DEBUG("%s message: Setting remote BW, maxVideoBW: %u", toLog(), remote_sdp_->videoBandwidth);
     this->rtcp_processor_->setMaxVideoBW(remote_sdp_->videoBandwidth*1000);
@@ -169,7 +169,6 @@ bool MediaStream::setRemoteSdp(std::shared_ptr<SdpInfo> sdp) {
     pipeline_->notifyUpdate();
     return true;
   }
-
 
   bundle_ = remote_sdp_->isBundle;
   auto video_ssrc_list_it = remote_sdp_->video_ssrc_map.find(getLabel());

--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -307,7 +307,7 @@ NAN_METHOD(WebRtcConnection::setRemoteDescription) {
 
   ConnectionDescription* param =
     Nan::ObjectWrap::Unwrap<ConnectionDescription>(Nan::To<v8::Object>(info[0]).ToLocalChecked());
-  auto sdp = std::shared_ptr<erizo::SdpInfo>(param->me);
+  auto sdp = std::make_shared<erizo::SdpInfo>(*param->me.get());
 
   v8::String::Utf8Value stream_id_param(Nan::To<v8::String>(info[1]).ToLocalChecked());
   std::string stream_id = std::string(*stream_id_param);
@@ -323,7 +323,7 @@ NAN_METHOD(WebRtcConnection::getLocalDescription) {
     return;
   }
 
-  std::shared_ptr<erizo::SdpInfo> sdp_info = me->getLocalSdpInfo();
+  std::shared_ptr<erizo::SdpInfo> sdp_info = std::make_shared<erizo::SdpInfo>(*me->getLocalSdpInfo().get());
 
   v8::Local<v8::Object> instance = ConnectionDescription::NewInstance();
   ConnectionDescription* description = ObjectWrap::Unwrap<ConnectionDescription>(instance);


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This fixes potential  concurrency problems when managing `SdpInfo` in `ConnectionDescription` `WebRtcConnection` and `MediaStream`, they all shared the same pointer causing problems. They don't need a shared pointer and the info can be copied when needed, at very specific points.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.