### PR TITLE
[POC] Do not send varying packet losts in RR

### DIFF
--- a/erizo/src/erizo/rtp/RtcpAggregator.cpp
+++ b/erizo/src/erizo/rtp/RtcpAggregator.cpp
@@ -421,6 +421,5 @@ void RtcpAggregator::resetData(boost::shared_ptr<RtcpData> data, uint32_t bandwi
 }
 
 void RtcpAggregator::setLostPacketsInfo(uint32_t source_ssrc, uint32_t lost, uint8_t frac_lost) {
-
 }
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/RtcpAggregator.cpp
+++ b/erizo/src/erizo/rtp/RtcpAggregator.cpp
@@ -419,4 +419,8 @@ void RtcpAggregator::resetData(boost::shared_ptr<RtcpData> data, uint32_t bandwi
   }
   data->lastDelay = data->lastDelay*0.6;
 }
+
+void RtcpAggregator::setLostPacketsInfo(uint32_t source_ssrc, uint32_t lost, uint8_t frac_lost) {
+
+}
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/RtcpAggregator.h
+++ b/erizo/src/erizo/rtp/RtcpAggregator.h
@@ -22,11 +22,12 @@ class RtcpAggregator: public RtcpProcessor{
  public:
   RtcpAggregator(MediaSink* msink, MediaSource* msource, uint32_t max_video_bw = 300000);
   virtual ~RtcpAggregator() {}
-  void addSourceSsrc(uint32_t ssrc);
-  void setPublisherBW(uint32_t bandwidth);
-  void analyzeSr(RtcpHeader* chead);
-  int analyzeFeedback(char* buf, int len);
-  void checkRtcpFb();
+  void addSourceSsrc(uint32_t ssrc) override;
+  void setPublisherBW(uint32_t bandwidth) override;
+  void analyzeSr(RtcpHeader* chead) override;
+  int analyzeFeedback(char* buf, int len) override;
+  void checkRtcpFb() override;
+  void setLostPacketsInfo(uint32_t source_ssrc, uint32_t lost, uint8_t frac_lost) override;
 
  private:
   static const int REMB_TIMEOUT = 1000;

--- a/erizo/src/erizo/rtp/RtcpFeedbackGenerationHandler.cpp
+++ b/erizo/src/erizo/rtp/RtcpFeedbackGenerationHandler.cpp
@@ -83,13 +83,14 @@ void RtcpFeedbackGenerationHandler::notifyUpdate() {
   if (!stream_) {
     return;
   }
+  processor_ = pipeline->getService<RtcpProcessor>();
   // TODO(pedro) detect if nacks are enabled here with the negotiated SDP scanning the rtp_mappings
   std::vector<uint32_t> video_ssrc_list = stream_->getVideoSourceSSRCList();
   std::for_each(video_ssrc_list.begin(), video_ssrc_list.end(), [this] (uint32_t video_ssrc) {
     if (video_ssrc != 0) {
       auto video_generator = std::make_shared<RtcpGeneratorPair>();
       generators_map_[video_ssrc] = video_generator;
-      auto video_rr = std::make_shared<RtcpRrGenerator>(video_ssrc, VIDEO_PACKET, clock_);
+      auto video_rr = std::make_shared<RtcpRrGenerator>(video_ssrc, VIDEO_PACKET, processor_, clock_);
       video_generator->rr_generator = video_rr;
       ELOG_DEBUG("%s, message: Initialized video rrGenerator, ssrc: %u", stream_->toLog(), video_ssrc);
       if (nacks_enabled_) {
@@ -103,7 +104,7 @@ void RtcpFeedbackGenerationHandler::notifyUpdate() {
   if (audio_ssrc != 0) {
     auto audio_generator = std::make_shared<RtcpGeneratorPair>();
     generators_map_[audio_ssrc] = audio_generator;
-    auto audio_rr = std::make_shared<RtcpRrGenerator>(audio_ssrc, AUDIO_PACKET, clock_);
+    auto audio_rr = std::make_shared<RtcpRrGenerator>(audio_ssrc, AUDIO_PACKET, processor_, clock_);
     audio_generator->rr_generator = audio_rr;
     ELOG_DEBUG("%s, message: Initialized audio, ssrc: %u", stream_->toLog(), audio_ssrc);
   }

--- a/erizo/src/erizo/rtp/RtcpFeedbackGenerationHandler.h
+++ b/erizo/src/erizo/rtp/RtcpFeedbackGenerationHandler.h
@@ -9,6 +9,7 @@
 #include "pipeline/Handler.h"
 #include "rtp/RtcpRrGenerator.h"
 #include "rtp/RtcpNackGenerator.h"
+#include "rtp/RtcpProcessor.h"
 #include "lib/ClockUtils.h"
 
 #define MAX_DELAY 450000
@@ -51,6 +52,7 @@ class RtcpFeedbackGenerationHandler: public Handler {
   bool enabled_, initialized_;
   bool nacks_enabled_;
   std::shared_ptr<Clock> clock_;
+  std::shared_ptr<RtcpProcessor> processor_;
 };
 }  // namespace erizo
 

--- a/erizo/src/erizo/rtp/RtcpForwarder.h
+++ b/erizo/src/erizo/rtp/RtcpForwarder.h
@@ -26,6 +26,8 @@ class RtcpForwarder: public RtcpProcessor{
   void analyzeSr(RtcpHeader* chead) override;
   int analyzeFeedback(char* buf, int len) override;
   void checkRtcpFb() override;
+  std::pair<uint32_t, uint8_t> getLostPacketsInfo(uint32_t source_ssrc);
+  void setLostPacketsInfo(uint32_t ssrc, uint32_t lost, uint8_t frac_lost) override;
 
  private:
   static const int RR_AUDIO_PERIOD = 2000;
@@ -35,6 +37,9 @@ class RtcpForwarder: public RtcpProcessor{
   boost::mutex mapLock_;
   int addREMB(char* buf, int len, uint32_t bitrate);
   int addNACK(char* buf, int len, uint16_t seqNum, uint16_t blp, uint32_t sourceSsrc, uint32_t sinkSsrc);
+  std::pair<uint32_t, uint8_t> initAndGetLostPacketsInfo(uint32_t source_ssrc);
+
+  std::map<uint32_t, std::pair<uint32_t, uint8_t>> lost_packet_info_;
 };
 
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/RtcpProcessor.h
+++ b/erizo/src/erizo/rtp/RtcpProcessor.h
@@ -117,6 +117,7 @@ class RtcpProcessor : public Service {
   virtual void analyzeSr(RtcpHeader* chead) = 0;
   virtual int analyzeFeedback(char* buf, int len) = 0;
   virtual void checkRtcpFb() = 0;
+  virtual void setLostPacketsInfo(uint32_t source_ssrc, uint32_t lost, uint8_t frac_lost) = 0;
 
   virtual void setMaxVideoBW(uint32_t bandwidth) { max_video_bw_ = bandwidth; }
   virtual uint32_t getMaxVideoBW() { return max_video_bw_; }

--- a/erizo/src/erizo/rtp/RtcpRrGenerator.h
+++ b/erizo/src/erizo/rtp/RtcpRrGenerator.h
@@ -9,6 +9,7 @@
 #include "./logger.h"
 #include "pipeline/Handler.h"
 #include "lib/ClockUtils.h"
+#include "rtp/RtcpProcessor.h"
 
 #define MAX_DELAY 450000
 
@@ -20,6 +21,7 @@ class RtcpRrGenerator {
 
  public:
   explicit RtcpRrGenerator(uint32_t ssrc, packetType type,
+      std::shared_ptr<RtcpProcessor> processor,
       std::shared_ptr<Clock> the_clock = std::make_shared<SteadyClock>());
 
   explicit RtcpRrGenerator(const RtcpRrGenerator&& handler);  // NOLINT
@@ -66,6 +68,7 @@ class RtcpRrGenerator {
   packetType type_;
   std::random_device random_device_;
   std::mt19937 random_generator_;
+  std::shared_ptr<RtcpProcessor> processor_;
   std::shared_ptr<Clock> clock_;
 };
 }  // namespace erizo

--- a/erizo/src/test/rtp/RtcpRrGeneratorTest.cpp
+++ b/erizo/src/test/rtp/RtcpRrGeneratorTest.cpp
@@ -3,6 +3,7 @@
 
 #include <thread/Scheduler.h>
 #include <rtp/RtcpRrGenerator.h>
+#include <rtp/RtcpForwarder.h>
 #include <lib/Clock.h>
 #include <lib/ClockUtils.h>
 #include <rtp/RtpHeaders.h>
@@ -27,13 +28,15 @@ using erizo::AUDIO_PACKET;
 using erizo::VIDEO_PACKET;
 using erizo::RtcpRrGenerator;
 using erizo::RtcpHeader;
+using erizo::RtcpForwarder;
 using erizo::WebRtcConnection;
 using erizo::SimulatedClock;
 
 class RtcpRrGeneratorTest :public ::testing::Test {
  public:
-  RtcpRrGeneratorTest(): clock{std::make_shared<SimulatedClock>()}, rr_generator{erizo::kVideoSsrc,
-    VIDEO_PACKET, clock} {}
+  RtcpRrGeneratorTest(): clock{std::make_shared<SimulatedClock>()},
+    processor{std::make_shared<RtcpForwarder>(nullptr, nullptr, 0)},
+    rr_generator{erizo::kVideoSsrc, VIDEO_PACKET, processor, clock} {}
 
  protected:
   void advanceClockMs(int time_ms) {
@@ -41,6 +44,7 @@ class RtcpRrGeneratorTest :public ::testing::Test {
   }
 
   std::shared_ptr<SimulatedClock> clock;
+  std::shared_ptr<RtcpForwarder> processor;
   RtcpRrGenerator rr_generator;
 };
 

--- a/erizo/src/test/utils/Mocks.h
+++ b/erizo/src/test/utils/Mocks.h
@@ -25,6 +25,7 @@ class MockRtcpProcessor : public RtcpProcessor {
   MOCK_METHOD1(analyzeSr, void(RtcpHeader*));
   MOCK_METHOD2(analyzeFeedback, int(char*, int));
   MOCK_METHOD0(checkRtcpFb, void());
+  MOCK_METHOD3(setLostPacketsInfo, void(uint32_t, uint32_t, uint8_t));
 };
 
 class MockQualityManager : public QualityManager {


### PR DESCRIPTION
**Description**

Chrome 72+ has changed the bandwidth estimation behaviour and it's now getting affected in situations where we forward RRs with different packet losts reported. This PR is a PoC that might become in a final solution if we don't find a better one.

The issue is well explained at #1364.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.