### PR TITLE
[POC] Record still images from vp8 keyframes to webp

### DIFF
--- a/erizo/src/erizo/rtp/RtpSlideShowHandler.h
+++ b/erizo/src/erizo/rtp/RtpSlideShowHandler.h
@@ -10,6 +10,7 @@
 #include "rtp/RtpVP8Parser.h"
 #include "rtp/RtpVP9Parser.h"
 #include "lib/ClockUtils.h"
+#include "media/Depacketizer.h"
 
 static constexpr uint16_t kMaxKeyframeSize = 20;
 static constexpr erizo::duration kFallbackKeyframeTimeout = std::chrono::seconds(5);
@@ -62,6 +63,7 @@ class RtpSlideShowHandler : public Handler {
   std::vector<std::shared_ptr<DataPacket>> keyframe_buffer_;
   std::vector<std::shared_ptr<DataPacket>> stored_keyframe_;
   time_point last_keyframe_sent_time_;
+  std::unique_ptr<Depacketizer> depacketizer_;
 };
 }  // namespace erizo
 


### PR DESCRIPTION
**Description**

I just wanted to experiment with the possibility of creating webp images from vp8 keyframes. This code worked for me and it stores images if we have subscribers. This example is useless and I did it in the first handler I found that managed keyframes. But I didn't want to loose this code so I decided to create a PoC for future references.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.