### PR TITLE
change DTLSv1_2_method to DTLS_method

### DIFF
--- a/erizo/src/erizo/dtls/DtlsClient.cpp
+++ b/erizo/src/erizo/dtls/DtlsClient.cpp
@@ -217,7 +217,7 @@ int createCert(const std::string& pAor, int expireDays, int keyLen, X509*& outCe
 
     ELOG_DEBUG("Creating Dtls factory, Openssl v %s", OPENSSL_VERSION_TEXT);
 
-    mContext = SSL_CTX_new(DTLSv1_2_method());
+    mContext = SSL_CTX_new(DTLS_method());
     assert(mContext);
 
     int r = SSL_CTX_use_certificate(mContext, mCert);


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->
refer #1380 
 `mContext = SSL_CTX_new(DTLSv1_2_method());`
Chrome under M74 （mine 版本 73.0.3683.75（正式版本） （64 位））got “message: Handshake failed, transportName:video, openSSLerror: error:1409210A:SSL routines:ssl3_get_server_hello:wrong ssl version”
ssl/ssl.h
const SSL_METHOD *DTLS_method(void); /* DTLS 1.0 and 1.2 */
should be ok
<!--
Add a short description here, please.
If the contribution needs and includes Unit Tests check the box below.
-->

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.