### PR TITLE
Added FSM to protect peerConnection use in basestack

### DIFF
--- a/erizo_controller/erizoClient/lib/state-machine.js
+++ b/erizo_controller/erizoClient/lib/state-machine.js
@@ -1,0 +1,669 @@
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define("StateMachine", [], factory);
+	else if(typeof exports === 'object')
+		exports["StateMachine"] = factory();
+	else
+		root["StateMachine"] = factory();
+})(this, function() {
+return /******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 5);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+module.exports = function(target, sources) {
+  var n, source, key;
+  for(n = 1 ; n < arguments.length ; n++) {
+    source = arguments[n];
+    for(key in source) {
+      if (source.hasOwnProperty(key))
+        target[key] = source[key];
+    }
+  }
+  return target;
+}
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+//-------------------------------------------------------------------------------------------------
+
+var mixin = __webpack_require__(0);
+
+//-------------------------------------------------------------------------------------------------
+
+module.exports = {
+
+  build: function(target, config) {
+    var n, max, plugin, plugins = config.plugins;
+    for(n = 0, max = plugins.length ; n < max ; n++) {
+      plugin = plugins[n];
+      if (plugin.methods)
+        mixin(target, plugin.methods);
+      if (plugin.properties)
+        Object.defineProperties(target, plugin.properties);
+    }
+  },
+
+  hook: function(fsm, name, additional) {
+    var n, max, method, plugin,
+        plugins = fsm.config.plugins,
+        args    = [fsm.context];
+
+    if (additional)
+      args = args.concat(additional)
+
+    for(n = 0, max = plugins.length ; n < max ; n++) {
+      plugin = plugins[n]
+      method = plugins[n][name]
+      if (method)
+        method.apply(plugin, args);
+    }
+  }
+
+}
+
+//-------------------------------------------------------------------------------------------------
+
+
+/***/ }),
+/* 2 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+//-------------------------------------------------------------------------------------------------
+
+function camelize(label) {
+
+  if (label.length === 0)
+    return label;
+
+  var n, result, word, words = label.split(/[_-]/);
+
+  // single word with first character already lowercase, return untouched
+  if ((words.length === 1) && (words[0][0].toLowerCase() === words[0][0]))
+    return label;
+
+  result = words[0].toLowerCase();
+  for(n = 1 ; n < words.length ; n++) {
+    result = result + words[n].charAt(0).toUpperCase() + words[n].substring(1).toLowerCase();
+  }
+
+  return result;
+}
+
+//-------------------------------------------------------------------------------------------------
+
+camelize.prepended = function(prepend, label) {
+  label = camelize(label);
+  return prepend + label[0].toUpperCase() + label.substring(1);
+}
+
+//-------------------------------------------------------------------------------------------------
+
+module.exports = camelize;
+
+
+/***/ }),
+/* 3 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+//-------------------------------------------------------------------------------------------------
+
+var mixin    = __webpack_require__(0),
+    camelize = __webpack_require__(2);
+
+//-------------------------------------------------------------------------------------------------
+
+function Config(options, StateMachine) {
+
+  options = options || {};
+
+  this.options     = options; // preserving original options can be useful (e.g visualize plugin)
+  this.defaults    = StateMachine.defaults;
+  this.states      = [];
+  this.transitions = [];
+  this.map         = {};
+  this.lifecycle   = this.configureLifecycle();
+  this.init        = this.configureInitTransition(options.init);
+  this.data        = this.configureData(options.data);
+  this.methods     = this.configureMethods(options.methods);
+
+  this.map[this.defaults.wildcard] = {};
+
+  this.configureTransitions(options.transitions || []);
+
+  this.plugins = this.configurePlugins(options.plugins, StateMachine.plugin);
+
+}
+
+//-------------------------------------------------------------------------------------------------
+
+mixin(Config.prototype, {
+
+  addState: function(name) {
+    if (!this.map[name]) {
+      this.states.push(name);
+      this.addStateLifecycleNames(name);
+      this.map[name] = {};
+    }
+  },
+
+  addStateLifecycleNames: function(name) {
+    this.lifecycle.onEnter[name] = camelize.prepended('onEnter', name);
+    this.lifecycle.onLeave[name] = camelize.prepended('onLeave', name);
+    this.lifecycle.on[name]      = camelize.prepended('on',      name);
+  },
+
+  addTransition: function(name) {
+    if (this.transitions.indexOf(name) < 0) {
+      this.transitions.push(name);
+      this.addTransitionLifecycleNames(name);
+    }
+  },
+
+  addTransitionLifecycleNames: function(name) {
+    this.lifecycle.onBefore[name] = camelize.prepended('onBefore', name);
+    this.lifecycle.onAfter[name]  = camelize.prepended('onAfter',  name);
+    this.lifecycle.on[name]       = camelize.prepended('on',       name);
+  },
+
+  mapTransition: function(transition) {
+    var name = transition.name,
+        from = transition.from,
+        to   = transition.to;
+    this.addState(from);
+    if (typeof to !== 'function')
+      this.addState(to);
+    this.addTransition(name);
+    this.map[from][name] = transition;
+    return transition;
+  },
+
+  configureLifecycle: function() {
+    return {
+      onBefore: { transition: 'onBeforeTransition' },
+      onAfter:  { transition: 'onAfterTransition'  },
+      onEnter:  { state:      'onEnterState'       },
+      onLeave:  { state:      'onLeaveState'       },
+      on:       { transition: 'onTransition'       }
+    };
+  },
+
+  configureInitTransition: function(init) {
+    if (typeof init === 'string') {
+      return this.mapTransition(mixin({}, this.defaults.init, { to: init, active: true }));
+    }
+    else if (typeof init === 'object') {
+      return this.mapTransition(mixin({}, this.defaults.init, init, { active: true }));
+    }
+    else {
+      this.addState(this.defaults.init.from);
+      return this.defaults.init;
+    }
+  },
+
+  configureData: function(data) {
+    if (typeof data === 'function')
+      return data;
+    else if (typeof data === 'object')
+      return function() { return data; }
+    else
+      return function() { return {};  }
+  },
+
+  configureMethods: function(methods) {
+    return methods || {};
+  },
+
+  configurePlugins: function(plugins, builtin) {
+    plugins = plugins || [];
+    var n, max, plugin;
+    for(n = 0, max = plugins.length ; n < max ; n++) {
+      plugin = plugins[n];
+      if (typeof plugin === 'function')
+        plugins[n] = plugin = plugin()
+      if (plugin.configure)
+        plugin.configure(this);
+    }
+    return plugins
+  },
+
+  configureTransitions: function(transitions) {
+    var i, n, transition, from, to, wildcard = this.defaults.wildcard;
+    for(n = 0 ; n < transitions.length ; n++) {
+      transition = transitions[n];
+      from  = Array.isArray(transition.from) ? transition.from : [transition.from || wildcard]
+      to    = transition.to || wildcard;
+      for(i = 0 ; i < from.length ; i++) {
+        this.mapTransition({ name: transition.name, from: from[i], to: to });
+      }
+    }
+  },
+
+  transitionFor: function(state, transition) {
+    var wildcard = this.defaults.wildcard;
+    return this.map[state][transition] ||
+           this.map[wildcard][transition];
+  },
+
+  transitionsFor: function(state) {
+    var wildcard = this.defaults.wildcard;
+    return Object.keys(this.map[state]).concat(Object.keys(this.map[wildcard]));
+  },
+
+  allStates: function() {
+    return this.states;
+  },
+
+  allTransitions: function() {
+    return this.transitions;
+  }
+
+});
+
+//-------------------------------------------------------------------------------------------------
+
+module.exports = Config;
+
+//-------------------------------------------------------------------------------------------------
+
+
+/***/ }),
+/* 4 */
+/***/ (function(module, exports, __webpack_require__) {
+
+
+var mixin      = __webpack_require__(0),
+    Exception  = __webpack_require__(6),
+    plugin     = __webpack_require__(1),
+    UNOBSERVED = [ null, [] ];
+
+//-------------------------------------------------------------------------------------------------
+
+function JSM(context, config) {
+  this.context   = context;
+  this.config    = config;
+  this.state     = config.init.from;
+  this.observers = [context];
+}
+
+//-------------------------------------------------------------------------------------------------
+
+mixin(JSM.prototype, {
+
+  init: function(args) {
+    mixin(this.context, this.config.data.apply(this.context, args));
+    plugin.hook(this, 'init');
+    if (this.config.init.active)
+      return this.fire(this.config.init.name, []);
+  },
+
+  is: function(state) {
+    return Array.isArray(state) ? (state.indexOf(this.state) >= 0) : (this.state === state);
+  },
+
+  isPending: function() {
+    return this.pending;
+  },
+
+  can: function(transition) {
+    return !this.isPending() && !!this.seek(transition);
+  },
+
+  cannot: function(transition) {
+    return !this.can(transition);
+  },
+
+  allStates: function() {
+    return this.config.allStates();
+  },
+
+  allTransitions: function() {
+    return this.config.allTransitions();
+  },
+
+  transitions: function() {
+    return this.config.transitionsFor(this.state);
+  },
+
+  seek: function(transition, args) {
+    var wildcard = this.config.defaults.wildcard,
+        entry    = this.config.transitionFor(this.state, transition),
+        to       = entry && entry.to;
+    if (typeof to === 'function')
+      return to.apply(this.context, args);
+    else if (to === wildcard)
+      return this.state
+    else
+      return to
+  },
+
+  fire: function(transition, args) {
+    return this.transit(transition, this.state, this.seek(transition, args), args);
+  },
+
+  transit: function(transition, from, to, args) {
+
+    var lifecycle = this.config.lifecycle,
+        changed   = this.config.options.observeUnchangedState || (from !== to);
+
+    if (!to)
+      return this.context.onInvalidTransition(transition, from, to);
+
+    if (this.isPending())
+      return this.context.onPendingTransition(transition, from, to);
+
+    this.config.addState(to);  // might need to add this state if it's unknown (e.g. conditional transition or goto)
+
+    this.beginTransit();
+
+    args.unshift({             // this context will be passed to each lifecycle event observer
+      transition: transition,
+      from:       from,
+      to:         to,
+      fsm:        this.context
+    });
+
+    return this.observeEvents([
+                this.observersForEvent(lifecycle.onBefore.transition),
+                this.observersForEvent(lifecycle.onBefore[transition]),
+      changed ? this.observersForEvent(lifecycle.onLeave.state) : UNOBSERVED,
+      changed ? this.observersForEvent(lifecycle.onLeave[from]) : UNOBSERVED,
+                this.observersForEvent(lifecycle.on.transition),
+      changed ? [ 'doTransit', [ this ] ]                       : UNOBSERVED,
+      changed ? this.observersForEvent(lifecycle.onEnter.state) : UNOBSERVED,
+      changed ? this.observersForEvent(lifecycle.onEnter[to])   : UNOBSERVED,
+      changed ? this.observersForEvent(lifecycle.on[to])        : UNOBSERVED,
+                this.observersForEvent(lifecycle.onAfter.transition),
+                this.observersForEvent(lifecycle.onAfter[transition]),
+                this.observersForEvent(lifecycle.on[transition])
+    ], args);
+  },
+
+  beginTransit: function()          { this.pending = true;                 },
+  endTransit:   function(result)    { this.pending = false; return result; },
+  failTransit:  function(result)    { this.pending = false; throw result;  },
+  doTransit:    function(lifecycle) { this.state = lifecycle.to;           },
+
+  observe: function(args) {
+    if (args.length === 2) {
+      var observer = {};
+      observer[args[0]] = args[1];
+      this.observers.push(observer);
+    }
+    else {
+      this.observers.push(args[0]);
+    }
+  },
+
+  observersForEvent: function(event) { // TODO: this could be cached
+    var n = 0, max = this.observers.length, observer, result = [];
+    for( ; n < max ; n++) {
+      observer = this.observers[n];
+      if (observer[event])
+        result.push(observer);
+    }
+    return [ event, result, true ]
+  },
+
+  observeEvents: function(events, args, previousEvent, previousResult) {
+    if (events.length === 0) {
+      return this.endTransit(previousResult === undefined ? true : previousResult);
+    }
+
+    var event     = events[0][0],
+        observers = events[0][1],
+        pluggable = events[0][2];
+
+    args[0].event = event;
+    if (event && pluggable && event !== previousEvent)
+      plugin.hook(this, 'lifecycle', args);
+
+    if (observers.length === 0) {
+      events.shift();
+      return this.observeEvents(events, args, event, previousResult);
+    }
+    else {
+      var observer = observers.shift(),
+          result = observer[event].apply(observer, args);
+      if (result && typeof result.then === 'function') {
+        return result.then(this.observeEvents.bind(this, events, args, event))
+                     .catch(this.failTransit.bind(this))
+      }
+      else if (result === false) {
+        return this.endTransit(false);
+      }
+      else {
+        return this.observeEvents(events, args, event, result);
+      }
+    }
+  },
+
+  onInvalidTransition: function(transition, from, to) {
+    throw new Exception("transition is invalid in current state", transition, from, to, this.state);
+  },
+
+  onPendingTransition: function(transition, from, to) {
+    throw new Exception("transition is invalid while previous transition is still in progress", transition, from, to, this.state);
+  }
+
+});
+
+//-------------------------------------------------------------------------------------------------
+
+module.exports = JSM;
+
+//-------------------------------------------------------------------------------------------------
+
+
+/***/ }),
+/* 5 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+//-----------------------------------------------------------------------------------------------
+
+var mixin    = __webpack_require__(0),
+    camelize = __webpack_require__(2),
+    plugin   = __webpack_require__(1),
+    Config   = __webpack_require__(3),
+    JSM      = __webpack_require__(4);
+
+//-----------------------------------------------------------------------------------------------
+
+var PublicMethods = {
+  is:                  function(state)       { return this._fsm.is(state)                                     },
+  can:                 function(transition)  { return this._fsm.can(transition)                               },
+  cannot:              function(transition)  { return this._fsm.cannot(transition)                            },
+  observe:             function()            { return this._fsm.observe(arguments)                            },
+  transitions:         function()            { return this._fsm.transitions()                                 },
+  allTransitions:      function()            { return this._fsm.allTransitions()                              },
+  allStates:           function()            { return this._fsm.allStates()                                   },
+  onInvalidTransition: function(t, from, to) { return this._fsm.onInvalidTransition(t, from, to)              },
+  onPendingTransition: function(t, from, to) { return this._fsm.onPendingTransition(t, from, to)              },
+}
+
+var PublicProperties = {
+  state: {
+    configurable: false,
+    enumerable:   true,
+    get: function() {
+      return this._fsm.state;
+    },
+    set: function(state) {
+      throw Error('use transitions to change state')
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------------------------
+
+function StateMachine(options) {
+  return apply(this || {}, options);
+}
+
+function factory() {
+  var cstor, options;
+  if (typeof arguments[0] === 'function') {
+    cstor   = arguments[0];
+    options = arguments[1] || {};
+  }
+  else {
+    cstor   = function() { this._fsm.apply(this, arguments) };
+    options = arguments[0] || {};
+  }
+  var config = new Config(options, StateMachine);
+  build(cstor.prototype, config);
+  cstor.prototype._fsm.config = config; // convenience access to shared config without needing an instance
+  return cstor;
+}
+
+//-------------------------------------------------------------------------------------------------
+
+function apply(instance, options) {
+  var config = new Config(options, StateMachine);
+  build(instance, config);
+  instance._fsm();
+  return instance;
+}
+
+function build(target, config) {
+  if ((typeof target !== 'object') || Array.isArray(target))
+    throw Error('StateMachine can only be applied to objects');
+  plugin.build(target, config);
+  Object.defineProperties(target, PublicProperties);
+  mixin(target, PublicMethods);
+  mixin(target, config.methods);
+  config.allTransitions().forEach(function(transition) {
+    target[camelize(transition)] = function() {
+      return this._fsm.fire(transition, [].slice.call(arguments))
+    }
+  });
+  target._fsm = function() {
+    this._fsm = new JSM(this, config);
+    this._fsm.init(arguments);
+  }
+}
+
+//-----------------------------------------------------------------------------------------------
+
+StateMachine.version  = '3.0.1';
+StateMachine.factory  = factory;
+StateMachine.apply    = apply;
+StateMachine.defaults = {
+  wildcard: '*',
+  init: {
+    name: 'init',
+    from: 'none'
+  }
+}
+
+//===============================================================================================
+
+module.exports = StateMachine;
+
+
+/***/ }),
+/* 6 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+module.exports = function(message, transition, from, to, current) {
+  this.message    = message;
+  this.transition = transition;
+  this.from       = from;
+  this.to         = to;
+  this.current    = current;
+}
+
+
+/***/ })
+/******/ ]);
+});

