### PR TITLE
Implement customizing bitrate layer for simulcast

### DIFF
--- a/doc/client_api.md
+++ b/doc/client_api.md
@@ -429,6 +429,14 @@ room.publish(localStream, {simulcast: {numSpatialLayers: 2}});
 
 Being `numSpatialLayers` the max number of spatial layers the publisher will send.
 
+You can also limit the bitrate for each layer:
+
+```
+room.publish(localStream, {simulcast: {numSpatialLayers: 2, spatialLayerBitrates: {0: 80000, 1: 430000}}});
+```
+
+In that example we are configuring 2 spatial layers, limiting the lower layer to 80 Kbps and the higher to 430 Kbps.
+
 **Note:** Simulcast only works with Google Chrome and it's not compatible with Licode's recording yet.
 
 ## Subscribe to a remote stream

--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -167,6 +167,11 @@ void QualityManager::selectLayer(bool try_higher_layers) {
     aux_temporal_layer = 0;
     aux_spatial_layer++;
   }
+  // TODO(pedro): implement activating fallback as an option
+  // currently it's always disabled
+  if (!enable_slideshow_below_spatial_layer_) {
+    below_min_layer = false;
+  }
 
   ELOG_DEBUG("message: below_min_layer %u, freeze_fallback_active_: %u", below_min_layer, freeze_fallback_active_);
   if (below_min_layer != freeze_fallback_active_) {

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -189,6 +189,7 @@ const BaseStack = (specInput) => {
 
     remoteDesc = msg;
     that.peerConnection.setLocalDescription(localDesc).then(() => {
+      that.setSimulcastLayersBitrate();
       that.peerConnection.setRemoteDescription(new RTCSessionDescription(msg)).then(() => {
         specBase.remoteDescriptionSet = true;
         Logger.info('Candidates to be added: ', specBase.remoteCandidates.length,
@@ -252,6 +253,10 @@ const BaseStack = (specInput) => {
   that.enableSimulcast = (sdpInput) => {
     Logger.error('Simulcast not implemented');
     return sdpInput;
+  };
+
+  that.setSimulcastLayerBitrate = () => {
+    Logger.error('Simulcast not implemented');
   };
 
   that.close = () => {

--- a/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
@@ -68,6 +68,10 @@ const ChromeStableStack = (specInput) => {
   };
 
   const setBitrateForVideoLayers = (sender) => {
+    if (typeof sender.getParameters !== 'function' || typeof sender.setParameters !== 'function') {
+      Logger.warning('Cannot set simulcast layers bitrate: getParameters or setParameters is not available');
+      return;
+    }
     const parameters = sender.getParameters();
     Object.keys(that.simulcast.spatialLayerBitrates).forEach((key) => {
       if (parameters.encodings[key] !== undefined) {

--- a/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
@@ -67,6 +67,34 @@ const ChromeStableStack = (specInput) => {
     return sdp.replace(matchGroup[0], result);
   };
 
+  const setBitrateForVideoLayers = (sender) => {
+    const parameters = sender.getParameters();
+    Object.keys(that.simulcast.spatialLayerBitrates).forEach((key) => {
+      if (parameters.encodings[key] !== undefined) {
+        Logger.debug(`Setting bitrate for layer ${key}, bps: ${that.simulcast.spatialLayerBitrates[key]}`);
+        parameters.encodings[key].maxBitrate = that.simulcast.spatialLayerBitrates[key];
+      }
+    });
+    sender.setParameters(parameters)
+      .then((result) => {
+        Logger.debug('Success setting simulcast layer bitrates', result);
+      })
+      .catch((e) => {
+        Logger.warning('Error setting simulcast layer bitrates', e);
+      });
+  };
+
+  that.setSimulcastLayersBitrate = () => {
+    Logger.debug('Maybe set simulcast Layers bitrate', that.simulcast);
+    if (that.simulcast && that.simulcast.spatialLayerBitrates) {
+      that.peerConnection.getSenders().forEach((sender) => {
+        if (sender.track.kind === 'video') {
+          setBitrateForVideoLayers(sender);
+        }
+      });
+    }
+  };
+
   that.setStartVideoBW = (sdpInfo) => {
     if (that.video && spec.startVideoBW) {
       Logger.debug(`startVideoBW requested: ${spec.startVideoBW}`);


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
This PR adds a new option for the simulcast API. You can now set spatial layer bitrate limits in simulcast.

This PR also removes the 'fallback' we put in place for simulcast since it no longer works as expected. This fallback mechanism was used to keep receiving video data (and padding) to help the estimate recover when under the lowest simulcast layer. The recommended solution for now is to lower the bitrate of the lowest layer.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

New parameter for simulcast configuration detailing the layers and the requested bitrate in bps.

- [x] It includes documentation for these changes in `/doc`.