### PR TITLE
fix subscribing to you own streams

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -232,7 +232,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       return;
     }
     const stream = Stream(that.Connection, { streamID: arg.id,
-      local: localStreams.has(arg.id),
+      local: false,
       audio: arg.audio,
       video: arg.video,
       data: arg.data,


### PR DESCRIPTION
was changed to ``localStreams.has(arg.id),``  a few commits ago but breaks subscribing to own streams (You can check it in the basic example. 