### PR TITLE
1，Fix H264Depacketizer ProcessPacket Crash

### DIFF
--- a/erizo/src/erizo/media/Depacketizer.cpp
+++ b/erizo/src/erizo/media/Depacketizer.cpp
@@ -139,6 +139,7 @@ bool H264Depacketizer::processPacket() {
     case single: {
       if (search_state_ == SearchState::lookingForEnd) {
         reset();
+        return false;
       }
       if (last_payload_->dataLength == 0) {
         return false;


### PR DESCRIPTION
bool H264Depacketizer::processPacket() ；
if last_payload_->nal_type == single and search_state_ == SearchState::lookingForEnd Conditions set up
than will call reset()，last_payload_ set to nullptr，this fun last_payload_->dataLength call must crash


dawn_liuwei@outlook.com