### PR TITLE
Add Black keyframes in mute video

### DIFF
--- a/erizo/src/erizo/rtp/FakeKeyframeGeneratorHandler.cpp
+++ b/erizo/src/erizo/rtp/FakeKeyframeGeneratorHandler.cpp
@@ -71,6 +71,7 @@ std::shared_ptr<DataPacket> FakeKeyframeGeneratorHandler::transformIntoKeyframeP
   (std::shared_ptr<DataPacket> packet) {
     if (packet->codec == "VP8") {
       auto keyframe_packet = RtpUtils::makeVP8BlackKeyframePacket(packet);
+      packet->is_keyframe = true;
       return keyframe_packet;
     } else {
       ELOG_DEBUG("Generate keyframe packet is not available for codec %s", packet->codec);

--- a/erizo/src/erizo/rtp/RtpTrackMuteHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpTrackMuteHandler.cpp
@@ -93,6 +93,7 @@ void RtpTrackMuteHandler::handlePacket(Context *ctx, TrackMuteInfo *info, std::s
     } else {
       ELOG_WARN("%s Letting keyframe through", stream_->toLog());
       packet = transformIntoBlackKeyframePacket(packet);
+      updateOffset(info);
     }
   }
   uint16_t offset = info->seq_num_offset;
@@ -100,7 +101,6 @@ void RtpTrackMuteHandler::handlePacket(Context *ctx, TrackMuteInfo *info, std::s
   if (offset > 0) {
     setPacketSeqNumber(packet, info->last_sent_seq_num);
   }
-  updateOffset(info);
   ctx->fireWrite(std::move(packet));
 }
 

--- a/erizo/src/erizo/rtp/RtpTrackMuteHandler.h
+++ b/erizo/src/erizo/rtp/RtpTrackMuteHandler.h
@@ -14,12 +14,13 @@ class TrackMuteInfo {
  public:
   explicit TrackMuteInfo(std::string label_)
     : label{label_}, last_original_seq_num{-1}, seq_num_offset{0},
-      last_sent_seq_num{-1}, mute_is_active{false} {}
+      last_sent_seq_num{-1}, mute_is_active{false}, unmute_requested{false} {}
   std::string label;
   int32_t last_original_seq_num;
   uint16_t seq_num_offset;
   int32_t last_sent_seq_num;
   bool mute_is_active;
+  bool unmute_requested;
 };
 
 class RtpTrackMuteHandler: public Handler {

--- a/erizo/src/erizo/rtp/RtpTrackMuteHandler.h
+++ b/erizo/src/erizo/rtp/RtpTrackMuteHandler.h
@@ -14,11 +14,11 @@ class TrackMuteInfo {
  public:
   explicit TrackMuteInfo(std::string label_)
     : label{label_}, last_original_seq_num{-1}, seq_num_offset{0},
-      last_sent_seq_num{0}, mute_is_active{false} {}
+      last_sent_seq_num{-1}, mute_is_active{false} {}
   std::string label;
   int32_t last_original_seq_num;
   uint16_t seq_num_offset;
-  uint16_t last_sent_seq_num;
+  int32_t last_sent_seq_num;
   bool mute_is_active;
 };
 
@@ -46,6 +46,8 @@ class RtpTrackMuteHandler: public Handler {
   void handleFeedback(const TrackMuteInfo &info, const std::shared_ptr<DataPacket> &packet);
   void handlePacket(Context *ctx, TrackMuteInfo *info, std::shared_ptr<DataPacket> packet);
   inline void setPacketSeqNumber(std::shared_ptr<DataPacket> packet, uint16_t seq_number);
+  std::shared_ptr<DataPacket> transformIntoBlackKeyframePacket(std::shared_ptr<DataPacket> packet);
+  void updateOffset(TrackMuteInfo *info);
 
  private:
   TrackMuteInfo audio_info_;

--- a/erizo/src/erizo/rtp/RtpTrackMuteHandler.h
+++ b/erizo/src/erizo/rtp/RtpTrackMuteHandler.h
@@ -47,7 +47,7 @@ class RtpTrackMuteHandler: public Handler {
   void handleFeedback(const TrackMuteInfo &info, const std::shared_ptr<DataPacket> &packet);
   void handlePacket(Context *ctx, TrackMuteInfo *info, std::shared_ptr<DataPacket> packet);
   inline void setPacketSeqNumber(std::shared_ptr<DataPacket> packet, uint16_t seq_number);
-  std::shared_ptr<DataPacket> transformIntoBlackKeyframePacket(std::shared_ptr<DataPacket> packet);
+  bool maybeTransformIntoBlackKeyframePacket(std::shared_ptr<DataPacket> packet);
   void updateOffset(TrackMuteInfo *info);
 
  private:

--- a/erizo/src/erizo/rtp/RtpTrackMuteHandler.h
+++ b/erizo/src/erizo/rtp/RtpTrackMuteHandler.h
@@ -47,7 +47,7 @@ class RtpTrackMuteHandler: public Handler {
   void handleFeedback(const TrackMuteInfo &info, const std::shared_ptr<DataPacket> &packet);
   void handlePacket(Context *ctx, TrackMuteInfo *info, std::shared_ptr<DataPacket> packet);
   inline void setPacketSeqNumber(std::shared_ptr<DataPacket> packet, uint16_t seq_number);
-  bool maybeTransformIntoBlackKeyframePacket(std::shared_ptr<DataPacket> packet);
+  std::shared_ptr<DataPacket> transformIntoBlackKeyframePacket(std::shared_ptr<DataPacket> packet);
   void updateOffset(TrackMuteInfo *info);
 
  private:

--- a/erizo/src/test/rtp/RtpTrackMuteHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpTrackMuteHandlerTest.cpp
@@ -102,11 +102,11 @@ TEST_F(RtpTrackMuteHandlerTest, shouldNotWriteAnyPacketsIfAllIsActive) {
 }
 
 TEST_F(RtpTrackMuteHandlerTest, shouldSendPLIsWhenVideoIsActivated) {
-    track_mute_handler->muteVideo(false);
+    track_mute_handler->muteVideo(true);
 
     EXPECT_CALL(*reader.get(), read(_, _)).With(Args<1>(erizo::IsPLI())).Times(1);
 
-    track_mute_handler->muteVideo(true);
+    track_mute_handler->muteVideo(false);
 }
 
 TEST_F(RtpTrackMuteHandlerTest, shouldAdjustSequenceNumbers) {


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR solves a race condition when muting video before receiving any keyframes. To solve this, this PR implements transforming all keyframes into black keyframes when muted (and using VP8).
Also, to solve possible problems when unmuting a video, it will wait until a keyframe comes to start forwarding video again.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.