### PR TITLE
BWE Fixes for publisher estimation in chrome >72

### DIFF
--- a/erizo/src/erizo/rtp/QualityFilterHandler.cpp
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.cpp
@@ -36,13 +36,16 @@ void QualityFilterHandler::handleFeedbackPackets(const std::shared_ptr<DataPacke
            chead->getBlockCount() == RTCP_FIR_FMT)) {
       sendPLI();
     }
-  });
+    });
 }
 
 void QualityFilterHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet) {
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
-  if (chead->isFeedback() && enabled_ && is_scalable_) {
+  if (chead->isFeedback() && enabled_) {
     handleFeedbackPackets(packet);
+    if (!is_scalable_ && chead->isREMB()) {
+      ctx->fireRead(std::move(packet));
+    }
     return;
   }
 

--- a/erizo/src/erizo/rtp/QualityFilterHandler.cpp
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.cpp
@@ -41,6 +41,8 @@ void QualityFilterHandler::handleFeedbackPackets(const std::shared_ptr<DataPacke
 
 void QualityFilterHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet) {
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
+  // TODO(pedro): This logic drops feedback also for non-simulcast streams.
+  // For clarity, we should consider using a new handler for that.
   if (chead->isFeedback() && enabled_) {
     handleFeedbackPackets(packet);
     if (!is_scalable_ && chead->isREMB()) {

--- a/erizo/src/erizo/rtp/RtcpRrGenerator.cpp
+++ b/erizo/src/erizo/rtp/RtcpRrGenerator.cpp
@@ -98,7 +98,7 @@ std::shared_ptr<DataPacket> RtcpRrGenerator::generateReceiverReport() {
     0 : (now - rr_info_.last_sr_ts) * 65536 / 1000;
   uint32_t expected = rr_info_.extended_seq - rr_info_.base_seq + 1;
   // TODO(pedro): This is the previous way to calculate packet loss
-  // it accounts for packets recovered with retransmissions and 
+  // it accounts for packets recovered with retransmissions and
   // Chrome does not seem to like that
   /* if (expected < rr_info_.packets_received) { */
   /*   rr_info_.lost = 0; */

--- a/erizo/src/erizo/rtp/RtcpRrGenerator.cpp
+++ b/erizo/src/erizo/rtp/RtcpRrGenerator.cpp
@@ -97,11 +97,14 @@ std::shared_ptr<DataPacket> RtcpRrGenerator::generateReceiverReport() {
   uint64_t delay_since_last_sr = rr_info_.last_sr_ts == 0 ?
     0 : (now - rr_info_.last_sr_ts) * 65536 / 1000;
   uint32_t expected = rr_info_.extended_seq - rr_info_.base_seq + 1;
-  if (expected < rr_info_.packets_received) {
-    rr_info_.lost = 0;
-  } else {
-    rr_info_.lost = expected - rr_info_.packets_received;
-  }
+  // TODO(pedro): This is the previous way to calculate packet loss
+  // it accounts for packets recovered with retransmissions and 
+  // Chrome does not seem to like that
+  /* if (expected < rr_info_.packets_received) { */
+  /*   rr_info_.lost = 0; */
+  /* } else { */
+  /*   rr_info_.lost = expected - rr_info_.packets_received; */
+  /* } */
 
 
   uint8_t fraction = 0;
@@ -113,6 +116,12 @@ std::shared_ptr<DataPacket> RtcpRrGenerator::generateReceiverReport() {
   int64_t lost_interval = static_cast<int64_t>(expected_interval) - received_interval;
   if (expected_interval != 0 && lost_interval > 0) {
     fraction = (static_cast<uint32_t>(lost_interval) << 8) / expected_interval;
+  }
+
+  // TODO(pedro): We're getting closer to packet loss without retransmissions by ignoring negative
+  // lost in the interval. This is not perfect but will provide a more "monotonically increasing" behavior
+  if (lost_interval > 0) {
+    rr_info_.lost += lost_interval;
   }
 
   rr_info_.frac_lost = fraction;

--- a/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
@@ -161,7 +161,7 @@ void SenderBandwidthEstimationHandler::analyzeSr(RtcpHeader* chead) {
   uint64_t now = ClockUtils::timePointToMs(clock_->now());
   uint32_t ntp;
   ntp = chead->get32MiddleNtp();
-  ELOG_WARN("%s message: adding incoming SR to list, ntp: %u", stream_->toLog(), ntp);
+  ELOG_DEBUG("%s message: adding incoming SR to list, ntp: %u", stream_->toLog(), ntp);
   sr_delay_data_.push_back(std::shared_ptr<SrDelayData>( new SrDelayData(ntp, now)));
   if (sr_delay_data_.size() >= kMaxSrListSize) {
     sr_delay_data_.pop_front();

--- a/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
@@ -117,12 +117,12 @@ void SenderBandwidthEstimationHandler::read(Context *ctx, std::shared_ptr<DataPa
               if (!strncmp(uniqueId, "REMB", 4)) {
                 received_remb_ = true;
                 int64_t now_ms = ClockUtils::timePointToMs(clock_->now());
-                uint64_t bitrate = chead->getBrMantis() << chead->getBrExp();
+                uint64_t remb_bitrate =  chead->getBrMantis() << chead->getBrExp();
+                uint64_t bitrate = estimated_bitrate_ !=0 ? estimated_bitrate_ : remb_bitrate;
                 uint64_t cappedBitrate = bitrate < processor_->getMaxVideoBW() ? bitrate : processor_->getMaxVideoBW();
                 chead->setREMBBitRate(cappedBitrate);
-
-                ELOG_DEBUG("%s message: Updating Estimate with REMB, bitrate %lu", stream_->toLog(),
-                    cappedBitrate);
+                ELOG_DEBUG("%s message: Updating estimate REMB, bitrate: %lu, estimated_bitrate %lu, remb_bitrate %lu",
+                    stream_->toLog(), cappedBitrate, estimated_bitrate_, remb_bitrate);
                 sender_bwe_->UpdateReceiverEstimate(now_ms, cappedBitrate);
                 updateEstimate();
               } else {

--- a/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
@@ -123,7 +123,7 @@ void SenderBandwidthEstimationHandler::read(Context *ctx, std::shared_ptr<DataPa
                 chead->setREMBBitRate(cappedBitrate);
                 ELOG_DEBUG("%s message: Updating estimate REMB, bitrate: %lu, estimated_bitrate %lu, remb_bitrate %lu",
                     stream_->toLog(), cappedBitrate, estimated_bitrate_, remb_bitrate);
-                sender_bwe_->UpdateReceiverEstimate(now_ms, cappedBitrate);
+                sender_bwe_->UpdateReceiverEstimate(now_ms, remb_bitrate);
                 updateEstimate();
               } else {
                 ELOG_DEBUG("%s message: Unsupported AFB Packet not REMB", stream_->toLog());
@@ -161,7 +161,7 @@ void SenderBandwidthEstimationHandler::analyzeSr(RtcpHeader* chead) {
   uint64_t now = ClockUtils::timePointToMs(clock_->now());
   uint32_t ntp;
   ntp = chead->get32MiddleNtp();
-  ELOG_DEBUG("%s message: adding incoming SR to list, ntp: %u", stream_->toLog(), ntp);
+  ELOG_WARN("%s message: adding incoming SR to list, ntp: %u", stream_->toLog(), ntp);
   sr_delay_data_.push_back(std::shared_ptr<SrDelayData>( new SrDelayData(ntp, now)));
   if (sr_delay_data_.size() >= kMaxSrListSize) {
     sr_delay_data_.pop_front();


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

Another possible solution for the bandwidth estimation problems when not using simulcast in Chrome >72.
This PR drops all other RR packets from subscribers and relies on the sender estimation implementation in licode to update REMB from subscribers.

Also, this PR updated RR packets generated in Licode so the packets lost are monotonically increasing. There are different ways to do this but, at this time, we chose to use the packet loss ratio when it's > 0.

If tests are positive, in the future, we will work on separating the logic that decides what RR packets to forward in a new handler.
[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.