### PR TITLE
Fix SDP negotiation when a stream is audio only

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -240,6 +240,9 @@ std::shared_ptr<SdpInfo> WebRtcConnection::getLocalSdpInfo() {
   bool receiving_audio = remote_sdp_->audio_ssrc_map.size() > 0;
   bool receiving_video = remote_sdp_->video_ssrc_map.size() > 0;
 
+  audio_enabled_ = sending_audio || receiving_audio;
+  video_enabled_ = sending_video || receiving_video;
+
   if (!sending_audio && receiving_audio) {
     local_sdp_->audioDirection = erizo::RECVONLY;
   } else if (sending_audio && !receiving_audio) {

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -43,8 +43,8 @@ const BaseStack = (specInput) => {
   specBase.remoteDescriptionSet = false;
 
   that.mediaConstraints = {
-    offerToReceiveVideo: true,
-    offerToReceiveAudio: true,
+    offerToReceiveVideo: (that.video !== undefined && that.video !== false),
+    offerToReceiveAudio: (that.audio !== undefined && that.audio !== false),
   };
 
   that.peerConnection = new RTCPeerConnection(that.pcConfig, that.con);

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -43,8 +43,8 @@ const BaseStack = (specInput) => {
   specBase.remoteDescriptionSet = false;
 
   that.mediaConstraints = {
-    offerToReceiveVideo: (that.video !== undefined && that.video !== false),
-    offerToReceiveAudio: (that.audio !== undefined && that.audio !== false),
+    offerToReceiveVideo: true,
+    offerToReceiveAudio: true,
   };
 
   that.peerConnection = new RTCPeerConnection(that.pcConfig, that.con);

--- a/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
@@ -7,6 +7,10 @@ const ChromeStableStack = (specInput) => {
   const spec = specInput;
   const that = BaseStack(specInput);
   const defaultSimulcastSpatialLayers = 2;
+  that.mediaConstraints = {
+    offerToReceiveVideo: true,
+    offerToReceiveAudio: true,
+  };
 
   that.enableSimulcast = (sdpInput) => {
     let result;

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -51,12 +51,13 @@ window.onload = function () {
   var roomName = getParameterByName('room') || 'basicExampleRoom';
   var singlePC = getParameterByName('singlePC') || false;
   var roomType = getParameterByName('type') || 'erizo';
+  var audioOnly = getParameterByName('onlyAudio') || false;
   var mediaConfiguration = getParameterByName('mediaConfiguration') || 'default';
   var onlySubscribe = getParameterByName('onlySubscribe');
   var onlyPublish = getParameterByName('onlyPublish');
   console.log('Selected Room', roomName, 'of type', roomType);
   var config = {audio: true,
-                video: true,
+                video: !audioOnly,
                 data: true,
                 screen: screen,
                 videoSize: [640, 480, 640, 480],


### PR DESCRIPTION
**Description**

There was an issue in Single Peer Connection by which we were not negotiating SDP properly when the first subscribed stream had only audio.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.