### PR TITLE
Fixed crash when enablingSlideShowBelowSpatialLayer when un initialized

### DIFF
--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -270,9 +270,13 @@ void QualityManager::enableSlideShowBelowSpatialLayer(bool enable, int spatial_l
   enable_slideshow_below_spatial_layer_ = enable;
   slideshow_below_spatial_layer_ = spatial_layer;
 
-  stream_->notifyMediaStreamEvent("slideshow_fallback_update", "false");
+  if (!initialized_) {
+    return;
+  }
 
+  stream_->notifyMediaStreamEvent("slideshow_fallback_update", "false");
   freeze_fallback_active_ = false;
+
   selectLayer(true);
 }
 


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR fixes a crash that could potentially happen when calling `enableSlideShowBelowSpatialLayer` before `QualityManager` is initialized

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.