### PR TITLE
Added option to set a prefix for prometheus stats

### DIFF
--- a/erizo_controller/ROV/rovMetricsGatherer.js
+++ b/erizo_controller/ROV/rovMetricsGatherer.js
@@ -1,12 +1,14 @@
 class RovMetricsGatherer {
-  constructor(rovClient, promClient, logger) {
+  constructor(rovClient, promClient, statsPrefix, logger) {
     this.rovClient = rovClient;
+    this.prefix = statsPrefix;
+    this.getNameWithPrefix = name => `${this.prefix}${name}`;
     this.prometheusMetrics = {
-      activeRooms: new promClient.Gauge({ name: 'active_rooms', help: 'active rooms in all erizoControllers' }),
-      activeClients: new promClient.Gauge({ name: 'active_clients', help: 'active clients in all erizoControllers' }),
-      totalPublishers: new promClient.Gauge({ name: 'total_publishers', help: 'total active publishers' }),
-      totalSubscribers: new promClient.Gauge({ name: 'total_subscribers', help: 'total active subscribers' }),
-      activeErizoJsProcesses: new promClient.Gauge({ name: 'active_erizojs_processes', help: 'active processes' }),
+      activeRooms: new promClient.Gauge({ name: this.getNameWithPrefix('active_rooms'), help: 'active rooms in all erizoControllers' }),
+      activeClients: new promClient.Gauge({ name: this.getNameWithPrefix('active_clients'), help: 'active clients in all erizoControllers' }),
+      totalPublishers: new promClient.Gauge({ name: this.getNameWithPrefix('total_publishers'), help: 'total active publishers' }),
+      totalSubscribers: new promClient.Gauge({ name: this.getNameWithPrefix('total_subscribers'), help: 'total active subscribers' }),
+      activeErizoJsProcesses: new promClient.Gauge({ name: this.getNameWithPrefix('active_erizojs_processes'), help: 'active processes' }),
     };
     this.log = logger;
   }

--- a/erizo_controller/ROV/rovMetricsGatherer.js
+++ b/erizo_controller/ROV/rovMetricsGatherer.js
@@ -2,7 +2,6 @@ class RovMetricsGatherer {
   constructor(rovClient, promClient, statsPrefix, logger) {
     this.rovClient = rovClient;
     this.prefix = statsPrefix;
-    this.getNameWithPrefix = name => `${this.prefix}${name}`;
     this.prometheusMetrics = {
       activeRooms: new promClient.Gauge({ name: this.getNameWithPrefix('active_rooms'), help: 'active rooms in all erizoControllers' }),
       activeClients: new promClient.Gauge({ name: this.getNameWithPrefix('active_clients'), help: 'active clients in all erizoControllers' }),
@@ -11,6 +10,10 @@ class RovMetricsGatherer {
       activeErizoJsProcesses: new promClient.Gauge({ name: this.getNameWithPrefix('active_erizojs_processes'), help: 'active processes' }),
     };
     this.log = logger;
+  }
+
+  getNameWithPrefix(name) {
+    return `${this.prefix}${name}`;
   }
 
   getTotalRooms() {

--- a/erizo_controller/ROV/rovMetricsServer.js
+++ b/erizo_controller/ROV/rovMetricsServer.js
@@ -65,12 +65,14 @@ log.info('Starting: Connecting to rabbitmq');
 amqper.connect(() => {
   log.info('connected to rabbitmq');
   const rovClient = new RovClient(amqper);
-  const rovMetricsGatherer = new RovMetricsGatherer(rovClient, promClient, log);
+  const rovMetricsGatherer =
+    new RovMetricsGatherer(rovClient, promClient, config.rov.statsPrefix, log);
+  promClient.collectDefaultMetrics(
+    { prefix: config.rov.statsPrefix, timeout: config.rov.statsPeriod });
 
   setInterval(() => {
     rovMetricsGatherer.gatherMetrics().then(() => {
-      log.debug('Gathered metrics, promClient Collecting');
-      promClient.collectDefaultMetrics();
+      log.debug('Gathered licode metrics');
     })
     .catch((error) => {
       log.error('Error gathering metrics', error);

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -189,7 +189,8 @@ config.rov = {};
 config.rov.statsPeriod = 20000;
 // The port to expose the stats to prometheus
 config.rov.serverPort = 3005;
-
+// A prefix for the prometheus stats
+config.rov.statsPrefix = "licode_";
 /***** END *****/
 // Following lines are always needed.
 var module = module || {};


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

Added a prefix in prometheus stats to make them easier to manage. 
This PR also fixes a bad use of `collectDefaultMetrics `.


[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.