### PR TITLE
Emit stream-unsubscribed when callback is received and connection has failed

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -107,7 +107,8 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   const maybeDispatchStreamUnsubscribed = (streamInput) => {
     const stream = streamInput;
     Logger.debug(`maybeDispatchStreamUnsubscribed - unsubscribe id ${stream.getID()}`, stream.unsubscribing);
-    if (stream && stream.unsubscribing.callbackReceived && stream.unsubscribing.pcEventReceived) {
+    if (stream && stream.unsubscribing.callbackReceived &&
+      (stream.unsubscribing.pcEventReceived || stream.failed)) {
       Logger.info(`Dispatching Stream unsubscribed ${stream.getID()}`);
       stream.unsubscribing.callbackReceived = false;
       stream.unsubscribing.pcEventReceived = false;


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
This PR fixed an issue that prevented unsubscribing from failed connections. This should be much more common in multiplePC.
Before this, we were waiting for the peerConnection event that could not arrive since the peerConnection had failed. That would block future subscriptions to that stream since it was never removed and was marked as `failed`.
Now, if the connection (stream) has failed, the unsubscribe will take place.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.