### PR TITLE
Kill Erizo Controller if CH is not reachable

### DIFF
--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -217,6 +217,7 @@ const addToCloudHandler = (callback) => {
   const addECToCloudHandler = (attempt) => {
     if (attempt <= 0) {
       log.error('message: addECtoCloudHandler cloudHandler does not respond - fatal');
+      process.exit(-1);
       return;
     }
 


### PR DESCRIPTION
**Description**

This PR exits Erizo Controller process when there is a timeout trying to connect to Cloud Handler.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.