### PR TITLE
Add origin info to streamEvent failed

### DIFF
--- a/doc/client_api.md
+++ b/doc/client_api.md
@@ -676,7 +676,7 @@ room.startRecording(localStream, function(recordingId, error) {
   } else {
     console.log("Recording started, the id of the recording is ", recordingId);
   }
-});   
+});
 ```
 
 ## Stop Recording
@@ -809,6 +809,8 @@ It represents an event related to a stream.
 You can access the related stream by `streamEvent.stream`.
 
 Some of them have a more detailed message in `streamEvent.msg`.
+
+For `stream-failed` events there is another field `streamEvent.origin` to give us more info about the reason of the failure.
 
 There are the different types of Stream events:
 

--- a/erizo_controller/erizoClient/src/Events.js
+++ b/erizo_controller/erizoClient/src/Events.js
@@ -158,6 +158,7 @@ const StreamEvent = (spec) => {
   that.stream = spec.stream;
 
   that.msg = spec.msg;
+  that.origin = spec.origin;
   that.bandwidth = spec.bandwidth;
   that.attrs = spec.attrs;
 

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -106,7 +106,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     }
   };
 
-  const onStreamFailed = (streamInput, message) => {
+  const onStreamFailed = (streamInput, message, origin = 'unknown') => {
     const stream = streamInput;
     if (that.state !== DISCONNECTED && stream && !stream.failed) {
       stream.failed = true;
@@ -114,7 +114,8 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       const streamFailedEvt = StreamEvent(
         { type: 'stream-failed',
           msg: message || 'Stream failed after connection',
-          stream });
+          stream,
+          origin });
       that.dispatchEvent(streamFailedEvt);
       const connection = stream.pc;
 
@@ -163,7 +164,8 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     stream.on('icestatechanged', (evt) => {
       Logger.info(`${stream.getID()} - iceConnectionState: ${evt.msg.state}`);
       if (evt.msg.state === 'failed') {
-        onStreamFailed(stream);
+        const message = 'ICE Connection Failed';
+        onStreamFailed(stream, message, 'ice-client');
       }
     });
   };
@@ -255,7 +257,8 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     stream.on('icestatechanged', (evt) => {
       Logger.info(`${stream.getID()} - iceConnectionState: ${evt.msg.state}`);
       if (evt.msg.state === 'failed') {
-        onStreamFailed(stream);
+        const message = 'ICE Connection Failed';
+        onStreamFailed(stream, message, 'ice-client');
         if (spec.singlePC) {
           connectionOpts.callback({ type: 'failed' });
         }
@@ -273,7 +276,8 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     stream.on('icestatechanged', (evt) => {
       Logger.info(`${stream.getID()} - iceConnectionState: ${evt.msg.state}`);
       if (evt.msg.state === 'failed') {
-        onStreamFailed(stream);
+        const message = 'ICE Connection Failed';
+        onStreamFailed(stream, message, 'ice-client');
         if (spec.singlePC) {
           connectionOpts.callback({ type: 'failed' });
         }
@@ -432,7 +436,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   const socketOnRemoveStream = (arg) => {
     let stream = localStreams.get(arg.id);
     if (stream) {
-      onStreamFailed(stream);
+      onStreamFailed(stream, 'Stream removed from server', 'server');
       return;
     }
     stream = remoteStreams.get(arg.id);
@@ -467,7 +471,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     } else {
       stream = remoteStreams.get(arg.streamId);
     }
-    onStreamFailed(stream, message);
+    onStreamFailed(stream, message, 'ice-server');
   };
 
   const socketOnError = (e) => {


### PR DESCRIPTION
**Description**

Add more info to the stream-failed event to know exactly the origin of the failure.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.