### PR TITLE
Fix audio issues caused by not creating offers

### DIFF
--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -3,6 +3,7 @@
 // eslint-disable-next-line
 import SemanticSdp from '../../../common/semanticSdp/SemanticSdp';
 import Setup from '../../../common/semanticSdp/Setup';
+import Direction from '../../../common/semanticSdp/Direction';
 
 import PeerConnectionFsm from './PeerConnectionFsm';
 
@@ -73,6 +74,24 @@ const BaseStack = (specInput) => {
     localDesc.type = 'answer';
     localSdp = SemanticSdp.SDPInfo.processString(localDesc.sdp);
     SdpHelpers.setMaxBW(localSdp, specBase);
+
+    const numberOfRemoteMedias = that.remoteSdp.getStreams().size;
+    const numberOfLocalMedias = localSdp.getStreams().size;
+
+    let direction = Direction.reverse('sendrecv');
+    if (numberOfRemoteMedias > 0 && numberOfLocalMedias > 0) {
+      direction = Direction.reverse('sendrecv');
+    } else if (numberOfRemoteMedias > 0 && numberOfLocalMedias === 0) {
+      direction = Direction.reverse('recvonly');
+    } else if (numberOfRemoteMedias === 0 && numberOfLocalMedias > 0) {
+      direction = Direction.reverse('sendonly');
+    } else {
+      direction = Direction.reverse('inactive');
+    }
+    localSdp.getMedias().forEach((media) => {
+      media.setDirection(direction);
+    });
+
     localDesc.sdp = localSdp.toString();
     that.localSdp = localSdp;
   };


### PR DESCRIPTION
**Description**

I introduced an issue by which we were sending SDPs with sendonly in cases where we wanted to receive medias too. That's caused by the new policy of not creating SDP offers so often.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.