--- a/erizo_controller/erizoClient/lib/state-machine.js
+++ b/erizo_controller/erizoClient/lib/state-machine.js
@@ -1,3 +1,25 @@
+/*
+Copyright (c) 2012, 2013, 2014, 2015, 2016, 2017, 2018, Jake Gordon and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 (function webpackUniversalModuleDefinition(root, factory) {
 	if(typeof exports === 'object' && typeof module === 'object')
 		module.exports = factory();

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -1,7 +1,10 @@
 /* global RTCSessionDescription, RTCIceCandidate, RTCPeerConnection */
+
 // eslint-disable-next-line
 import SemanticSdp from '../../../common/semanticSdp/SemanticSdp';
 import Setup from '../../../common/semanticSdp/Setup';
+
+import PeerConnectionFsm from './PeerConnectionFsm';
 
 import SdpHelpers from '../utils/SdpHelpers';
 import Logger from '../utils/Logger';
@@ -61,42 +64,8 @@ const BaseStack = (specInput) => {
     negotiationneededCount += 1;
   };
 
-  // Aux functions
-
-  const errorCallback = (where, errorcb, message) => {
-    Logger.error('message:', message, 'in baseStack at', where);
-    if (errorcb !== undefined) {
-      errorcb('error');
-    }
-  };
-
-  const onIceCandidate = (event) => {
-    let candidateObject = {};
-    const candidate = event.candidate;
-    if (!candidate) {
-      Logger.info('Gathered all candidates. Sending END candidate');
-      candidateObject = {
-        sdpMLineIndex: -1,
-        sdpMid: 'end',
-        candidate: 'end',
-      };
-    } else {
-      candidateObject = {
-        sdpMLineIndex: candidate.sdpMLineIndex,
-        sdpMid: candidate.sdpMid,
-        candidate: candidate.candidate,
-      };
-      if (!candidateObject.candidate.match(/a=/)) {
-        candidateObject.candidate = `a=${candidateObject.candidate}`;
-      }
-    }
-
-    if (specBase.remoteDescriptionSet) {
-      specBase.callback({ type: 'candidate', candidate: candidateObject });
-    } else {
-      specBase.localCandidates.push(candidateObject);
-      Logger.info('Storing candidate: ', specBase.localCandidates.length, candidateObject);
-    }
+  const onFsmError = (message) => {
+    that.peerConnectionFsm.error(message);
   };
 
   const configureLocalSdpAsAnswer = () => {
@@ -148,130 +117,337 @@ const BaseStack = (specInput) => {
     return that.peerConnection.setLocalDescription(localDesc);
   };
 
-  const _processOffer = negotiationQueue.protectFunction((message) => {
-    const msg = message;
-    remoteSdp = SemanticSdp.SDPInfo.processString(msg.sdp);
-
-    const sessionVersion = remoteSdp && remoteSdp.origin && remoteSdp.origin.sessionVersion;
-    if (latestSessionVersion >= sessionVersion) {
-      Logger.warning(`message: processOffer discarding old sdp sessionVersion: ${sessionVersion}, latestSessionVersion: ${latestSessionVersion}`);
-      // We send an answer back to finish this negotiation
-      specBase.callback({
-        type: 'answer',
-        sdp: localDesc.sdp,
-        config: { maxVideoBW: specBase.maxVideoBW },
-      });
-      return;
-    }
-    negotiationQueue.startEnqueuing();
-    latestSessionVersion = sessionVersion;
-
-    SdpHelpers.setMaxBW(remoteSdp, specBase);
-    msg.sdp = remoteSdp.toString();
-    that.remoteSdp = remoteSdp;
-    that.peerConnection.setRemoteDescription(msg)
-    .then(() => {
-      specBase.remoteDescriptionSet = true;
-    }).then(() => that.peerConnection.createAnswer(that.mediaConstraints))
-    .catch(errorCallback.bind(null, 'createAnswer', undefined))
-    .then(setLocalDescForAnswer.bind(this))
-    .catch(errorCallback.bind(null, 'process Offer', undefined))
-    .then(() => {
-      firstLocalDescriptionSet = true;
-      firstLocalDescriptionQueue.stopEnqueuing();
-      firstLocalDescriptionQueue.dequeueAll();
-      negotiationQueue.stopEnqueuing();
-      negotiationQueue.nextInQueue();
-    });
-  });
-
-  const processOffer = firstLocalDescriptionQueue.protectFunction((message) => {
-    if (!firstLocalDescriptionSet) {
-      firstLocalDescriptionQueue.startEnqueuing();
-    }
-    _processOffer(message);
-  });
-
-  const processAnswer = negotiationQueue.protectFunction((message) => {
-    const msg = message;
-
-    remoteSdp = SemanticSdp.SDPInfo.processString(msg.sdp);
-    const sessionVersion = remoteSdp && remoteSdp.origin && remoteSdp.origin.sessionVersion;
-    if (latestSessionVersion >= sessionVersion) {
-      Logger.warning(`processAnswer discarding old sdp, sessionVersion: ${sessionVersion}, latestSessionVersion: ${latestSessionVersion}`);
-      return;
-    }
-    negotiationQueue.startEnqueuing();
-    latestSessionVersion = sessionVersion;
-    Logger.info('Set remote and local description');
-
-    SdpHelpers.setMaxBW(remoteSdp, specBase);
-    that.setStartVideoBW(remoteSdp);
-    that.setHardMinVideoBW(remoteSdp);
-
-    msg.sdp = remoteSdp.toString();
-
-    configureLocalSdpAsOffer();
-
-    Logger.debug('processAnswer - Remote Description', msg.type, msg.sdp);
-    Logger.debug('processAnswer - Local Description', msg.type, localDesc.sdp);
-    that.remoteSdp = remoteSdp;
-
-    remoteDesc = msg;
-    that.peerConnection.setLocalDescription(localDesc)
-      .then(() => that.peerConnection.setRemoteDescription(new RTCSessionDescription(msg)))
-      .then(() => {
-        specBase.remoteDescriptionSet = true;
-        Logger.info('Candidates to be added: ', specBase.remoteCandidates.length,
-                      specBase.remoteCandidates);
-        while (specBase.remoteCandidates.length > 0) {
-          // IMPORTANT: preserve ordering of candidates
-          that.peerConnection.addIceCandidate(specBase.remoteCandidates.shift());
+  // Functions that are protected by a functionQueue
+  that.enqueuedCalls = {
+    negotiationQueue: {
+      createOffer: negotiationQueue.protectFunction((isSubscribe = false) => {
+        that.peerConnectionFsm.createOffer(isSubscribe).catch(onFsmError.bind(this));
+      }),
+      processOffer: negotiationQueue.protectFunction((message) => {
+        that.peerConnectionFsm.processOffer(message).catch(onFsmError.bind(this));
+      }),
+      processAnswer: negotiationQueue.protectFunction((message) => {
+        that.peerConnectionFsm.processAnswer(message).catch(onFsmError.bind(this));
+      }),
+      negotiateMaxBW: negotiationQueue.protectFunction((configInput, callback) => {
+        that.peerConnectionFsm.negotiateMaxBW(configInput, callback).catch(onFsmError.bind(this));
+      }),
+      processNewCandidate: negotiationQueue.protectFunction((message) => {
+        const msg = message;
+        try {
+          let obj;
+          if (typeof (msg.candidate) === 'object') {
+            obj = msg.candidate;
+          } else {
+            obj = JSON.parse(msg.candidate);
+          }
+          if (obj.candidate === 'end') {
+            // ignore the end candidate for chrome
+            return;
+          }
+          obj.candidate = obj.candidate.replace(/a=/g, '');
+          obj.sdpMLineIndex = parseInt(obj.sdpMLineIndex, 10);
+          const candidate = new RTCIceCandidate(obj);
+          if (specBase.remoteDescriptionSet) {
+            negotiationQueue.startEnqueuing();
+            that.peerConnectionFsm.addIceCandidate(candidate).catch(onFsmError.bind(this));
+          } else {
+            specBase.remoteCandidates.push(candidate);
+          }
+        } catch (e) {
+          Logger.error('Error parsing candidate', msg.candidate);
         }
-        Logger.info('Local candidates to send:', specBase.localCandidates.length);
-        while (specBase.localCandidates.length > 0) {
-          // IMPORTANT: preserve ordering of candidates
-          specBase.callback({ type: 'candidate', candidate: specBase.localCandidates.shift() });
+      }),
+      addStream: negotiationQueue.protectFunction((stream) => {
+        negotiationQueue.startEnqueuing();
+        that.peerConnectionFsm.addStream(stream).catch(onFsmError.bind(this));
+      }),
+      removeStream: negotiationQueue.protectFunction((stream) => {
+        negotiationQueue.startEnqueuing();
+        that.peerConnectionFsm.removeStream(stream).catch(onFsmError.bind(this));
+      }),
+      close: negotiationQueue.protectFunction(() => {
+        negotiationQueue.startEnqueuing();
+        that.peerConnectionFsm.close().catch(onFsmError.bind(this));
+      }),
+    },
+
+    firstLocalDescriptionQueue: {
+      createOffer:
+      firstLocalDescriptionQueue.protectFunction((isSubscribe = false,
+        forceOfferToReceive = false) => {
+        if (!firstLocalDescriptionSet) {
+          firstLocalDescriptionQueue.startEnqueuing();
         }
-      })
-      .catch(errorCallback.bind(null, 'processAnswer', undefined))
-      .then(() => {
-        firstLocalDescriptionSet = true;
-        firstLocalDescriptionQueue.stopEnqueuing();
-        firstLocalDescriptionQueue.dequeueAll();
+        if (!isSubscribe && !forceOfferToReceive) {
+          that.mediaConstraints = {
+            offerToReceiveVideo: false,
+            offerToReceiveAudio: false,
+          };
+        }
+        that.enqueuedCalls.negotiationQueue.createOffer(isSubscribe);
+      }),
+
+      sendOffer: firstLocalDescriptionQueue.protectFunction(() => {
+        if (!firstLocalDescriptionSet) {
+          that.createOffer(true, true);
+          return;
+        }
+        setLocalDescForOffer(true, localDesc);
+      }),
+
+      processOffer:
+      firstLocalDescriptionQueue.protectFunction((message) => {
+        if (!firstLocalDescriptionSet) {
+          firstLocalDescriptionQueue.startEnqueuing();
+        }
+        that.enqueuedCalls.negotiationQueue.processOffer(message);
+      }),
+    },
+  };
+
+  // Functions that are protected by the FSM.
+  // The promise of one has to be resolved before another can be called.
+  that.protectedCalls = {
+    protectedAddStream: (stream) => {
+      that.peerConnection.addStream(stream);
+      setTimeout(() => {
         negotiationQueue.stopEnqueuing();
         negotiationQueue.nextInQueue();
-      });
-  });
+      }, 0);
+      return Promise.resolve();
+    },
+    protectedRemoveStream: (stream) => {
+      that.peerConnection.removeStream(stream);
+      setTimeout(() => {
+        negotiationQueue.stopEnqueuing();
+        negotiationQueue.nextInQueue();
+      }, 0);
+      return Promise.resolve();
+    },
+    protectedCreateOffer: (isSubscribe = false) => {
+      negotiationQueue.startEnqueuing();
+      Logger.debug('Creating offer', that.mediaConstraints);
+      const rejectMessages = [];
+      return that.peerConnection.createOffer(that.mediaConstraints)
+        .then(setLocalDescForOffer.bind(null, isSubscribe))
+        .catch((error) => {
+          rejectMessages.push(`in protectedCreateOffer-createOffer, error: ${error}`);
+        })
+        .then(() => {
+          setTimeout(() => {
+            negotiationQueue.stopEnqueuing();
+            negotiationQueue.nextInQueue();
+          }, 0);
+          if (rejectMessages.length !== 0) {
+            return Promise.reject(rejectMessages);
+          }
+          return Promise.resolve();
+        });
+    },
+    protectedProcessOffer: (message) => {
+      Logger.info('Protected process Offer,', message, 'localDesc', localDesc);
+      const msg = message;
+      remoteSdp = SemanticSdp.SDPInfo.processString(msg.sdp);
 
-  const processNewCandidate = (message) => {
-    const msg = message;
-    try {
-      let obj;
-      if (typeof (msg.candidate) === 'object') {
-        obj = msg.candidate;
-      } else {
-        obj = JSON.parse(msg.candidate);
+      const sessionVersion = remoteSdp && remoteSdp.origin && remoteSdp.origin.sessionVersion;
+      if (latestSessionVersion >= sessionVersion) {
+        Logger.warning(`message: processOffer discarding old sdp sessionVersion: ${sessionVersion}, latestSessionVersion: ${latestSessionVersion}`);
+        // We send an answer back to finish this negotiation
+        specBase.callback({
+          type: 'answer',
+          sdp: localDesc.sdp,
+          config: { maxVideoBW: specBase.maxVideoBW },
+        });
+        return Promise.resolve();
       }
-      if (obj.candidate === 'end') {
-        // ignore the end candidate for chrome
-        return;
+      negotiationQueue.startEnqueuing();
+      latestSessionVersion = sessionVersion;
+
+      SdpHelpers.setMaxBW(remoteSdp, specBase);
+      msg.sdp = remoteSdp.toString();
+      that.remoteSdp = remoteSdp;
+      const rejectMessage = [];
+      return that.peerConnection.setRemoteDescription(msg)
+        .then(() => {
+          specBase.remoteDescriptionSet = true;
+        }).then(() => that.peerConnection.createAnswer(that.mediaConstraints))
+        .catch((error) => {
+          rejectMessage.push(`in: protectedProcessOffer-createAnswer, error: ${error}`);
+        })
+        .then(setLocalDescForAnswer.bind(this))
+        .catch((error) => {
+          rejectMessage.push(`in: protectedProcessOffer-setLocalDescForAnswer, error: ${error}`);
+        })
+        .then(() => {
+          firstLocalDescriptionSet = true;
+          firstLocalDescriptionQueue.stopEnqueuing();
+          firstLocalDescriptionQueue.dequeueAll();
+          setTimeout(() => {
+            negotiationQueue.stopEnqueuing();
+            negotiationQueue.nextInQueue();
+          }, 0);
+          if (rejectMessage.length !== 0) {
+            return Promise.reject(rejectMessage);
+          }
+          return Promise.resolve();
+        });
+    },
+
+    protectedProcessAnswer: (message) => {
+      const msg = message;
+
+      remoteSdp = SemanticSdp.SDPInfo.processString(msg.sdp);
+      const sessionVersion = remoteSdp && remoteSdp.origin && remoteSdp.origin.sessionVersion;
+      if (latestSessionVersion >= sessionVersion) {
+        Logger.warning(`processAnswer discarding old sdp, sessionVersion: ${sessionVersion}, latestSessionVersion: ${latestSessionVersion}`);
+        return Promise.resolve();
       }
-      obj.candidate = obj.candidate.replace(/a=/g, '');
-      obj.sdpMLineIndex = parseInt(obj.sdpMLineIndex, 10);
-      const candidate = new RTCIceCandidate(obj);
-      if (specBase.remoteDescriptionSet) {
-        that.peerConnection.addIceCandidate(candidate);
-      } else {
-        specBase.remoteCandidates.push(candidate);
+      negotiationQueue.startEnqueuing();
+      latestSessionVersion = sessionVersion;
+      Logger.info('Set remote and local description');
+
+      SdpHelpers.setMaxBW(remoteSdp, specBase);
+      that.setStartVideoBW(remoteSdp);
+      that.setHardMinVideoBW(remoteSdp);
+
+      msg.sdp = remoteSdp.toString();
+
+      configureLocalSdpAsOffer();
+
+      Logger.debug('processAnswer - Remote Description', msg.type, msg.sdp);
+      Logger.debug('processAnswer - Local Description', msg.type, localDesc.sdp);
+      that.remoteSdp = remoteSdp;
+
+      remoteDesc = msg;
+      const rejectMessages = [];
+      return that.peerConnection.setLocalDescription(localDesc)
+        .then(() => {
+          that.peerConnection.setRemoteDescription(new RTCSessionDescription(msg));
+        })
+        .then(() => {
+          specBase.remoteDescriptionSet = true;
+          Logger.info('Candidates to be added: ', specBase.remoteCandidates.length,
+            specBase.remoteCandidates);
+          while (specBase.remoteCandidates.length > 0) {
+            // IMPORTANT: preserve ordering of candidates
+            that.peerConnectionFsm.addIceCandidate(specBase.remoteCandidates.shift())
+              .catch(onFsmError.bind(this));
+          }
+          Logger.info('Local candidates to send:', specBase.localCandidates.length);
+          while (specBase.localCandidates.length > 0) {
+            // IMPORTANT: preserve ordering of candidates
+            specBase.callback({ type: 'candidate', candidate: specBase.localCandidates.shift() });
+          }
+        })
+        .catch((error) => {
+          rejectMessages.push(`in: protectedProcessAnswer, error: ${error}`);
+        })
+        .then(() => {
+          firstLocalDescriptionSet = true;
+          firstLocalDescriptionQueue.stopEnqueuing();
+          firstLocalDescriptionQueue.dequeueAll();
+          setTimeout(() => {
+            negotiationQueue.stopEnqueuing();
+            negotiationQueue.nextInQueue();
+          }, 0);
+          if (rejectMessages.length !== 0) {
+            return Promise.reject(rejectMessages);
+          }
+          return Promise.resolve();
+        });
+    },
+    protectedNegotiateMaxBW: (configInput, callback) => {
+      const config = configInput;
+      if (config.Sdp || config.maxAudioBW) {
+        negotiationQueue.startEnqueuing();
+        const rejectMessages = [];
+
+        configureLocalSdpAsOffer();
+        that.peerConnection.setLocalDescription(localDesc)
+          .then(() => {
+            remoteSdp = SemanticSdp.SDPInfo.processString(remoteDesc.sdp);
+            SdpHelpers.setMaxBW(remoteSdp, specBase);
+            remoteDesc.sdp = remoteSdp.toString();
+            that.remoteSdp = remoteSdp;
+            return that.peerConnection.setRemoteDescription(
+              new RTCSessionDescription(remoteDesc));
+          }).then(() => {
+            specBase.remoteDescriptionSet = true;
+            specBase.callback({ type: 'offer-noanswer', sdp: localDesc.sdp });
+          }).catch((error) => {
+            callback('error', 'updateSpec');
+            rejectMessages.push(`in: protectedNegotiateMaxBW error: ${error}`);
+          })
+          .then(() => {
+            setTimeout(() => {
+              negotiationQueue.stopEnqueuing();
+              negotiationQueue.nextInQueue();
+            }, 0);
+            if (rejectMessages.length !== 0) {
+              return Promise.reject(rejectMessages);
+            }
+            return Promise.resolve();
+          });
       }
-    } catch (e) {
-      Logger.error('Error parsing candidate', msg.candidate);
+    },
+    protectedAddIceCandiate: (candidate) => {
+      const rejectMessages = [];
+      return that.peerConnection.addIceCandidate(candidate)
+        .catch((error) => {
+          rejectMessages.push(`in: protectedAddIceCandidate, error: ${error}`);
+        }).then(() => {
+          setTimeout(() => {
+            negotiationQueue.stopEnqueuing();
+            negotiationQueue.nextInQueue();
+          }, 0);
+          if (rejectMessages.length !== 0) {
+            return Promise.reject(rejectMessages);
+          }
+          return Promise.resolve();
+        });
+    },
+    protectedClose: () => {
+      that.peerConnection.close();
+      setTimeout(() => {
+        negotiationQueue.stopEnqueuing();
+        negotiationQueue.nextInQueue();
+      }, 0);
+      return Promise.resolve();
+    },
+  };
+
+
+  const onIceCandidate = (event) => {
+    let candidateObject = {};
+    const candidate = event.candidate;
+    if (!candidate) {
+      Logger.info('Gathered all candidates. Sending END candidate');
+      candidateObject = {
+        sdpMLineIndex: -1,
+        sdpMid: 'end',
+        candidate: 'end',
+      };
+    } else {
+      candidateObject = {
+        sdpMLineIndex: candidate.sdpMLineIndex,
+        sdpMid: candidate.sdpMid,
+        candidate: candidate.candidate,
+      };
+      if (!candidateObject.candidate.match(/a=/)) {
+        candidateObject.candidate = `a=${candidateObject.candidate}`;
+      }
+    }
+
+    if (specBase.remoteDescriptionSet) {
+      specBase.callback({ type: 'candidate', candidate: candidateObject });
+    } else {
+      specBase.localCandidates.push(candidateObject);
+      Logger.info('Storing candidate: ', specBase.localCandidates.length, candidateObject);
     }
   };
 
   // Peerconnection events
-
   that.peerConnection.onicecandidate = onIceCandidate;
   // public functions
 
@@ -290,11 +466,6 @@ const BaseStack = (specInput) => {
     return sdpInput;
   };
 
-  that.close = () => {
-    that.state = 'closed';
-    that.peerConnection.close();
-  };
-
   that.setSimulcast = (enable) => {
     that.simulcast = enable;
   };
@@ -306,30 +477,6 @@ const BaseStack = (specInput) => {
   that.setAudio = (audio) => {
     that.audio = audio;
   };
-
-  const negotiatieMaxBWInSdp = negotiationQueue.protectFunction((configInput, callback) => {
-    const config = configInput;
-    if (config.Sdp || config.maxAudioBW) {
-      negotiationQueue.startEnqueuing();
-
-      configureLocalSdpAsOffer();
-      that.peerConnection.setLocalDescription(localDesc)
-        .then(() => {
-          remoteSdp = SemanticSdp.SDPInfo.processString(remoteDesc.sdp);
-          SdpHelpers.setMaxBW(remoteSdp, specBase);
-          remoteDesc.sdp = remoteSdp.toString();
-          that.remoteSdp = remoteSdp;
-          return that.peerConnection.setRemoteDescription(new RTCSessionDescription(remoteDesc));
-        }).then(() => {
-          specBase.remoteDescriptionSet = true;
-          specBase.callback({ type: 'offer-noanswer', sdp: localDesc.sdp });
-        }).catch(errorCallback.bind(null, 'updateSpec', callback))
-        .then(() => {
-          negotiationQueue.stopEnqueuing();
-          negotiationQueue.nextInQueue();
-        });
-    }
-  });
 
   that.updateSpec = (configInput, streamId, callback = () => {}) => {
     const config = configInput;
@@ -351,7 +498,7 @@ const BaseStack = (specInput) => {
       specBase.maxAudioBW = config.maxAudioBW;
     }
     if (shouldApplyMaxVideoBWToSdp || config.maxAudioBW) {
-      negotiatieMaxBWInSdp(config, callback);
+      that.enqueuedCalls.negotiationQueue.negotiateMaxBW(config, callback);
     }
     if (shouldSendMaxVideoBWInOptions ||
         config.minVideoBW ||
@@ -370,62 +517,32 @@ const BaseStack = (specInput) => {
     }
   };
 
-  const _createOfferOnPeerConnection = negotiationQueue.protectFunction((isSubscribe = false) => {
-    negotiationQueue.startEnqueuing();
-    Logger.debug('Creating offer', that.mediaConstraints);
-    that.peerConnection.createOffer(that.mediaConstraints)
-      .then(setLocalDescForOffer.bind(null, isSubscribe))
-      .catch(errorCallback.bind(null, 'Create Offer', undefined))
-      .then(() => {
-        negotiationQueue.stopEnqueuing();
-        negotiationQueue.nextInQueue();
-      });
-  });
 
   // We need to protect it against calling multiple times to createOffer.
   // Otherwise it could change the ICE credentials before calling setLocalDescription
   // the first time in Chrome.
-  that.createOffer = firstLocalDescriptionQueue.protectFunction((isSubscribe = false,
-                                                                 forceOfferToReceive = false) => {
-    if (!firstLocalDescriptionSet) {
-      firstLocalDescriptionQueue.startEnqueuing();
-    }
+  that.createOffer = that.enqueuedCalls.firstLocalDescriptionQueue.createOffer;
 
-    if (!isSubscribe && !forceOfferToReceive) {
-      that.mediaConstraints = {
-        offerToReceiveVideo: false,
-        offerToReceiveAudio: false,
-      };
-    }
-    _createOfferOnPeerConnection(isSubscribe);
-  });
+  that.sendOffer = that.enqueuedCalls.firstLocalDescriptionQueue.sendOffer;
 
-  that.sendOffer = firstLocalDescriptionQueue.protectFunction(() => {
-    if (!firstLocalDescriptionSet) {
-      that.createOffer(true, true);
-      return;
-    }
-    setLocalDescForOffer(true, localDesc);
-  });
+  that.addStream = that.enqueuedCalls.negotiationQueue.addStream;
 
-  that.addStream = (stream) => {
-    that.peerConnection.addStream(stream);
-  };
+  that.removeStream = that.enqueuedCalls.negotiationQueue.removeStream;
 
-  that.removeStream = (stream) => {
-    that.peerConnection.removeStream(stream);
-  };
+  that.close = that.enqueuedCalls.negotiationQueue.close;
+
 
   that.processSignalingMessage = (msgInput) => {
     if (msgInput.type === 'offer') {
-      processOffer(msgInput);
+      that.enqueuedCalls.firstLocalDescriptionQueue.processOffer(msgInput);
     } else if (msgInput.type === 'answer') {
-      processAnswer(msgInput);
+      that.enqueuedCalls.negotiationQueue.processAnswer(msgInput);
     } else if (msgInput.type === 'candidate') {
-      processNewCandidate(msgInput);
+      that.enqueuedCalls.negotiationQueue.processNewCandidate(msgInput);
     }
   };
 
+  that.peerConnectionFsm = new PeerConnectionFsm(that.protectedCalls);
   return that;
 };
 

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -123,15 +123,19 @@ const BaseStack = (specInput) => {
       createOffer: negotiationQueue.protectFunction((isSubscribe = false) => {
         that.peerConnectionFsm.createOffer(isSubscribe).catch(onFsmError.bind(this));
       }),
+
       processOffer: negotiationQueue.protectFunction((message) => {
         that.peerConnectionFsm.processOffer(message).catch(onFsmError.bind(this));
       }),
+
       processAnswer: negotiationQueue.protectFunction((message) => {
         that.peerConnectionFsm.processAnswer(message).catch(onFsmError.bind(this));
       }),
+
       negotiateMaxBW: negotiationQueue.protectFunction((configInput, callback) => {
         that.peerConnectionFsm.negotiateMaxBW(configInput, callback).catch(onFsmError.bind(this));
       }),
+
       processNewCandidate: negotiationQueue.protectFunction((message) => {
         const msg = message;
         try {
@@ -158,14 +162,17 @@ const BaseStack = (specInput) => {
           Logger.error('Error parsing candidate', msg.candidate);
         }
       }),
+
       addStream: negotiationQueue.protectFunction((stream) => {
         negotiationQueue.startEnqueuing();
         that.peerConnectionFsm.addStream(stream).catch(onFsmError.bind(this));
       }),
+
       removeStream: negotiationQueue.protectFunction((stream) => {
         negotiationQueue.startEnqueuing();
         that.peerConnectionFsm.removeStream(stream).catch(onFsmError.bind(this));
       }),
+
       close: negotiationQueue.protectFunction(() => {
         negotiationQueue.startEnqueuing();
         that.peerConnectionFsm.close().catch(onFsmError.bind(this));
@@ -217,6 +224,7 @@ const BaseStack = (specInput) => {
       }, 0);
       return Promise.resolve();
     },
+
     protectedRemoveStream: (stream) => {
       that.peerConnection.removeStream(stream);
       setTimeout(() => {
@@ -225,6 +233,7 @@ const BaseStack = (specInput) => {
       }, 0);
       return Promise.resolve();
     },
+
     protectedCreateOffer: (isSubscribe = false) => {
       negotiationQueue.startEnqueuing();
       Logger.debug('Creating offer', that.mediaConstraints);
@@ -245,6 +254,7 @@ const BaseStack = (specInput) => {
           return Promise.resolve();
         });
     },
+
     protectedProcessOffer: (message) => {
       Logger.info('Protected process Offer,', message, 'localDesc', localDesc);
       const msg = message;
@@ -280,10 +290,10 @@ const BaseStack = (specInput) => {
           rejectMessage.push(`in: protectedProcessOffer-setLocalDescForAnswer, error: ${error}`);
         })
         .then(() => {
-          firstLocalDescriptionSet = true;
-          firstLocalDescriptionQueue.stopEnqueuing();
-          firstLocalDescriptionQueue.dequeueAll();
           setTimeout(() => {
+            firstLocalDescriptionSet = true;
+            firstLocalDescriptionQueue.stopEnqueuing();
+            firstLocalDescriptionQueue.dequeueAll();
             negotiationQueue.stopEnqueuing();
             negotiationQueue.nextInQueue();
           }, 0);
@@ -344,10 +354,10 @@ const BaseStack = (specInput) => {
           rejectMessages.push(`in: protectedProcessAnswer, error: ${error}`);
         })
         .then(() => {
-          firstLocalDescriptionSet = true;
-          firstLocalDescriptionQueue.stopEnqueuing();
-          firstLocalDescriptionQueue.dequeueAll();
           setTimeout(() => {
+            firstLocalDescriptionSet = true;
+            firstLocalDescriptionQueue.stopEnqueuing();
+            firstLocalDescriptionQueue.dequeueAll();
             negotiationQueue.stopEnqueuing();
             negotiationQueue.nextInQueue();
           }, 0);
@@ -357,6 +367,7 @@ const BaseStack = (specInput) => {
           return Promise.resolve();
         });
     },
+
     protectedNegotiateMaxBW: (configInput, callback) => {
       const config = configInput;
       if (config.Sdp || config.maxAudioBW) {
@@ -391,6 +402,7 @@ const BaseStack = (specInput) => {
           });
       }
     },
+
     protectedAddIceCandiate: (candidate) => {
       const rejectMessages = [];
       return that.peerConnection.addIceCandidate(candidate)
@@ -407,6 +419,7 @@ const BaseStack = (specInput) => {
           return Promise.resolve();
         });
     },
+
     protectedClose: () => {
       that.peerConnection.close();
       setTimeout(() => {

--- a/erizo_controller/erizoClient/src/webrtc-stacks/PeerConnectionFsm.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/PeerConnectionFsm.js
@@ -1,0 +1,95 @@
+/* global */
+
+import StateMachine from '../../lib/state-machine';
+import Logger from '../utils/Logger';
+
+const activeStates = ['initial', 'failed', 'stable'];
+const HISTORY_SIZE_LIMIT = 200;
+// FSM
+const PeerConnectionFsm = StateMachine.factory({
+  init: 'initial',
+  transitions: [
+    { name: 'create-offer', from: activeStates, to: 'stable' },
+    { name: 'add-ice-candidate', from: activeStates, to: function nextState() { return this.state; } },
+    { name: 'process-answer', from: activeStates, to: 'stable' },
+    { name: 'process-offer', from: activeStates, to: 'stable' },
+    { name: 'negotiate-max-bw', from: activeStates, to: 'stable' },
+    { name: 'add-stream', from: activeStates, to: function nextState() { return this.state; } },
+    { name: 'remove-stream', from: activeStates, to: function nextState() { return this.state; } },
+    { name: 'close', from: activeStates, to: 'closed' },
+    { name: 'error', from: '*', to: 'failed' },
+  ],
+  data: function data(baseStackCalls) {
+    return { baseStackCalls,
+      history: [],
+    };
+  },
+  methods: {
+    getHistory: function getHistory() {
+      return this.history;
+    },
+    onBeforeClose: function onBeforeClose(lifecycle) {
+      Logger.info(`FSM onBeforeClose from: ${lifecycle.from}, to: ${lifecycle.to}`);
+      return this.baseStackCalls.protectedClose();
+    },
+    onBeforeAddIceCandidate(lifecycle, candidate) {
+      Logger.info(`FSM onBeforeAddIceCandidate, from ${lifecycle.from}, to: ${lifecycle.to}`);
+      return this.baseStackCalls.protectedAddIceCandidate(candidate);
+    },
+    onBeforeAddStream: function onBeforeAddStream(lifecycle, stream) {
+      Logger.info(`FSM onBeforeAddStream, from ${lifecycle.from}, to: ${lifecycle.to}`);
+      return this.baseStackCalls.protectedAddStream(stream);
+    },
+    onBeforeRemoveStream: function onBeforeRemoveStream(lifecycle, stream) {
+      Logger.info(`FSM onBeforeRemoveStream, from ${lifecycle.from}, to: ${lifecycle.to}`);
+      return this.baseStackCalls.protectedRemoveStream(stream);
+    },
+    onBeforeCreateOffer: function onBeforeCreateOffer(lifecycle, isSubscribe) {
+      Logger.info(`FSM onBeforeCreateOffer, from ${lifecycle.from}, to: ${lifecycle.to}`);
+      return this.baseStackCalls.protectedCreateOffer(isSubscribe);
+    },
+    onBeforeProcessOffer:
+    function onBeforeProcessOffer(lifecycle, message) {
+      Logger.info(`FSM onBeforeProcessOffer, from ${lifecycle.from}, to: ${lifecycle.to}`);
+      return this.baseStackCalls.protectedProcessOffer(message);
+    },
+    onBeforeProcessAnswer:
+    function onBeforeProcessAnswer(lifecycle, message) {
+      Logger.info(`FSM onBeforeProcessAnswer from: ${lifecycle.from}, to: ${lifecycle.to}`);
+      return this.baseStackCalls.protectedProcessAnswer(message);
+    },
+    onBeforeNegotiateMaxBW:
+    function onBeforeNegotiateMaxBW(lifecycle, configInput, callback) {
+      Logger.info(`FSM onBeforeNegotiateMaxBW from: ${lifecycle.from}, to: ${lifecycle.to}`);
+      return this.baseStackCalls.protectedNegotiateMaxBW(configInput, callback);
+    },
+    onStable: function onStable(lifecycle) {
+      Logger.info(`FSM reached STABLE, from ${lifecycle.from}, to: ${lifecycle.to}`);
+    },
+    onClosed: function onClosed(lifecycle) {
+      Logger.info(`FSM reached close, from ${lifecycle.from}, to: ${lifecycle.to}`);
+    },
+    onTransition: function saveToHistory(lifecycle) {
+      Logger.debug(`FSM onTransition, transition: ${lifecycle.transition}, from ${lifecycle.from}, to: ${lifecycle.to}`);
+      this.history.push(
+        { from: lifecycle.from, to: lifecycle.to, transition: lifecycle.transition });
+      if (this.history.length > HISTORY_SIZE_LIMIT) {
+        this.history.shift();
+      }
+    },
+    onError: function onFailed(lifecycle, message) {
+      Logger.error(`FSM Error Transition Failed, message: ${message}, from: ${lifecycle.from}, to: ${lifecycle.to}, printing history:`);
+      this.history.forEach((item) => {
+        Logger.error(item);
+      });
+    },
+    onInvalidTransition: function onInvalidTransition(transition, from, to) {
+      Logger.error(`FSM Error Invalid transition: ${transition}, from: ${from}, to: ${to}`);
+    },
+    onPendingTransition: function onPendingTransition(transition, from, to) {
+      Logger.error(`FSM Error Pending transition: ${transition}, from: ${from}, to: ${to}`);
+    },
+  },
+});
+
+export default PeerConnectionFsm;

--- a/erizo_controller/erizoClient/src/webrtc-stacks/PeerConnectionFsm.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/PeerConnectionFsm.js
@@ -28,47 +28,58 @@ const PeerConnectionFsm = StateMachine.factory({
     getHistory: function getHistory() {
       return this.history;
     },
+
     onBeforeClose: function onBeforeClose(lifecycle) {
       Logger.info(`FSM onBeforeClose from: ${lifecycle.from}, to: ${lifecycle.to}`);
       return this.baseStackCalls.protectedClose();
     },
-    onBeforeAddIceCandidate(lifecycle, candidate) {
+
+    onBeforeAddIceCandidate: function onBeforeAddIceCandidate(lifecycle, candidate) {
       Logger.info(`FSM onBeforeAddIceCandidate, from ${lifecycle.from}, to: ${lifecycle.to}`);
       return this.baseStackCalls.protectedAddIceCandidate(candidate);
     },
+
     onBeforeAddStream: function onBeforeAddStream(lifecycle, stream) {
       Logger.info(`FSM onBeforeAddStream, from ${lifecycle.from}, to: ${lifecycle.to}`);
       return this.baseStackCalls.protectedAddStream(stream);
     },
+
     onBeforeRemoveStream: function onBeforeRemoveStream(lifecycle, stream) {
       Logger.info(`FSM onBeforeRemoveStream, from ${lifecycle.from}, to: ${lifecycle.to}`);
       return this.baseStackCalls.protectedRemoveStream(stream);
     },
+
     onBeforeCreateOffer: function onBeforeCreateOffer(lifecycle, isSubscribe) {
       Logger.info(`FSM onBeforeCreateOffer, from ${lifecycle.from}, to: ${lifecycle.to}`);
       return this.baseStackCalls.protectedCreateOffer(isSubscribe);
     },
+
     onBeforeProcessOffer:
     function onBeforeProcessOffer(lifecycle, message) {
       Logger.info(`FSM onBeforeProcessOffer, from ${lifecycle.from}, to: ${lifecycle.to}`);
       return this.baseStackCalls.protectedProcessOffer(message);
     },
+
     onBeforeProcessAnswer:
     function onBeforeProcessAnswer(lifecycle, message) {
       Logger.info(`FSM onBeforeProcessAnswer from: ${lifecycle.from}, to: ${lifecycle.to}`);
       return this.baseStackCalls.protectedProcessAnswer(message);
     },
+
     onBeforeNegotiateMaxBW:
     function onBeforeNegotiateMaxBW(lifecycle, configInput, callback) {
       Logger.info(`FSM onBeforeNegotiateMaxBW from: ${lifecycle.from}, to: ${lifecycle.to}`);
       return this.baseStackCalls.protectedNegotiateMaxBW(configInput, callback);
     },
+
     onStable: function onStable(lifecycle) {
       Logger.info(`FSM reached STABLE, from ${lifecycle.from}, to: ${lifecycle.to}`);
     },
+
     onClosed: function onClosed(lifecycle) {
       Logger.info(`FSM reached close, from ${lifecycle.from}, to: ${lifecycle.to}`);
     },
+
     onTransition: function saveToHistory(lifecycle) {
       Logger.debug(`FSM onTransition, transition: ${lifecycle.transition}, from ${lifecycle.from}, to: ${lifecycle.to}`);
       this.history.push(
@@ -77,15 +88,18 @@ const PeerConnectionFsm = StateMachine.factory({
         this.history.shift();
       }
     },
-    onError: function onFailed(lifecycle, message) {
+
+    onError: function onError(lifecycle, message) {
       Logger.error(`FSM Error Transition Failed, message: ${message}, from: ${lifecycle.from}, to: ${lifecycle.to}, printing history:`);
       this.history.forEach((item) => {
         Logger.error(item);
       });
     },
+
     onInvalidTransition: function onInvalidTransition(transition, from, to) {
       Logger.error(`FSM Error Invalid transition: ${transition}, from: ${from}, to: ${to}`);
     },
+
     onPendingTransition: function onPendingTransition(transition, from, to) {
       Logger.error(`FSM Error Pending transition: ${transition}, from: ${from}, to: ${to}`);
     },


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
This PR adds a finite state machine that tracks and protects all calls from baseStack to peerConnection.
This PR also reorganizes many of the functions in baseStack. There are now two structures `enqueuedCalls` and `protectedCalls`.
`protectedCalls` are only called from `PeerConnectionFsm`
`enqueuedCalls` can be called from anywhere else and they are protected by a `FunctionQueue`.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.