### PR TITLE
Set MaxVideoBW in ErizoJS when starting pub

### DIFF
--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -407,6 +407,10 @@ class Publisher extends Source {
     this.ready = false;
     this.connectionReady = connection.ready;
 
+    if (options.maxVideoBW) {
+      this.mediaStream.setMaxVideoBW(options.maxVideoBW);
+    }
+
     this.mediaStream.setAudioReceiver(this.muxer);
     this.mediaStream.setVideoReceiver(this.muxer);
     this.muxer.setPublisher(this.mediaStream);


### PR DESCRIPTION
**Description**

We were not setting the maxVideoBW configuration when publishing in ErizoJS.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.