### PR TITLE
Fix memory corruption with latest nicer

### DIFF
--- a/erizo/src/third_party/nicer.cmake
+++ b/erizo/src/third_party/nicer.cmake
@@ -1,7 +1,7 @@
 set(NICER_BUILD "${CMAKE_CURRENT_BINARY_DIR}/libdeps/nicer")
 ExternalProject_Add(project_nicer
   GIT_REPOSITORY "https://github.com/lynckia/nicer.git"
-  GIT_TAG "1.3"
+  GIT_TAG "1.4"
   PREFIX ${NICER_BUILD}
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${NICER_BUILD}
   DOWNLOAD_DIR "${NICER_BUILD}/src"


### PR DESCRIPTION
**Description**

There was a memory corruption in latest nicer so we need to update it.  More info here: https://github.com/lynckia/nrappkit/pull/3

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.