### PR TITLE
Burst size is now calculated depending on the packets to be sent

### DIFF
--- a/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.cpp
@@ -15,7 +15,8 @@ constexpr duration kStatsPeriod = std::chrono::milliseconds(100);
 constexpr uint8_t kMaxPaddingSize = 255;
 constexpr uint64_t kMinMarkerRate = 3;
 constexpr uint64_t kInitialBitrate = 300000;
-constexpr uint64_t kPaddingBurstSize = 255 * 10;
+constexpr uint8_t kMaxBurstPackets = 200;
+constexpr uint8_t kSlideShowBurstPackets = 20;
 
 RtpPaddingGeneratorHandler::RtpPaddingGeneratorHandler(std::shared_ptr<erizo::Clock> the_clock) :
   clock_{the_clock}, stream_{nullptr}, max_video_bw_{0}, higher_sequence_number_{0},
@@ -23,10 +24,12 @@ RtpPaddingGeneratorHandler::RtpPaddingGeneratorHandler(std::shared_ptr<erizo::Cl
   number_of_full_padding_packets_{0}, last_padding_packet_size_{0},
   last_rate_calculation_time_{clock_->now()}, started_at_{clock_->now()},
   enabled_{false}, first_packet_received_{false},
+  slideshow_mode_active_ {false},
   marker_rate_{std::chrono::milliseconds(100), 20, 1., clock_},
   rtp_header_length_{12},
-  bucket_{kInitialBitrate, kPaddingBurstSize, clock_},
-  scheduled_task_{std::make_shared<ScheduledTaskReference>()} {}
+  bucket_{kInitialBitrate, kSlideShowBurstPackets * kMaxPaddingSize, clock_},
+  scheduled_task_{std::make_shared<ScheduledTaskReference>()} {
+  }
 
 
 
@@ -59,6 +62,8 @@ void RtpPaddingGeneratorHandler::notifyUpdate() {
   if (processor) {
     max_video_bw_ = processor->getMaxVideoBW();
   }
+
+  slideshow_mode_active_ = stream_->isSlideShowModeEnabled();
 }
 
 void RtpPaddingGeneratorHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet) {
@@ -174,7 +179,7 @@ void RtpPaddingGeneratorHandler::recalculatePaddingRate() {
 
   int64_t target_padding_bitrate = target_bitrate - media_bitrate;
   // TODO(pedro): figure out a burst size that makes sense here
-  bucket_.reset(std::max(target_padding_bitrate, int64_t(0)), kPaddingBurstSize);
+  bucket_.reset(std::max(target_padding_bitrate, int64_t(0)), getBurstSize());
 
   if (target_padding_bitrate <= 0) {
     number_of_full_padding_packets_ = 0;
@@ -200,6 +205,14 @@ uint64_t RtpPaddingGeneratorHandler::getTargetBitrate() {
     target_bitrate = std::min(target_bitrate, max_video_bw_);
   }
   return target_bitrate;
+}
+
+uint64_t RtpPaddingGeneratorHandler::getBurstSize() {
+  uint64_t burstPackets = kSlideShowBurstPackets;
+  if (!slideshow_mode_active_) {
+    burstPackets = std::min((number_of_full_padding_packets_ + 1), (uint64_t)kMaxBurstPackets);
+  }
+  return burstPackets * kMaxPaddingSize;
 }
 
 void RtpPaddingGeneratorHandler::enablePadding() {

--- a/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.h
+++ b/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.h
@@ -40,6 +40,7 @@ class RtpPaddingGeneratorHandler: public Handler, public std::enable_shared_from
 
   uint64_t getStat(std::string stat_name);
   uint64_t getTargetBitrate();
+  uint64_t getBurstSize();
 
   bool isTimeToCalculateBitrate();
   void recalculatePaddingRate();
@@ -62,6 +63,7 @@ class RtpPaddingGeneratorHandler: public Handler, public std::enable_shared_from
   time_point started_at_;
   bool enabled_;
   bool first_packet_received_;
+  bool slideshow_mode_active_;
   MovingIntervalRateStat marker_rate_;
   uint32_t rtp_header_length_;
   TokenBucket bucket_;


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
This PR makes the burst size for the Token Bucket used in `PaddingGeneratorHandler` variable.
Before this PR, the burst size was a constant but we are trying to send a variable amount of packets depending on the target padding bitrate. It makes sense to also make variable the burst size that the tokenBucket will allow.

The maximum and minimum burst sizes are bounded to avoid bursts that are too big and, at the same time, avoid setting a burst limit too small.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.