### PR TITLE
Fix crash in resendLastAnswer

### DIFF
--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -121,7 +121,7 @@ class Connection extends events.EventEmitter {
   }
 
   _resendLastAnswer(evt, streamId, label, forceOffer = false, removeStream = false) {
-    if (!this.wrtc.localDescription) {
+    if (!this.wrtc || !this.wrtc.localDescription) {
       return;
     }
     this.wrtc.localDescription = new SessionDescription(this.wrtc.getLocalDescription());


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

ResendLastAnswer can be called after closing the connection. `wrtc` is not available anymore so it results in a ErizoJS crash

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.