### PR TITLE
Fix some build errors being ignored

### DIFF
--- a/scripts/checkNvm.sh
+++ b/scripts/checkNvm.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set +e
-
 check_readlink() {
   if [ "$(uname)" == "Darwin" ]; then
     # Do something under Mac OS X platform
@@ -15,8 +13,7 @@ check_readlink() {
   fi
 
 }
-command -v nvm | grep 'nvm' &> /dev/null
-if [ ! $? == 0 ]; then
+if ! command -v nvm | grep 'nvm' &> /dev/null; then
   check_readlink
   CHECK_SCRIPT=$($READLINK -f "$0")
   CHECK_SCRIPT_PATH=$(dirname "$CHECK_SCRIPT")
@@ -25,10 +22,12 @@ if [ ! $? == 0 ]; then
   echo "Checking dir $NVM_DIR"
   if [ -s "$NVM_DIR/nvm.sh" ]; then
     echo "Running nvm"
+    [[ $- = *e* ]] && WAS_E_SET=true
+    set +e
     . "$NVM_DIR/nvm.sh" # This loads nvm
+    if [ $WAS_E_SET ]; then set -e; fi
   else
     echo "ERROR: Missing NVM"
     exit 1
   fi
 fi
-


### PR DESCRIPTION
Fixes a problem where `scripts/checkNvm.sh` is being sourced and so therefore overwriting the `set -e` of the parent script, causing subsequent errors in the build output to be ignored rather than causing a build failure. Also will include fixes to get the build back to a successful state.

[] It needs and includes Unit Tests - Doesn't need any tests

**Changes in Client or Server public APIs**

No changes
[] It includes documentation for these changes in `/doc`.