### PR TITLE
Do SSL/DTLS init on addon start instead of in DtlsClient constructor

### DIFF
--- a/erizo/src/erizo/dtls/DtlsClient.cpp
+++ b/erizo/src/erizo/dtls/DtlsClient.cpp
@@ -214,7 +214,6 @@ int createCert(const std::string& pAor, int expireDays, int keyLen, X509*& outCe
   // is required
   DtlsSocketContext::DtlsSocketContext() {
     started = false;
-    DtlsSocketContext::Init();
 
     ELOG_DEBUG("Creating Dtls factory, Openssl v %s", OPENSSL_VERSION_TEXT);
 

--- a/erizoAPI/addon.cc
+++ b/erizoAPI/addon.cc
@@ -2,6 +2,7 @@
 #define BUILDING_NODE_EXTENSION
 #endif
 #include <nan.h>
+#include <dtls/DtlsSocket.h>
 #include "WebRtcConnection.h"
 #include "MediaStream.h"
 #include "OneToManyProcessor.h"
@@ -14,6 +15,7 @@
 #include "IOThreadPool.h"
 
 NAN_MODULE_INIT(InitAll) {
+  dtls::DtlsSocketContext::Init();
   WebRtcConnection::Init(target);
   MediaStream::Init(target);
   OneToManyProcessor::Init(target);


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

The ssl init and the creation of the static certificate used in the session where being created in the `DtlsSocketContext` constructor and the `Init` static function was not thread-safe. 
This PR avoids this problem by initializing those fields in the initialization of the  Node Addon which is done synchronously when starting the ErizoJS process

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.