### PR TITLE
Add info to log whether a stream quality is capped by layer constraints

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -250,6 +250,7 @@ void MediaStream::initializeStats() {
   log_stats_->getNode().insertStat("bwe", CumulativeStat{0});
 
   log_stats_->getNode().insertStat("maxVideoBW", CumulativeStat{0});
+  log_stats_->getNode().insertStat("qualityCappedByConstraints", CumulativeStat{0});
 
   std::weak_ptr<MediaStream> weak_this = shared_from_this();
   worker_->scheduleEvery([weak_this] () {
@@ -289,6 +290,8 @@ void MediaStream::printStats() {
   log_stats_->getNode().insertStat("videoEnabled", CumulativeStat{video_enabled_});
 
   log_stats_->getNode().insertStat("maxVideoBW", CumulativeStat{getMaxVideoBW()});
+
+  transferMediaStats("qualityCappedByConstraints", "qualityLayers", "qualityCappedByConstraints");
 
   if (audio_enabled_) {
     audio_ssrc = std::to_string(is_publisher_ ? getAudioSourceSSRC() : getAudioSinkSSRC());

--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -204,6 +204,8 @@ void QualityManager::selectLayer(bool try_higher_layers) {
     // TODO(javier): should we wait for the actual spatial switch?
     // should we disable padding temporarily to avoid congestion (old padding + new bitrate)?
   }
+  stats_->getNode()["qualityLayers"].insertStat("qualityCappedByConstraints",
+                                                CumulativeStat{layer_capped_by_constraints});
   setPadding(!isInMaxLayer() && !layer_capped_by_constraints);
   ELOG_DEBUG("message: Is padding enabled, padding_enabled_: %d", padding_enabled_);
 }


### PR DESCRIPTION
**Description**

Add info to log whether a stream quality is capped by layer constraints

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.