### PR TITLE
Periodic task that checks uptime in erizoJS

### DIFF
--- a/erizo_controller/erizoJS/erizoJS.js
+++ b/erizo_controller/erizoJS/erizoJS.js
@@ -23,6 +23,9 @@ global.config.erizo.turnport = global.config.erizo.turnport || 0;
 global.config.erizo.turnusername = global.config.erizo.turnusername || '';
 global.config.erizo.turnpass = global.config.erizo.turnpass || '';
 global.config.erizo.networkinterface = global.config.erizo.networkinterface || '';
+global.config.erizo.activeUptimeLimit = global.config.erizo.activeUptimeLimit || 7;
+global.config.erizo.maxTimeSinceLastOperation = global.config.erizo.maxTimeSinceLastOperation || 3;
+global.config.erizo.checkUptimeInterval = global.config.erizo.checkUptimeInterval || 1800;
 global.mediaConfig = mediaConfig || {};
 // Parse command line arguments
 const getopt = new Getopt([

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -159,6 +159,13 @@ config.erizo.numWorkers = 24;
 // Number of workers what will be used for IO (including ICE logic)
 config.erizo.numIOWorkers = 1;
 
+// the max amount of time in days a process is allowed to be up after the first publisher is added
+config.erizo.activeUptimeLimit = 7;
+// the max time in hours since last publish or subscribe operation where a erizoJS process can be killed
+config.erizo.maxTimeSinceLastOperation = 3;
+// Interval to check uptime in seconds
+config.erizo.checkUptimeInterval = 1800;
+
 //STUN server IP address and port to be used by the server.
 //if '' is used, the address is discovered locally
 //Please note this is only needed if your server does not have a public IP


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

We've detected that there are times where ErizoJS processes won't stop when all publishers leave, causing problems when those processes stay up a long time processing many connections.
We're investigating the issue and will fix the root of the problem. 

This PR adds a protection for this problem by checking erizoJS processes that remain up after a long time since the first time they were active. It also makes sure that no new publisher or subscriber has been added recently. These parameters can be adjusted in `licode_config`.

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.