### PR TITLE
Update to 1.2 version of DTLS

### DIFF
--- a/erizo/src/erizo/dtls/DtlsClient.cpp
+++ b/erizo/src/erizo/dtls/DtlsClient.cpp
@@ -217,7 +217,7 @@ int createCert(const std::string& pAor, int expireDays, int keyLen, X509*& outCe
 
     ELOG_DEBUG("Creating Dtls factory, Openssl v %s", OPENSSL_VERSION_TEXT);
 
-    mContext = SSL_CTX_new(DTLSv1_method());
+    mContext = SSL_CTX_new(DTLSv1_2_method());
     assert(mContext);
 
     int r = SSL_CTX_use_certificate(mContext, mCert);


### PR DESCRIPTION
**Description**

This fixes #1378 and #1373. We were still using DTLS 1.0

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.