### PR TITLE
Fix events on erizoList

### DIFF
--- a/erizo_controller/erizoController/models/ErizoList.js
+++ b/erizo_controller/erizoController/models/ErizoList.js
@@ -71,7 +71,7 @@ class ErizoList extends EventEmitter {
     erizo.erizoId = erizoId;
     erizo.agentId = agentId;
     erizo.erizoIdForAgent = erizoIdForAgent;
-    this.emit(position, erizo);
+    this.emit(this.getInternalPosition(position), erizo);
   }
 }
 

--- a/erizo_controller/erizoController/models/ErizoList.js
+++ b/erizo_controller/erizoController/models/ErizoList.js
@@ -28,7 +28,7 @@ class ErizoList extends EventEmitter {
   }
 
   onErizoReceived(position, callback) {
-    this.on(this.getInternalPosition(position), callback);
+    this.once(this.getInternalPosition(position), callback);
   }
 
   getInternalPosition(position) {


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR solves a race condition when rapidly publishing multiple streams on the first use of the same ErizoJS process. We were subscribing to the event for a different position in the list.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.