### PR TITLE
Fix unsubscribe from the last stream in a connection

### DIFF
--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -99,15 +99,15 @@ class ErizoConnection extends EventEmitterConst {
   removeStream(stream) {
     const streamId = stream.getID();
     if (!this.streamsMap.has(streamId)) {
-      Logger.warning(`message: Cannot remove stream not in map, streamId: ${streamId}`);
+      Logger.debug(`message: Cannot remove stream not in map, streamId: ${streamId}`);
       return;
     }
+    this.streamsMap.remove(streamId);
     if (stream.local) {
       this.stack.removeStream(stream.stream);
-    } else if (this.streamsMap.size() === 1) {
+    } else if (this.streamsMap.size() === 0) {
       this.streamRemovedListener(stream.getLabel());
     }
-    this.streamsMap.remove(streamId);
   }
 
   processSignalingMessage(msg) {

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -109,11 +109,11 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     Logger.debug(`maybeDispatchStreamUnsubscribed - unsubscribe id ${stream.getID()}`, stream.unsubscribing);
     if (stream && stream.unsubscribing.callbackReceived && stream.unsubscribing.pcEventReceived) {
       Logger.info(`Dispatching Stream unsubscribed ${stream.getID()}`);
+      stream.unsubscribing.callbackReceived = false;
+      stream.unsubscribing.pcEventReceived = false;
       removeStream(stream);
       delete stream.failed;
       const evt2 = StreamEvent({ type: 'stream-unsubscribed', stream });
-      stream.unsubscribing.callbackReceived = false;
-      stream.unsubscribing.pcEventReceived = false;
       that.dispatchEvent(evt2);
     } else {
       Logger.debug(`Not dispatching stream unsubscribed yet ${stream.getID()}`);


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR fixes an issue that caused unsubscribes to the last stream in a connection to create a never ending loop of calls to removeStream.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.