### PR TITLE
Fix the way we detect layers in VP9 parser

### DIFF
--- a/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
+++ b/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
@@ -137,6 +137,10 @@ void LayerDetectorHandler::parseLayerInfoFromVP9(std::shared_ptr<DataPacket> pac
   RTPPayloadVP9* payload = vp9_parser_.parseVP9(
       start_buffer, packet->length - rtp_header->getHeaderLength());
 
+  if (payload->hasPictureID) {
+    packet->picture_id = payload->pictureID;
+  }
+
   int spatial_layer = payload->spatialID;
 
   packet->compatible_spatial_layers = {};
@@ -163,9 +167,11 @@ void LayerDetectorHandler::parseLayerInfoFromVP9(std::shared_ptr<DataPacket> pac
   bool resolution_changed = false;
   if (payload->resolutions.size() > 0) {
     for (uint position = 0; position < payload->resolutions.size(); position++) {
-      resolution_changed = true;
-      video_frame_width_list_[position] = payload->resolutions[position].width;
-      video_frame_height_list_[position] = payload->resolutions[position].height;
+      if (video_frame_width_list_[position] != payload->resolutions[position].width) {
+        resolution_changed = true;
+        video_frame_width_list_[position] = payload->resolutions[position].width;
+        video_frame_height_list_[position] = payload->resolutions[position].height;
+      }
     }
   }
   if (resolution_changed) {

--- a/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
+++ b/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
@@ -167,11 +167,9 @@ void LayerDetectorHandler::parseLayerInfoFromVP9(std::shared_ptr<DataPacket> pac
   bool resolution_changed = false;
   if (payload->resolutions.size() > 0) {
     for (uint position = 0; position < payload->resolutions.size(); position++) {
-      if (video_frame_width_list_[position] != payload->resolutions[position].width) {
-        resolution_changed = true;
-        video_frame_width_list_[position] = payload->resolutions[position].width;
-        video_frame_height_list_[position] = payload->resolutions[position].height;
-      }
+      resolution_changed = true;
+      video_frame_width_list_[position] = payload->resolutions[position].width;
+      video_frame_height_list_[position] = payload->resolutions[position].height;
     }
   }
   if (resolution_changed) {

--- a/erizo/src/erizo/rtp/RtpVP9Parser.cpp
+++ b/erizo/src/erizo/rtp/RtpVP9Parser.cpp
@@ -97,6 +97,8 @@ RTPPayloadVP9* RtpVP9Parser::parseVP9(unsigned char* data, int dataLength) {
     dataPtr++;
     len--;
   }
+  vp9->temporalID = 0;
+  vp9->spatialID = 0;
 
   if (vp9->hasLayerIndices) {
     vp9->temporalID = (*dataPtr & 0xE0) >> 5;  // T bits


### PR DESCRIPTION
**Description**

We were not setting pictureId and right TIDs and SIDs in VP9. There is still some work to do to fix SVC, but it is not a priority since it is not enabled by default in Chrome (we still need a magic argument).

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.