### PR TITLE
Use nvm to launch erizojs from agent

### DIFF
--- a/erizo_controller/erizoAgent/launch.sh
+++ b/erizo_controller/erizoAgent/launch.sh
@@ -1,3 +1,10 @@
 #!/usr/bin/env bash
+
+SCRIPT=`pwd`
+PATHNAME=`dirname $SCRIPT`
+ROOT=$PATHNAME/..
+SCRIPTS_FOLDER=$ROOT/scripts
+NVM_CHECK="$SCRIPTS_FOLDER"/checkNvm.sh
+
 ulimit -c unlimited
-exec node $ERIZOJS_NODE_OPTIONS $*
+exec $NVM_CHECK node $ERIZOJS_NODE_OPTIONS $*

--- a/scripts/checkNvm.sh
+++ b/scripts/checkNvm.sh
@@ -26,6 +26,10 @@ if [ ! $? == 0 ]; then
   if [ -s "$NVM_DIR/nvm.sh" ]; then
     echo "Running nvm"
     . "$NVM_DIR/nvm.sh" # This loads nvm
+    # If arguments are provided, instead of only sourcing nvm it executes
+    if [ ! $1 == 0 ]; then  
+      nvm run $*
+    fi
   else
     echo "ERROR: Missing NVM"
     exit 1


### PR DESCRIPTION
Currently erizo.js is spawned by launch.sh
this exec node, which is the globally installed node and not the one sourced with nvm.

this can cause some conflicts on a machine running node >8 since the APIs are compiled with gyp of node 6 but spawned with node 8.