### PR TITLE
Add a new stream-unsubscribed event

### DIFF
--- a/doc/client_api.md
+++ b/doc/client_api.md
@@ -396,8 +396,8 @@ room.publish(localStream, {forceTurn: true});
 ```
 
 There are two options that allow advance control of video bitrate in Chrome:
-- `startVideoBW`: Configures Chrome to start sending video at the specified bitrate instead of the default one. 
-- `hardMinVideoBW`: Configures a hard limit for the minimum video bitrate. 
+- `startVideoBW`: Configures Chrome to start sending video at the specified bitrate instead of the default one.
+- `hardMinVideoBW`: Configures a hard limit for the minimum video bitrate.
 
 ```
 room.publish(localStream, {startVideoBW: 1000, hardMinVideoBW:500});
@@ -550,6 +550,8 @@ room.unsubscribe(stream, function(result, error){
   }
 });
 ```
+
+We can listen to an event called `stream-unsubscribed` that is triggered when the unsubscription is completed (the stream no longer lives in the client nor the server). This event is interesting in cases where we might subscribe again to the stream, to avoid having conflicts or setting artificial delays to wait for resubscriptions.
 
 ## Unpublish a local stream
 
@@ -957,7 +959,7 @@ And for creating a Stream:
 var stream = Erizo.Stream(undefined, {stream: {audio:true, video:true, data: true}});
 ```
 
-The parameters set to `undefined` can be used for defining helper functions for getting the user media, the type of browser, etc. You can see examples of these helpers in *erizoClient* or *spine* code. 
+The parameters set to `undefined` can be used for defining helper functions for getting the user media, the type of browser, etc. You can see examples of these helpers in *erizoClient* or *spine* code.
 
 After instantiating a room and a stream you can use the API like explained for the browser case, calling `Erizo.Room`, `Erizo.Stream` and `Erizo.Events`. Note that you can not publish/subscribe streams with video and/or audio. We are working on this feature in order to develop another way of distribute video/audio streams.
 

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -81,9 +81,6 @@ MediaStream::MediaStream(std::shared_ptr<Worker> worker,
   log_stats_ = std::make_shared<Stats>();
   quality_manager_ = std::make_shared<QualityManager>();
   packet_buffer_ = std::make_shared<PacketBufferService>();
-  std::srand(std::time(nullptr));
-  audio_sink_ssrc_ = std::rand();
-  video_sink_ssrc_ = std::rand();
 
   rtcp_processor_ = std::make_shared<RtcpForwarder>(static_cast<MediaSink*>(this), static_cast<MediaSource*>(this));
 

--- a/erizo/src/erizo/OneToManyProcessor.h
+++ b/erizo/src/erizo/OneToManyProcessor.h
@@ -59,7 +59,7 @@ class OneToManyProcessor : public MediaSink, public FeedbackSink {
   int deliverEvent_(MediaEventPtr event) override;
   void closeAll();
   bool isSSRCFromAudio(uint32_t ssrc);
-  uint32_t translateAndMaybeAdaptForSimulcast(std::shared_ptr<MediaSink> sink, uint32_t orig_ssrc);
+  uint32_t translateAndMaybeAdaptForSimulcast(uint32_t orig_ssrc);
 };
 
 }  // namespace erizo

