### PR TITLE
Properly set default callback in callRpc

### DIFF
--- a/erizo_controller/common/amqper.js
+++ b/erizo_controller/common/amqper.js
@@ -206,7 +206,7 @@ exports.broadcast = (topic, message, callback) => {
 /*
  * Calls remotely the 'method' function defined in rpcPublic of 'to'.
  */
-exports.callRpc = (to, method, args, callbacks = {}, timeout = TIMEOUT) => {
+exports.callRpc = (to, method, args, callbacks = { callback: () => {} }, timeout = TIMEOUT) => {
   corrID += 1;
   map[corrID] = {};
   map[corrID].fn = callbacks;


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

There were periodic errors when `callRpc` was called without a callback.
This PR fixes this by properly setting a default callback

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.