### PR TITLE
Add start button in basicExample for onlySubscribe

### DIFF
--- a/extras/basic_example/public/index.html
+++ b/extras/basic_example/public/index.html
@@ -6,9 +6,11 @@
   </head>
 
   <body>
-    <button id="recordButton" onclick="startRecording()" disabled>Toggle Recording</button>
+    <button id="startButton" onclick="startBasicExample()" disabled>Start</button>
     <button id="testConnection" onclick="testConnection()">Test Connection</button>
-    <button id="slideShowMode" onclick="toggleSlideShowMode()">Toggle Slide Show Mode</button>
+    <button id="recordButton" onclick="startRecording()" disabled>Toggle Recording</button>
+    <button id="slideShowMode" onclick="toggleSlideShowMode()" disabled>Toggle Slide Show Mode</button>
+    <h1 id="startWarning">Press the start buttong to start receiving streams</h1>
     <div id="videoContainer"></div>
   </body>
 </html>

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -23,6 +23,7 @@ const testConnection = () => {
   window.location = '/connection_test.html';
 };
 
+
 // eslint-disable-next-line no-unused-vars
 function startRecording() {
   if (room !== undefined) {
@@ -55,7 +56,11 @@ function toggleSlideShowMode() {
   });
 }
 
-window.onload = () => {
+const startBasicExample = () => {
+  document.getElementById('startButton').disabled = true;
+  document.getElementById('slideShowMode').disabled = false;
+  document.getElementById('startWarning').hidden = true;
+  document.getElementById('startButton').hidden = true;
   recording = false;
   const screen = getParameterByName('screen');
   const roomName = getParameterByName('room') || 'basicExampleRoom';
@@ -177,4 +182,14 @@ window.onload = () => {
       localStream.init();
     }
   });
+};
+
+window.onload = () => {
+  const onlySubscribe = getParameterByName('onlySubscribe');
+  const bypassStartButton = getParameterByName('noStart');
+  if (!onlySubscribe || bypassStartButton) {
+    startBasicExample();
+  } else {
+    document.getElementById('startButton').disabled = false;
+  }
 };


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
Using Chrome in some environments, the `onlySubscribe` option for basic_example would only show the spinning logo instead of playing the video streams.
This issue is caused by the [autoplay policy update](https://developers.google.com/web/updates/2017/09/autoplay-policy-changes).

This PR updates basic_example to force a click in a new `start` button only when `onlySubscribe` is enabled. This check can be bypassed by using the `noStart` parameter. This can be useful when you know `MEI` for you is high enough in a given domain.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.