--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -24,6 +24,11 @@ class ErizoConnection extends EventEmitterConst {
     spec.sessionId = ErizoSessionId;
     this.sessionId = ErizoSessionId;
 
+    if (!spec.streamRemovedListener) {
+      spec.streamRemovedListener = () => {};
+    }
+    this.streamRemovedListener = spec.streamRemovedListener;
+
     // Check which WebRTC Stack is installed.
     this.browser = ConnectionHelpers.getBrowser();
     if (this.browser === 'fake') {
@@ -63,6 +68,7 @@ class ErizoConnection extends EventEmitterConst {
 
       this.stack.peerConnection.onremovestream = (evt) => {
         this.emit(ConnectionEvent({ type: 'remove-stream', stream: evt.stream }));
+        this.streamRemovedListener(evt.stream.id);
       };
 
       this.stack.peerConnection.oniceconnectionstatechange = () => {
@@ -98,6 +104,8 @@ class ErizoConnection extends EventEmitterConst {
     }
     if (stream.local) {
       this.stack.removeStream(stream.stream);
+    } else if (this.streamsMap.size() === 1) {
+      this.streamRemovedListener(stream.getLabel());
     }
     this.streamsMap.remove(streamId);
   }

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -40,7 +40,7 @@ const Stream = (altConnectionHelpers, specInput) => {
     }
   };
 
-  const onStreamRemovedFroPC = (evt) => {
+  const onStreamRemovedFromPC = (evt) => {
     if (evt.stream.id === that.getLabel()) {
       that.emit(StreamEvent({ type: 'removed', stream: that }));
     }
@@ -122,12 +122,12 @@ const Stream = (altConnectionHelpers, specInput) => {
     }
     if (that.pc) {
       that.pc.off('add-stream', onStreamAddedToPC);
-      that.pc.off('remove-stream', onStreamRemovedFroPC);
+      that.pc.off('remove-stream', onStreamRemovedFromPC);
       that.pc.off('ice-state-change', onICEConnectionStateChange);
     }
     that.pc = pc;
     that.pc.on('add-stream', onStreamAddedToPC);
-    that.pc.on('remove-stream', onStreamRemovedFroPC);
+    that.pc.on('remove-stream', onStreamRemovedFromPC);
     that.pc.on('ice-state-change', onICEConnectionStateChange);
   };
 
@@ -233,12 +233,12 @@ const Stream = (altConnectionHelpers, specInput) => {
     }
     if (that.pc && !that.p2p) {
       that.pc.off('add-stream', onStreamAddedToPC);
-      that.pc.off('remove-stream', onStreamRemovedFroPC);
+      that.pc.off('remove-stream', onStreamRemovedFromPC);
       that.pc.off('ice-state-change', onICEConnectionStateChange);
     } else if (that.pc && that.p2p) {
       that.pc.forEach((pc) => {
         pc.off('add-stream', onStreamAddedToPC);
-        pc.off('remove-stream', onStreamRemovedFroPC);
+        pc.off('remove-stream', onStreamRemovedFromPC);
         pc.off('ice-state-change', onICEConnectionStateChange);
       });
     }

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -21,6 +21,7 @@ const BaseStack = (specInput) => {
 
   that.pcConfig = {
     iceServers: [],
+    sdpSemantics: 'plan-b',  // WARN: Chrome 72+ will by default use unified-plan
   };
 
   that.con = {};

--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -121,6 +121,9 @@ class Connection extends events.EventEmitter {
   }
 
   _resendLastAnswer(evt, streamId, label, forceOffer = false, removeStream = false) {
+    if (!this.wrtc.localDescription) {
+      return;
+    }
     const sdp = this.wrtc.localDescription.getSdp(this.sessionVersion);
     this.sessionVersion += 1;
     const stream = sdp.getStream(label);

--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -120,6 +120,21 @@ class Connection extends events.EventEmitter {
     this.emit('status_event', info, evt, streamId);
   }
 
+  _resendLastAnswer(evt, streamId, label, forceOffer = false, removeStream = false) {
+    const sdp = this.wrtc.localDescription.getSdp(this.sessionVersion);
+    this.sessionVersion += 1;
+    const stream = sdp.getStream(label);
+    if (stream && removeStream) {
+      sdp.removeStream(stream);
+    }
+    let message = sdp.toString();
+    message = message.replace(this.options.privateRegexp, this.options.publicIP);
+
+    const info = { type: this.options.createOffer || forceOffer ? 'offer' : 'answer', sdp: message };
+    log.debug(`message: _resendLastAnswer sending event, type: ${info.type}, streamId: ${streamId}`);
+    this.emit('status_event', info, evt, streamId);
+  }
+
   init(newStreamId) {
     if (this.initialized) {
       return false;
@@ -196,11 +211,11 @@ class Connection extends events.EventEmitter {
 
   removeMediaStream(id) {
     if (this.mediaStreams.get(id) !== undefined) {
+      const label = this.mediaStreams.get(id).label;
       this.wrtc.removeMediaStream(id);
       this.mediaStreams.get(id).close();
       this.mediaStreams.delete(id);
-      log.debug(`removed mediaStreamId ${id}, remaining size ${this.getNumMediaStreams()}`);
-      this._maybeSendAnswer(CONN_SDP, id, true);
+      this._resendLastAnswer(CONN_SDP, id, label, true, true);
     } else {
       log.error(`message: Trying to remove mediaStream not found, id: ${id}`);
     }


### PR DESCRIPTION
**Description**

This PR adds a new event called `stream-unsubscribed` for some special cases where we want to exactly know when the stream no longer lives in client or server side.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Yes, it adds a new event `stream-unsubscribed`. See doc/client_api.md for further info.

- [x] It includes documentation for these changes in `/doc`.