### PR TITLE
update muteVideo and muteAudio for publishers when there are no subscribers

### DIFF
--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -300,9 +300,9 @@ class Source extends NodeClass {
     if (clientId && this.hasSubscriber(clientId)) {
       this.muteSubscriberStream(clientId, muteStreamInfo.video, muteStreamInfo.audio);
     } else {
+      this.muteVideo = muteStreamInfo.video;
+      this.muteAudio = muteStreamInfo.audio;
       this.forEachSubscriber((id, subscriber) => {
-        this.muteVideo = muteStreamInfo.video;
-        this.muteAudio = muteStreamInfo.audio;
         this.muteSubscriberStream(id, subscriber.muteVideo, subscriber.muteAudio);
       });
     }
@@ -333,7 +333,7 @@ class Source extends NodeClass {
     const subscriber = this.getSubscriber(clientId);
     subscriber.muteVideo = muteVideo;
     subscriber.muteAudio = muteAudio;
-    log.info('message: Mute Stream, video: ', this.muteVideo || muteVideo,
+    log.info('message: Mute Subscriber Stream, video: ', this.muteVideo || muteVideo,
                                  ', audio: ', this.muteAudio || muteAudio);
     subscriber.mediaStream.muteStream(this.muteVideo || muteVideo,
                           this.muteAudio || muteAudio);


### PR DESCRIPTION
subscribers

<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

`muteVideo` and `muteAudio` in the `Publisher` were not being updated if no subscribers are present. This caused publishers to remain in the same state even after a mute/unmute request

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.