### PR TITLE
Connections now persist with Clients when in singlePC

### DIFF
--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -187,6 +187,11 @@ class ErizoConnectionManager {
     Logger.debug(`Trying to remove connection ${connection.sessionId}
        with erizoId ${connection.erizoId}`);
     if (connection.streamsMap.size() === 0) {
+      Logger.debug(`No streams in connection ${connection.sessionId}, erizoId: ${connection.erizoId}`);
+      if (this.ErizoConnectionsMap.get(connection.erizoId) !== undefined && this.ErizoConnectionsMap.get(connection.erizoId)['single-pc']) {
+        Logger.debug(`Will not remove empty connection ${connection.erizoId} - it is singlePC`);
+        return;
+      }
       connection.close();
       if (this.ErizoConnectionsMap.get(connection.erizoId) !== undefined) {
         delete this.ErizoConnectionsMap.get(connection.erizoId)['single-pc'];

--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -527,7 +527,6 @@ class Client extends events.EventEmitter {
         }
       });
 
-      this.room.removeClient(this.id);
 
       if (this.room.controller) {
         this.room.controller.removeSubscriptions(this.id);
@@ -559,8 +558,9 @@ class Client extends events.EventEmitter {
           user: this.id,
           type: 'user_disconnection',
           timestamp: timeStamp.getTime() });
-      }
+      } 
 
+      this.room.removeClient(this.id);
       this.emit('disconnect');
     }
   }

--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -558,7 +558,7 @@ class Client extends events.EventEmitter {
           user: this.id,
           type: 'user_disconnection',
           timestamp: timeStamp.getTime() });
-      } 
+      }
 
       this.room.removeClient(this.id);
       this.emit('disconnect');

--- a/erizo_controller/erizoController/models/ErizoList.js
+++ b/erizo_controller/erizoController/models/ErizoList.js
@@ -43,9 +43,11 @@ class ErizoList extends EventEmitter {
     return this.erizos[this.getInternalPosition(position)];
   }
 
-  forEachExisting(task) {
+  forEachUniqueErizo(task) {
+    const uniqueIds = new Set();
     this.erizos.forEach((erizo) => {
-      if (erizo.erizoId) {
+      if (erizo.erizoId && !uniqueIds.has(erizo.erizoId)) {
+        uniqueIds.add(erizo.erizoId);
         task(erizo);
       }
     });

--- a/erizo_controller/erizoController/models/Room.js
+++ b/erizo_controller/erizoController/models/Room.js
@@ -52,6 +52,7 @@ class Room extends events.EventEmitter {
   }
 
   removeClient(id) {
+    this.controller.removeClient(id);
     return this.clients.delete(id);
   }
 

--- a/erizo_controller/erizoController/roomController.js
+++ b/erizo_controller/erizoController/roomController.js
@@ -64,7 +64,7 @@ exports.RoomController = (spec) => {
   };
 
   const sendKeepAlive = () => {
-    erizos.forEachExisting((erizo) => {
+    erizos.forEachUniqueErizo((erizo) => {
       const erizoId = erizo.erizoId;
       amqper.callRpc(`ErizoJS_${erizoId}`, 'keepAlive', [], { callback: callbackFor(erizoId) });
     });
@@ -477,6 +477,19 @@ exports.RoomController = (spec) => {
       log.warn('message: getStreamStats publisher not found, ' +
                      `streamId: ${streamId}`);
     }
+  };
+
+  that.removeClient = (clientId) => {
+    log.info(`message: removeClient clientId ${clientId}`);
+    erizos.forEachUniqueErizo((erizo) => {
+      const erizoId = erizo.erizoId;
+      const args = [clientId];
+      log.info(`message: removeClient - calling ErizoJS to remove client, erizoId: ${erizoId}, clientId: ${clientId}`);
+      amqper.callRpc(`ErizoJS_${erizoId}`, 'removeClient', args, {
+        callback: (result) => {
+          log.info(`message: removeClient - result from erizoJS ${erizo.erizoId}, result ${result}`);
+        } });
+    });
   };
 
   return that;

--- a/erizo_controller/erizoJS/erizoJS.js
+++ b/erizo_controller/erizoJS/erizoJS.js
@@ -95,6 +95,11 @@ const controller = require('./erizoJSController');
 // Logger
 const log = logger.getLogger('ErizoJS');
 
+process.on('unhandledRejection', (error) => {
+  log.error('unhandledRejection', error);
+});
+
+
 const threadPool = new addon.ThreadPool(global.config.erizo.numWorkers);
 threadPool.start();
 

--- a/erizo_controller/erizoJS/models/Client.js
+++ b/erizo_controller/erizoJS/models/Client.js
@@ -7,7 +7,7 @@ const log = logger.getLogger('Client');
 class Client {
 
   constructor(id, threadPool, ioThreadPool, singlePc = false) {
-    log.debug(`Constructor Client ${id}`);
+    log.info(`Constructor Client ${id}`);
     this.id = id;
     this.connections = new Map();
     this.threadPool = threadPool;
@@ -48,12 +48,24 @@ class Client {
     log.debug(`Client connections list size after add : ${this.connections.size}`);
   }
 
+  closeAllConnections() {
+    log.debug(`message: client closing all connections, clientId: ${this.id}`);
+    this.connections.forEach((connection) => {
+      connection.close();
+    });
+    this.connections.clear();
+  }
+
   maybeCloseConnection(id) {
     const connection = this.connections.get(id);
     log.debug(`message: maybeCloseConnection, connectionId: ${id}`);
     if (connection !== undefined) {
       // ExternalInputs don't have mediaStreams but have to be closed
       if (connection.getNumMediaStreams() === 0) {
+        if (this.singlePc) {
+          log.info(`message: not closing connection because it is singlePC: ${id}`);
+          return this.connections.size;
+        }
         log.info(`message: closing empty connection, clientId: ${this.id}` +
         ` connectionId: ${connection.id}`);
         connection.close();

--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -261,7 +261,7 @@ class Connection extends events.EventEmitter {
       mediaStream.close();
     });
     this.wrtc.close();
-    delete this.mediaStreams;
+    this.mediaStreams.clear();
     delete this.wrtc;
   }
 

--- a/erizo_controller/test/utils.js
+++ b/erizo_controller/test/utils.js
@@ -212,6 +212,7 @@ module.exports.reset = () => {
     removeSubscriber: sinon.stub(),
     removeSubscriptions: sinon.stub(),
     removeExternalOutput: sinon.stub(),
+    removeClient: sinon.stub(),
   };
 
   module.exports.roomController = createMock('../erizoController/roomController', {


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
This PR allows connections (the PeerConnection-WebRTCConnection pair) to remain open while a client stays in a room in SinglePC. That means when unpublishing or unsubscribing from the last stream, the connection won't be immediately closed, allowing the client to publish/subscribe again without the added cost of creating a new Connection (ice negotiation, etc.)

This also changes the way ErizoJS processes are handled, they are not closed when the last publisher leaves, they are now notified when clients leave ErizoController and the process ends when the last client leaves.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.