### PR TITLE
Fix exceptions happening due to too high marker rates

### DIFF
--- a/erizo/src/erizo/stats/StatNode.cpp
+++ b/erizo/src/erizo/stats/StatNode.cpp
@@ -211,6 +211,10 @@ uint64_t MovingIntervalRateStat::calculateRateForInterval(uint64_t interval_to_c
     last_value_part_in_interval = 0;
     added_intervals++;
   }
+  // Didn't pass enough time to know the rate
+  if (now_ms - interval_start_time == 0) {
+    return 0;
+  }
   double rate = static_cast<double> (total_sum) / (now_ms - interval_start_time);
   return (rate * 1000 * scale_);
 }

--- a/erizo/src/erizo/stats/StatNode.cpp
+++ b/erizo/src/erizo/stats/StatNode.cpp
@@ -212,7 +212,7 @@ uint64_t MovingIntervalRateStat::calculateRateForInterval(uint64_t interval_to_c
     added_intervals++;
   }
   // Didn't pass enough time to know the rate
-  if (now_ms - interval_start_time == 0) {
+  if (now_ms == interval_start_time) {
     return 0;
   }
   double rate = static_cast<double> (total_sum) / (now_ms - interval_start_time);

--- a/erizo/src/test/stats/MovingIntervalRateStatTest.cpp
+++ b/erizo/src/test/stats/MovingIntervalRateStatTest.cpp
@@ -35,6 +35,9 @@ class MovingIntervalRateStatTest : public ::testing::Test {
   void advanceClockMs(int time_ms) {
     clock->advanceTime(std::chrono::milliseconds(time_ms));
   }
+  void advanceClockUs(int time_us) {
+    clock->advanceTime(std::chrono::microseconds(time_us));
+  }
   virtual void SetUp() {
   }
 
@@ -53,6 +56,11 @@ TEST_F(MovingIntervalRateStatTest, shouldCalculateAverageForLessThanWindowSize) 
   EXPECT_EQ(moving_interval_stat.value(), uint((100 + 110 + 120)/3));
 }
 
+TEST_F(MovingIntervalRateStatTest, shouldReturnZeroIfNotEnoughTimePassed) {
+  moving_interval_stat+=1;
+  advanceClockUs(1);
+  EXPECT_EQ(moving_interval_stat.value(), 0);
+}
 
 TEST_F(MovingIntervalRateStatTest, shouldReturnAverageOfWindowSize) {
   const int kTotalSamples = 10;

--- a/erizo/src/test/stats/MovingIntervalRateStatTest.cpp
+++ b/erizo/src/test/stats/MovingIntervalRateStatTest.cpp
@@ -59,7 +59,7 @@ TEST_F(MovingIntervalRateStatTest, shouldCalculateAverageForLessThanWindowSize) 
 TEST_F(MovingIntervalRateStatTest, shouldReturnZeroIfNotEnoughTimePassed) {
   moving_interval_stat+=1;
   advanceClockUs(1);
-  EXPECT_EQ(moving_interval_stat.value(), 0);
+  EXPECT_EQ(moving_interval_stat.value(), 0u);
 }
 
 TEST_F(MovingIntervalRateStatTest, shouldReturnAverageOfWindowSize) {


### PR DESCRIPTION
**Description**

There is an exception that happens from time to time in Erizo due to a bad calculation in one of the stats. The issue happens when few time passes since we start the stat and we ask for data.
I added a Unit Test to check it does not happen again in the future.

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.