### PR TITLE
Fix h264 keyframe parse error

### DIFF
--- a/erizo/src/erizo/rtp/RtpH264Parser.cpp
+++ b/erizo/src/erizo/rtp/RtpH264Parser.cpp
@@ -103,7 +103,7 @@ int RtpH264Parser::parse_packet_fu_a(RTPPayloadH264* h264, unsigned char* buf, i
   buf += 2;
   len -= 2;
 
-  if (nal_type == 5) {
+  if (nal_type == 5 && start_bit == 1) {
     h264->frameType = kH264IFrame;
   }
 
@@ -145,6 +145,10 @@ int RtpH264Parser::parse_aggregated_packet(RTPPayloadH264* h264, unsigned char* 
           dst += sizeof(RTPPayloadH264::start_sequence);
           std::memcpy(dst, src, nal_size);
           dst += nal_size;
+          uint8_t nal_type = src[0] & 0x1f;
+          if (nal_type == 5) {
+            h264->frameType = kH264IFrame;
+          }
         }
       } else {
         ELOG_ERROR("NAL size exceeds length: %d %d\n", nal_size, src_len);


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

This PR fix H264 keyframe parse error:

- if the packet is FU-A (fragmented nal) type
     set keyframe flag to true when nal_type==5 and start_bit==1

- if the packet is STAP-A (one packet, multiple nals), sometimes the keyframe size is smaller than MTU, especially low resolution video, so publisher will put sps,pps and keyframe into one packet. need to parse it in such case.
    parse all nals type and  set keyframe flag to true if one nal_type==5