### PR TITLE
Remove socket listeners on channel disconnect

### DIFF
--- a/erizo_controller/erizoController/models/Channel.js
+++ b/erizo_controller/erizoController/models/Channel.js
@@ -113,6 +113,10 @@ class Channel extends events.EventEmitter {
     this.socket.on(eventName, listener);
   }
 
+  socketRemoveListener(eventName, listener) {
+    this.socket.removeListener(eventName, listener);
+  }
+
   onReconnected(clientId) {
     this.state = CONNECTED;
     this.emit('reconnected', clientId);

--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -26,6 +26,20 @@ function listenToSocketEvents(client) {
   client.channel.on('disconnect', client.onDisconnect.bind(client));
 }
 
+function stopListeningToSocketEvents(client) {
+  log.info('Stop listening to socket events');
+  client.channel.socketRemoveListener('sendDataStream', client.onSendDataStream.bind(client));
+  client.channel.socketRemoveListener('signaling_message', client.onSignalingMessage.bind(client));
+  client.channel.socketRemoveListener('updateStreamAttributes', client.onUpdateStreamAttributes.bind(client));
+  client.channel.socketRemoveListener('publish', client.onPublish.bind(client));
+  client.channel.socketRemoveListener('subscribe', client.onSubscribe.bind(client));
+  client.channel.socketRemoveListener('startRecorder', client.onStartRecorder.bind(client));
+  client.channel.socketRemoveListener('stopRecorder', client.onStopRecorder.bind(client));
+  client.channel.socketRemoveListener('unpublish', client.onUnpublish.bind(client));
+  client.channel.socketRemoveListener('unsubscribe', client.onUnsubscribe.bind(client));
+  client.channel.socketRemoveListener('getStreamStats', client.onGetStreamStats.bind(client));
+}
+
 class Client extends events.EventEmitter {
   constructor(channel, token, options, room) {
     super();
@@ -45,6 +59,7 @@ class Client extends events.EventEmitter {
   }
 
   disconnect() {
+    stopListeningToSocketEvents(this);
     this.channel.disconnect();
   }
 
@@ -496,6 +511,7 @@ class Client extends events.EventEmitter {
   }
 
   onDisconnect() {
+    stopListeningToSocketEvents(this);
     const timeStamp = new Date();
 
     log.info(`message: Channel disconnect, clientId: ${this.id}`, ', channelId:', this.channel.id);

--- a/erizo_controller/test/utils.js
+++ b/erizo_controller/test/utils.js
@@ -96,6 +96,7 @@ module.exports.reset = () => {
     disconnect: sinon.stub(),
     emit: sinon.stub(),
     on: sinon.stub(),
+    removeListener: sinon.stub(),
   };
 
   module.exports.socketIoInstance = {


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
We've detected some instances where `Client` would process calls even after `Channel` has disconnected. This PR makes sure `Client` does not receive any events from `socket` when `disconnect` is called or when the `disconnect` event is fired.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.