### PR TITLE
FakeKeyframeGeneratorHandler only acts if transport is ready

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -662,7 +662,7 @@ void WebRtcConnection::updateState(TransportState state, Transport * transport) 
 
   global_state_ = temp;
 
-  ELOG_INFO("%s newGlobalState: %d", toLog(), global_state_);
+  ELOG_DEBUG("%s newGlobalState: %d", toLog(), temp);
   maybeNotifyWebRtcConnectionEvent(global_state_, msg);
 }
 

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -662,7 +662,7 @@ void WebRtcConnection::updateState(TransportState state, Transport * transport) 
 
   global_state_ = temp;
 
-  ELOG_DEBUG("%s newGlobalState: %d", toLog(), temp);
+  ELOG_INFO("%s newGlobalState: %d", toLog(), temp);
   maybeNotifyWebRtcConnectionEvent(global_state_, msg);
 }
 

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -163,6 +163,9 @@ class WebRtcConnection: public TransportListener, public LogContext,
   void maybeNotifyWebRtcConnectionEvent(const WebRTCEvent& event, const std::string& message,
         const std::string& stream_id = "");
 
+ protected:
+  std::atomic<WebRTCEvent> global_state_;
+
  private:
   std::string connection_id_;
   bool audio_enabled_;
@@ -180,7 +183,6 @@ class WebRtcConnection: public TransportListener, public LogContext,
   std::shared_ptr<Transport> video_transport_, audio_transport_;
 
   std::shared_ptr<Stats> stats_;
-  WebRTCEvent global_state_;
 
   boost::mutex update_state_mutex_;
   boost::mutex event_listener_mutex_;

