### PR TITLE
Fix negotiation problems in Single PeerConnection

### DIFF
--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -172,7 +172,7 @@ const BaseStack = (specInput) => {
     remoteSdp = SemanticSdp.SDPInfo.processString(msg.sdp);
     const sessionVersion = remoteSdp && remoteSdp.origin && remoteSdp.origin.sessionVersion;
     if (latestSessionVersion >= sessionVersion) {
-      Logger.warning(`processAnswer discarding ald sdp, sessionVersion: ${sessionVersion}, latestSessionVersion: ${latestSessionVersion}`);
+      Logger.warning(`processAnswer discarding old sdp, sessionVersion: ${sessionVersion}, latestSessionVersion: ${latestSessionVersion}`);
       return;
     }
     Logger.info('Set remote and local description');

--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -124,12 +124,17 @@ class Connection extends events.EventEmitter {
     if (!this.wrtc.localDescription) {
       return;
     }
+    this.wrtc.localDescription = new SessionDescription(this.wrtc.getLocalDescription());
     const sdp = this.wrtc.localDescription.getSdp(this.sessionVersion);
-    this.sessionVersion += 1;
     const stream = sdp.getStream(label);
     if (stream && removeStream) {
-      sdp.removeStream(stream);
+      log.info(`resendLastAnswer: StreamId ${streamId} is stream and removeStream, label ${label}, sessionVersion ${this.sessionVersion}`);
+      setTimeout(() => {
+        this._resendLastAnswer(evt, streamId, label, forceOffer, removeStream);
+      }, 50);
+      return;
     }
+    this.sessionVersion += 1;
     let message = sdp.toString();
     message = message.replace(this.options.privateRegexp, this.options.publicIP);
 

--- a/erizo_controller/erizoJS/models/SessionDescription.js
+++ b/erizo_controller/erizoJS/models/SessionDescription.js
@@ -191,6 +191,13 @@ class SessionDescription {
 
   getSdp(sessionVersion = 0) {
     if (this.sdp) {
+      this.sdp.setOrigin({
+        username: '-',
+        sessionId: 0,
+        sessionVersion,
+        netType: 'IN',
+        ipVer: 4,
+        address: '127.0.0.1' });
       return this.sdp;
     }
     const info = this.connectionDescription;


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR fixes potential issues when handling multiple simultaneous negotiations in singlePC.

- Offer SDP queue is now properly ordered
- Offer SDPs generated in Erizo now update `sessionVersion` properly
- When processing unsubscriptions, streams are now not removed directly in the SDP. It is generated again

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.