### PR TITLE
Wait for mediaStreams to be closed before removing them from the list in ErizoJS

### DIFF
--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -337,14 +337,17 @@ class Connection extends events.EventEmitter {
     log.info(`message: Closing connection ${this.id}`);
     log.info(`message: WebRtcConnection status update, id: ${this.id}, status: ${CONN_FINISHED}, ` +
             `${logger.objectToLog(this.metadata)}`);
+    const promises = [];
     this.mediaStreams.forEach((mediaStream, id) => {
       log.debug(`message: Closing mediaStream, connectionId : ${this.id}, ` +
         `mediaStreamId: ${id}`);
-      mediaStream.close();
+      promises.push(mediaStream.close());
     });
-    this.wrtc.close();
-    this.mediaStreams.clear();
-    delete this.wrtc;
+    Promise.all(promises).then(() => {
+      this.wrtc.close();
+      this.mediaStreams.clear();
+      delete this.wrtc;
+    });
   }
 
 }


### PR DESCRIPTION
**Description**

We are seeing crashes because we are using destroyed OneToManyConnections. This PR aims to solve an obscure path that could lead to that scenario.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.