### PR TITLE
Fix missing raddr and rport in srflx candidates

### DIFF
--- a/erizo_controller/common/semanticSdp/SDPInfo.js
+++ b/erizo_controller/common/semanticSdp/SDPInfo.js
@@ -270,7 +270,7 @@ class SDPInfo {
 
       const candidates = media.getCandidates();
       candidates.forEach((candidate) => {
-        md.candidates.push({
+        const cand = {
           foundation: candidate.getFoundation(),
           component: candidate.getComponentId(),
           transport: candidate.getTransport(),
@@ -278,10 +278,13 @@ class SDPInfo {
           ip: candidate.getAddress(),
           port: candidate.getPort(),
           type: candidate.getType(),
-          relAddr: candidate.getRelAddr(),
-          relPort: candidate.getRelPort(),
           generation: candidate.getGeneration(),
-        });
+        };
+        if (candidate.getRelAddr()) {
+          cand.raddr = candidate.getRelAddr();
+          cand.rport = candidate.getRelPort();
+        }
+        md.candidates.push(cand);
       });
 
       ice = media.getICE();
@@ -822,7 +825,7 @@ SDPInfo.process = (sdp) => {
       candidates.forEach((candidate) => {
         mediaInfo.addCandidate(new CandidateInfo(candidate.foundation, candidate.component,
           candidate.transport, candidate.priority, candidate.ip, candidate.port, candidate.type,
-          candidate.generation, candidate.relAddr, candidate.relPort));
+          candidate.generation, candidate.raddr, candidate.rport));
       });
     }
 


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
The raddr and rport in srflx candidates are accidentally removed when converting SDP object to a string and vice versa. Should use the correct property names (raddr and rport) for the conversion.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.