--- a/erizo/src/erizo/rtp/FakeKeyframeGeneratorHandler.cpp
+++ b/erizo/src/erizo/rtp/FakeKeyframeGeneratorHandler.cpp
@@ -9,89 +9,102 @@
 
 namespace erizo {
 
-DEFINE_LOGGER(FakeKeyframeGeneratorHandler, "rtp.FakeKeyframeGeneratorHandler");
+  DEFINE_LOGGER(FakeKeyframeGeneratorHandler, "rtp.FakeKeyframeGeneratorHandler");
 
-constexpr uint64_t kPliPeriodMs = 300;
+  constexpr uint64_t kPliPeriodMs = 300;
 
-FakeKeyframeGeneratorHandler::FakeKeyframeGeneratorHandler() :
-  stream_{nullptr}, enabled_{true}, first_keyframe_received_{false}, plis_scheduled_{false},
-  video_source_ssrc_{0}, video_sink_ssrc_{0} {
+  FakeKeyframeGeneratorHandler::FakeKeyframeGeneratorHandler() :
+    stream_{nullptr}, enabled_{true}, first_keyframe_received_{false}, plis_scheduled_{false},
+    video_source_ssrc_{0}, video_sink_ssrc_{0} {
+    }
+
+  void FakeKeyframeGeneratorHandler::enable() {
+    enabled_ = true;
   }
 
-void FakeKeyframeGeneratorHandler::enable() {
-  enabled_ = true;
-}
-
-void FakeKeyframeGeneratorHandler::disable() {
-  enabled_ = false;
-}
-
-void FakeKeyframeGeneratorHandler::notifyUpdate() {
-  auto pipeline = getContext()->getPipelineShared();
-  if (pipeline && !stream_) {
-    stream_ = pipeline->getService<MediaStream>().get();
+  void FakeKeyframeGeneratorHandler::disable() {
+    enabled_ = false;
   }
-  if (stream_) {
-    video_source_ssrc_ = stream_->getVideoSourceSSRC();
-    video_sink_ssrc_ = stream_->getVideoSinkSSRC();
-  }
-}
 
-void FakeKeyframeGeneratorHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet) {
-  ctx->fireRead(std::move(packet));
-}
-
-void FakeKeyframeGeneratorHandler::write(Context *ctx, std::shared_ptr<DataPacket> packet) {
-  RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
-  if (enabled_) {
-    if (!first_keyframe_received_ && packet->type == VIDEO_PACKET && !chead->isRtcp()) {
-      if (!packet->is_keyframe) {
-        if (!plis_scheduled_) {
-          plis_scheduled_ = true;
-          ELOG_DEBUG("Scheduling PLIs");
-          sendPLI();
-          schedulePLI();
-        }
-        ELOG_DEBUG("Building a black keyframe from packet");
-        auto keyframe_packet = transformIntoKeyframePacket(packet);
-        ctx->fireWrite(keyframe_packet);
-        return;
-      } else {
-        ELOG_DEBUG("First part of a keyframe received, stop rewriting packets");
-        first_keyframe_received_ = true;
-      }
+  void FakeKeyframeGeneratorHandler::notifyUpdate() {
+    auto pipeline = getContext()->getPipelineShared();
+    if (pipeline && !stream_) {
+      stream_ = pipeline->getService<MediaStream>().get();
+    }
+    if (stream_) {
+      video_source_ssrc_ = stream_->getVideoSourceSSRC();
+      video_sink_ssrc_ = stream_->getVideoSinkSSRC();
     }
   }
-  ctx->fireWrite(std::move(packet));
-}
 
-std::shared_ptr<DataPacket> FakeKeyframeGeneratorHandler::transformIntoKeyframePacket
-(std::shared_ptr<DataPacket> packet) {
-  if (packet->codec == "VP8") {
-    auto keyframe_packet = RtpUtils::makeVP8BlackKeyframePacket(packet);
-    return keyframe_packet;
-  } else {
-    ELOG_DEBUG("Generate keyframe packet is not available for codec %s", packet->codec);
-    return packet;
+  void FakeKeyframeGeneratorHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet) {
+    ctx->fireRead(std::move(packet));
   }
-}
-void FakeKeyframeGeneratorHandler::sendPLI() {
-  getContext()->fireRead(RtpUtils::createPLI(video_sink_ssrc_, video_source_ssrc_));
-}
-void FakeKeyframeGeneratorHandler::schedulePLI() {
-  std::weak_ptr<FakeKeyframeGeneratorHandler> weak_this = shared_from_this();
-  stream_->getWorker()->scheduleEvery([weak_this] {
-      if (auto this_ptr = weak_this.lock()) {
-        if (!this_ptr->first_keyframe_received_) {
-          ELOG_DEBUG("Sending PLI in FakeGenerator, scheduling another");
-          this_ptr->sendPLI();
-          return true;
+
+  void FakeKeyframeGeneratorHandler::write(Context *ctx, std::shared_ptr<DataPacket> packet) {
+    RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
+    if (!enabled_) {
+      ctx->fireWrite(std::move(packet));
+      return;
+    }
+
+    if (!first_keyframe_received_ && packet->type == VIDEO_PACKET && !chead->isRtcp()) {
+      if (stream_->getCurrentState() == CONN_READY) {  // TODO(pedro): Find a solution for this in all handlers
+        if (!packet->is_keyframe) {
+          maybeSendAndSchedulePLIs();
+          ELOG_DEBUG("Building a black keyframe from packet");
+          auto keyframe_packet = transformIntoKeyframePacket(packet);
+          ctx->fireWrite(keyframe_packet);
+          return;
         } else {
-          ELOG_DEBUG("Stop sending scheduled PLI packets");
-          return false;
+          ELOG_DEBUG("First part of a keyframe received, stop rewriting packets");
+          first_keyframe_received_ = true;
         }
+      } else {
+        ELOG_DEBUG("Transport is not ready - not transforming packet");
       }
-      return false;
-    }, std::chrono::milliseconds(kPliPeriodMs));
-}
+    }
+    ctx->fireWrite(std::move(packet));
+  }
+
+  std::shared_ptr<DataPacket> FakeKeyframeGeneratorHandler::transformIntoKeyframePacket
+    (std::shared_ptr<DataPacket> packet) {
+      if (packet->codec == "VP8") {
+        auto keyframe_packet = RtpUtils::makeVP8BlackKeyframePacket(packet);
+        return keyframe_packet;
+      } else {
+        ELOG_DEBUG("Generate keyframe packet is not available for codec %s", packet->codec);
+        return packet;
+      }
+    }
+
+  void FakeKeyframeGeneratorHandler::maybeSendAndSchedulePLIs() {
+    if (!plis_scheduled_) {
+      plis_scheduled_ = true;
+      ELOG_DEBUG("Scheduling PLIs");
+      sendPLI();
+      schedulePLI();
+    }
+  }
+
+  void FakeKeyframeGeneratorHandler::sendPLI() {
+    getContext()->fireRead(RtpUtils::createPLI(video_sink_ssrc_, video_source_ssrc_));
+  }
+
+  void FakeKeyframeGeneratorHandler::schedulePLI() {
+    std::weak_ptr<FakeKeyframeGeneratorHandler> weak_this = shared_from_this();
+    stream_->getWorker()->scheduleEvery([weak_this] {
+        if (auto this_ptr = weak_this.lock()) {
+        if (!this_ptr->first_keyframe_received_) {
+        ELOG_DEBUG("Sending PLI in FakeGenerator, scheduling another");
+        this_ptr->sendPLI();
+        return true;
+        } else {
+        ELOG_DEBUG("Stop sending scheduled PLI packets");
+        return false;
+        }
+        }
+        return false;
+        }, std::chrono::milliseconds(kPliPeriodMs));
+  }
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/FakeKeyframeGeneratorHandler.cpp
+++ b/erizo/src/erizo/rtp/FakeKeyframeGeneratorHandler.cpp
@@ -9,102 +9,102 @@
 
 namespace erizo {
 
-  DEFINE_LOGGER(FakeKeyframeGeneratorHandler, "rtp.FakeKeyframeGeneratorHandler");
+DEFINE_LOGGER(FakeKeyframeGeneratorHandler, "rtp.FakeKeyframeGeneratorHandler");
 
-  constexpr uint64_t kPliPeriodMs = 300;
+constexpr uint64_t kPliPeriodMs = 300;
 
-  FakeKeyframeGeneratorHandler::FakeKeyframeGeneratorHandler() :
-    stream_{nullptr}, enabled_{true}, first_keyframe_received_{false}, plis_scheduled_{false},
-    video_source_ssrc_{0}, video_sink_ssrc_{0} {
-    }
+FakeKeyframeGeneratorHandler::FakeKeyframeGeneratorHandler() :
+  stream_{nullptr}, enabled_{true}, first_keyframe_received_{false}, plis_scheduled_{false},
+  video_source_ssrc_{0}, video_sink_ssrc_{0} {
+}
 
-  void FakeKeyframeGeneratorHandler::enable() {
-    enabled_ = true;
+void FakeKeyframeGeneratorHandler::enable() {
+  enabled_ = true;
+}
+
+void FakeKeyframeGeneratorHandler::disable() {
+  enabled_ = false;
+}
+
+void FakeKeyframeGeneratorHandler::notifyUpdate() {
+  auto pipeline = getContext()->getPipelineShared();
+  if (pipeline && !stream_) {
+    stream_ = pipeline->getService<MediaStream>().get();
   }
-
-  void FakeKeyframeGeneratorHandler::disable() {
-    enabled_ = false;
+  if (stream_) {
+    video_source_ssrc_ = stream_->getVideoSourceSSRC();
+    video_sink_ssrc_ = stream_->getVideoSinkSSRC();
   }
+}
 
-  void FakeKeyframeGeneratorHandler::notifyUpdate() {
-    auto pipeline = getContext()->getPipelineShared();
-    if (pipeline && !stream_) {
-      stream_ = pipeline->getService<MediaStream>().get();
-    }
-    if (stream_) {
-      video_source_ssrc_ = stream_->getVideoSourceSSRC();
-      video_sink_ssrc_ = stream_->getVideoSinkSSRC();
-    }
-  }
+void FakeKeyframeGeneratorHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet) {
+  ctx->fireRead(std::move(packet));
+}
 
-  void FakeKeyframeGeneratorHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet) {
-    ctx->fireRead(std::move(packet));
-  }
-
-  void FakeKeyframeGeneratorHandler::write(Context *ctx, std::shared_ptr<DataPacket> packet) {
-    RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
-    if (!enabled_) {
-      ctx->fireWrite(std::move(packet));
-      return;
-    }
-
-    if (!first_keyframe_received_ && packet->type == VIDEO_PACKET && !chead->isRtcp()) {
-      if (stream_->getCurrentState() == CONN_READY) {  // TODO(pedro): Find a solution for this in all handlers
-        if (!packet->is_keyframe) {
-          maybeSendAndSchedulePLIs();
-          ELOG_DEBUG("Building a black keyframe from packet");
-          auto keyframe_packet = transformIntoKeyframePacket(packet);
-          ctx->fireWrite(keyframe_packet);
-          return;
-        } else {
-          ELOG_DEBUG("First part of a keyframe received, stop rewriting packets");
-          first_keyframe_received_ = true;
-        }
-      } else {
-        ELOG_DEBUG("Transport is not ready - not transforming packet");
-      }
-    }
+void FakeKeyframeGeneratorHandler::write(Context *ctx, std::shared_ptr<DataPacket> packet) {
+  RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
+  if (!enabled_) {
     ctx->fireWrite(std::move(packet));
+    return;
   }
 
-  std::shared_ptr<DataPacket> FakeKeyframeGeneratorHandler::transformIntoKeyframePacket
-    (std::shared_ptr<DataPacket> packet) {
-      if (packet->codec == "VP8") {
-        auto keyframe_packet = RtpUtils::makeVP8BlackKeyframePacket(packet);
-        return keyframe_packet;
+  if (!first_keyframe_received_ && packet->type == VIDEO_PACKET && !chead->isRtcp()) {
+    if (stream_->getCurrentState() == CONN_READY) {  // TODO(pedro): Find a solution for this in all handlers
+      if (!packet->is_keyframe) {
+        maybeSendAndSchedulePLIs();
+        ELOG_DEBUG("Building a black keyframe from packet");
+        auto keyframe_packet = transformIntoKeyframePacket(packet);
+        ctx->fireWrite(keyframe_packet);
+        return;
       } else {
-        ELOG_DEBUG("Generate keyframe packet is not available for codec %s", packet->codec);
-        return packet;
+        ELOG_DEBUG("First part of a keyframe received, stop rewriting packets");
+        first_keyframe_received_ = true;
       }
+    } else {
+      ELOG_DEBUG("Transport is not ready - not transforming packet");
     }
+  }
+  ctx->fireWrite(std::move(packet));
+}
 
-  void FakeKeyframeGeneratorHandler::maybeSendAndSchedulePLIs() {
-    if (!plis_scheduled_) {
-      plis_scheduled_ = true;
-      ELOG_DEBUG("Scheduling PLIs");
-      sendPLI();
-      schedulePLI();
+std::shared_ptr<DataPacket> FakeKeyframeGeneratorHandler::transformIntoKeyframePacket
+  (std::shared_ptr<DataPacket> packet) {
+    if (packet->codec == "VP8") {
+      auto keyframe_packet = RtpUtils::makeVP8BlackKeyframePacket(packet);
+      return keyframe_packet;
+    } else {
+      ELOG_DEBUG("Generate keyframe packet is not available for codec %s", packet->codec);
+      return packet;
     }
   }
 
-  void FakeKeyframeGeneratorHandler::sendPLI() {
-    getContext()->fireRead(RtpUtils::createPLI(video_sink_ssrc_, video_source_ssrc_));
+void FakeKeyframeGeneratorHandler::maybeSendAndSchedulePLIs() {
+  if (!plis_scheduled_) {
+    plis_scheduled_ = true;
+    ELOG_DEBUG("Scheduling PLIs");
+    sendPLI();
+    schedulePLI();
   }
+}
 
-  void FakeKeyframeGeneratorHandler::schedulePLI() {
-    std::weak_ptr<FakeKeyframeGeneratorHandler> weak_this = shared_from_this();
-    stream_->getWorker()->scheduleEvery([weak_this] {
-        if (auto this_ptr = weak_this.lock()) {
-        if (!this_ptr->first_keyframe_received_) {
+void FakeKeyframeGeneratorHandler::sendPLI() {
+  getContext()->fireRead(RtpUtils::createPLI(video_sink_ssrc_, video_source_ssrc_));
+}
+
+void FakeKeyframeGeneratorHandler::schedulePLI() {
+  std::weak_ptr<FakeKeyframeGeneratorHandler> weak_this = shared_from_this();
+  stream_->getWorker()->scheduleEvery([weak_this] {
+    if (auto this_ptr = weak_this.lock()) {
+      if (!this_ptr->first_keyframe_received_) {
         ELOG_DEBUG("Sending PLI in FakeGenerator, scheduling another");
         this_ptr->sendPLI();
         return true;
-        } else {
+      } else {
         ELOG_DEBUG("Stop sending scheduled PLI packets");
         return false;
-        }
-        }
-        return false;
-        }, std::chrono::milliseconds(kPliPeriodMs));
-  }
+      }
+    }
+    return false;
+  }, std::chrono::milliseconds(kPliPeriodMs));
+}
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/FakeKeyframeGeneratorHandler.h
+++ b/erizo/src/erizo/rtp/FakeKeyframeGeneratorHandler.h
@@ -34,6 +34,7 @@ class FakeKeyframeGeneratorHandler: public Handler, public std::enable_shared_fr
 
  private:
   std::shared_ptr<DataPacket> transformIntoKeyframePacket(std::shared_ptr<DataPacket> packet);
+  void maybeSendAndSchedulePLIs();
   void sendPLI();
   void schedulePLI();
 

--- a/erizo/src/test/log4cxx.properties
+++ b/erizo/src/test/log4cxx.properties
@@ -49,6 +49,7 @@ log4j.logger.rtp.RtpPacketQueue=ERROR
 log4j.logger.rtp.RtpRetransmissionHandler=ERROR
 log4j.logger.rtp.RtpVP8Fragmenter=ERROR
 log4j.logger.rtp.RtpVP8Parser=ERROR
+log4j.logger.rtp.FakeKeyframeGeneratorHandler=ERROR
 log4j.logger.rtp.RtpSlideShowHandler=ERROR
 log4j.logger.rtp.RtpTrackMuteHandler=ERROR
 log4j.logger.rtp.RtpSink=ERROR

--- a/erizo/src/test/utils/Mocks.h
+++ b/erizo/src/test/utils/Mocks.h
@@ -91,7 +91,9 @@ class MockWebRtcConnection: public WebRtcConnection {
  public:
   MockWebRtcConnection(std::shared_ptr<Worker> worker, std::shared_ptr<IOWorker> io_worker, const IceConfig &ice_config,
                        const std::vector<RtpMap> rtp_mappings) :
-    WebRtcConnection(worker, io_worker, "", ice_config, rtp_mappings, std::vector<erizo::ExtMap>(), nullptr) {}
+    WebRtcConnection(worker, io_worker, "", ice_config, rtp_mappings, std::vector<erizo::ExtMap>(), nullptr) {
+      global_state_ = CONN_READY;
+    }
 
   virtual ~MockWebRtcConnection() {
   }


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR improves `FakeKeyframeGeneratorHandler` by making sure it's only active (transforming packets and requesting new keyframes) when the transport that will receive the packet is ready.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.