### PR TITLE
Fixed race conditions with promises when closing Nodes

### DIFF
--- a/erizoAPI/MediaStream.cc
+++ b/erizoAPI/MediaStream.cc
@@ -56,7 +56,7 @@ MediaStream::MediaStream() : closed_{false}, id_{"undefined"} {
   future_async_ = new uv_async_t;
   uv_async_init(uv_default_loop(), async_stats_, &MediaStream::statsCallback);
   uv_async_init(uv_default_loop(), async_event_, &MediaStream::eventCallback);
-  uv_async_init(uv_default_loop(), future_async_, &MediaStream::promiseResolver);
+  uv_async_init(uv_default_loop(), future_async_, &MediaStream::closePromiseResolver);
 }
 
 MediaStream::~MediaStream() {
@@ -77,6 +77,9 @@ void MediaStream::closeEvents() {
     uv_close(reinterpret_cast<uv_handle_t*>(async_event_), destroyAsyncHandle);
   }
   async_event_ = nullptr;
+}
+
+void MediaStream::closeFutureAsync() {
   if (!uv_is_closing(reinterpret_cast<uv_handle_t*>(future_async_))) {
     ELOG_DEBUG("%s, message: Closing future handle", toLog());
     uv_close(reinterpret_cast<uv_handle_t*>(future_async_), destroyAsyncHandle);
@@ -188,14 +191,12 @@ NAN_METHOD(MediaStream::close) {
   MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
   v8::Local<v8::Promise::Resolver> resolver = v8::Promise::Resolver::New(info.GetIsolate());
   Nan::Persistent<v8::Promise::Resolver> *persistent = new Nan::Persistent<v8::Promise::Resolver>(resolver);
-  if (obj) {
-    obj->Ref();
-    obj->close().then(
+  obj->Ref();
+  obj->close().then(
       [persistent, obj] (boost::future<void>) {
-        ELOG_DEBUG("%s, Close is finishied, resolving promise", obj->toLog());
+        ELOG_DEBUG("%s, MediaStream Close is finishied, resolving promise", obj->toLog());
         obj->notifyFuture(persistent);
       });
-  }
   info.GetReturnValue().Set(resolver->GetPromise());
 }
 
@@ -506,15 +507,16 @@ void MediaStream::notifyFuture(Nan::Persistent<v8::Promise::Resolver> *persisten
   uv_async_send(future_async_);
 }
 
-NAUV_WORK_CB(MediaStream::promiseResolver) {
+NAUV_WORK_CB(MediaStream::closePromiseResolver) {
   Nan::HandleScope scope;
   MediaStream* obj = reinterpret_cast<MediaStream*>(async->data);
-  if (!obj || !obj->me) {
+  if (!obj) {
     return;
   }
   boost::mutex::scoped_lock lock(obj->mutex);
-  ELOG_DEBUG("%s, message: promiseResolver", obj->toLog());
+  ELOG_DEBUG("%s, message: closePromiseResolver", obj->toLog());
   obj->futures_manager_.cleanResolvedFutures();
+  obj->Ref();
   while (!obj->futures.empty()) {
     auto persistent = obj->futures.front();
     v8::Local<v8::Promise::Resolver> resolver = Nan::New(*persistent);
@@ -522,5 +524,7 @@ NAUV_WORK_CB(MediaStream::promiseResolver) {
     obj->futures.pop();
     obj->Unref();
   }
-  ELOG_DEBUG("%s, message: promiseResolver finished", obj->toLog());
+  obj->closeFutureAsync();
+  obj->Unref();
+  ELOG_DEBUG("%s, message: closePromiseResolver finished", obj->toLog());
 }

--- a/erizoAPI/MediaStream.h
+++ b/erizoAPI/MediaStream.h
@@ -61,7 +61,7 @@ class MediaStream : public MediaSink, public erizo::MediaStreamStatsListener, pu
     Nan::Callback *stats_callback_;
     uv_async_t *async_stats_;
 
-    uv_async_t *future_async_;
+    uv_async_t *close_future_async_;
     bool has_stats_callback_;
     bool closed_;
     std::string id_;

--- a/erizoAPI/MediaStream.h
+++ b/erizoAPI/MediaStream.h
@@ -51,6 +51,7 @@ class MediaStream : public MediaSink, public erizo::MediaStreamStatsListener, pu
 
     boost::future<void> close();
     void closeEvents();
+    void closeFutureAsync();
     std::string toLog();
 
     Nan::Callback *event_callback_;
@@ -171,7 +172,7 @@ class MediaStream : public MediaSink, public erizo::MediaStreamStatsListener, pu
     static NAUV_WORK_CB(eventCallback);
     virtual void notifyMediaStreamEvent(const std::string& type = "",
         const std::string& message = "");
-    static NAUV_WORK_CB(promiseResolver);
+    static NAUV_WORK_CB(closePromiseResolver);
     virtual void notifyFuture(Nan::Persistent<v8::Promise::Resolver> *persistent);
 };
 

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -100,18 +100,18 @@ exports.ErizoJSController = (threadPool, ioThreadPool) => {
 
     const closePromise = node.close(sendOffer);
 
-    const client = clients.get(clientId);
-    if (client === undefined) {
-      log.debug('message: trying to close node with no associated client,' +
-        `clientId: ${clientId}, streamId: ${node.streamId}`);
-      return Promise.resolve();
-    }
-
-    const remainingConnections = client.maybeCloseConnection(connection.id);
-    if (remainingConnections === 0) {
-      log.debug(`message: Client is empty, clientId: ${client.id}`);
-    }
-    return closePromise;
+    return closePromise.then(() => {
+      const client = clients.get(clientId);
+      if (client === undefined) {
+        log.debug('message: trying to close node with no associated client,' +
+          `clientId: ${clientId}, streamId: ${node.streamId}`);
+        return;
+      }
+      const remainingConnections = client.maybeCloseConnection(connection.id);
+      if (remainingConnections === 0) {
+        log.debug(`message: Client is empty, clientId: ${client.id}`);
+      }
+    });
   };
 
   // RemoveClient does not imply deleting the data structures of publishers and subscribers

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -537,15 +537,17 @@ exports.ErizoJSController = (threadPool, ioThreadPool) => {
   that.removeSubscriptions = (clientId) => {
     log.info('message: removing subscriptions, clientId:', clientId);
     // we go through all the connections in the client and we close them
+    const closePromises = [];
     forEachPublisher((publisherId, publisher) => {
       const subscriber = publisher.getSubscriber(clientId);
       if (subscriber) {
         log.debug('message: removing subscription, ' +
           'id:', subscriber.clientId);
-        closeNode(subscriber);
+        closePromises.push(closeNode(subscriber));
         publisher.removeSubscriber(clientId);
       }
     });
+    return Promise.all(closePromises);
   };
 
   that.getStreamStats = (streamId, callbackRpc) => {

--- a/erizo_controller/test/erizoJS/erizoJSController.js
+++ b/erizo_controller/test/erizoJS/erizoJSController.js
@@ -655,10 +655,10 @@ describe('Erizo JS Controller', () => {
         });
 
         it('should remove subscriber only with its id', () => {
-          controller.removeSubscriptions(kArbitrarySubClientId);
-
-          expect(mocks.WebRtcConnection.close.callCount).to.equal(1);
-          expect(mocks.OneToManyProcessor.removeSubscriber.callCount).to.equal(1);
+          controller.removeSubscriptions(kArbitrarySubClientId).then(() => {
+            expect(mocks.WebRtcConnection.close.callCount).to.equal(1);
+            expect(mocks.OneToManyProcessor.removeSubscriber.callCount).to.equal(1);
+          });
         });
       });
     });


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR fixes two problems with `closeNode`:
1 - MediaStream close promise was not resolved because the `future_async_` was closed as part of the process, now the async will be closed after it notifies the completion of the task
2 - When WebRTCConnection is closed as part of closeNode because we're closing the last mediaStream in that connection, we would not resolve the `removeStream` promise. Now we make sure the stream is removed and the promise resolved before checking if we should close the connection

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.