### PR TITLE
Make getLocalSdpInfo async

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -107,7 +107,8 @@ class WebRtcConnection: public TransportListener, public LogContext,
    * Obtains the local SDP.
    * @return The SDP as a SdpInfo.
    */
-  std::shared_ptr<SdpInfo> getLocalSdpInfo();
+  boost::future<std::shared_ptr<SdpInfo>> getLocalSdpInfo();
+  std::shared_ptr<SdpInfo> getLocalSdpInfoSync();
   /**
    * Copy some SdpInfo data to local SdpInfo
    */

--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -264,7 +264,7 @@ NAN_METHOD(WebRtcConnection::createOffer) {
   obj->Ref();
   me->createOffer(video_enabled, audio_enabled, bundle).then(
     [persistent, obj] (boost::future<void>) {
-      obj->notifyFuture(persistent, "");
+      obj->notifyFuture(persistent);
     });
 
   info.GetReturnValue().Set(resolver->GetPromise());
@@ -312,7 +312,7 @@ NAN_METHOD(WebRtcConnection::setRemoteSdp) {
   obj->Ref();
   me->setRemoteSdp(sdp).then(
     [persistent, obj] (boost::future<void>) {
-      obj->notifyFuture(persistent, "");
+      obj->notifyFuture(persistent);
     });
 
   info.GetReturnValue().Set(resolver->GetPromise());
@@ -336,7 +336,7 @@ NAN_METHOD(WebRtcConnection::setRemoteDescription) {
   obj->Ref();
   me->setRemoteSdpInfo(sdp).then(
     [persistent, obj] (boost::future<void>) {
-      obj->notifyFuture(persistent, "");
+      obj->notifyFuture(persistent);
     });
 
   info.GetReturnValue().Set(resolver->GetPromise());
@@ -435,7 +435,7 @@ NAN_METHOD(WebRtcConnection::addMediaStream) {
   obj->Ref();
   me->addMediaStream(ms).then(
     [persistent, obj] (boost::future<void>) {
-      obj->notifyFuture(persistent, "");
+      obj->notifyFuture(persistent);
     });
 
   info.GetReturnValue().Set(resolver->GetPromise());
@@ -456,7 +456,7 @@ NAN_METHOD(WebRtcConnection::removeMediaStream) {
   obj->Ref();
   me->removeMediaStream(stream_id).then(
     [persistent, obj] (boost::future<void>) {
-      obj->notifyFuture(persistent, "");
+      obj->notifyFuture(persistent);
     });
 
   info.GetReturnValue().Set(resolver->GetPromise());

--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -264,7 +264,7 @@ NAN_METHOD(WebRtcConnection::createOffer) {
   obj->Ref();
   me->createOffer(video_enabled, audio_enabled, bundle).then(
     [persistent, obj] (boost::future<void>) {
-      obj->notifyFuture(persistent);
+      obj->notifyFuture(persistent, "");
     });
 
   info.GetReturnValue().Set(resolver->GetPromise());
@@ -312,7 +312,7 @@ NAN_METHOD(WebRtcConnection::setRemoteSdp) {
   obj->Ref();
   me->setRemoteSdp(sdp).then(
     [persistent, obj] (boost::future<void>) {
-      obj->notifyFuture(persistent);
+      obj->notifyFuture(persistent, "");
     });
 
   info.GetReturnValue().Set(resolver->GetPromise());
@@ -336,7 +336,7 @@ NAN_METHOD(WebRtcConnection::setRemoteDescription) {
   obj->Ref();
   me->setRemoteSdpInfo(sdp).then(
     [persistent, obj] (boost::future<void>) {
-      obj->notifyFuture(persistent);
+      obj->notifyFuture(persistent, "");
     });
 
   info.GetReturnValue().Set(resolver->GetPromise());
@@ -348,13 +348,17 @@ NAN_METHOD(WebRtcConnection::getLocalDescription) {
   if (!me) {
     return;
   }
+  v8::Local<v8::Promise::Resolver> resolver = v8::Promise::Resolver::New(info.GetIsolate());
+  Nan::Persistent<v8::Promise::Resolver> *persistent = new Nan::Persistent<v8::Promise::Resolver>(resolver);
+  obj->Ref();
 
-  std::shared_ptr<erizo::SdpInfo> sdp_info = std::make_shared<erizo::SdpInfo>(*me->getLocalSdpInfo().get());
-
-  v8::Local<v8::Object> instance = ConnectionDescription::NewInstance();
-  ConnectionDescription* description = ObjectWrap::Unwrap<ConnectionDescription>(instance);
-  description->me = sdp_info;
-  info.GetReturnValue().Set(instance);
+  me->getLocalSdpInfo().then(
+      [persistent, obj] (boost::future<std::shared_ptr<erizo::SdpInfo>> fut) {
+        std::shared_ptr<erizo::SdpInfo> sdp_info = std::make_shared<erizo::SdpInfo>(*fut.get().get());
+        ResultVariant result = sdp_info;
+        obj->notifyFuture(persistent, result);
+        });
+  info.GetReturnValue().Set(resolver->GetPromise());
 }
 
 NAN_METHOD(WebRtcConnection::copySdpToLocalDescription) {
@@ -431,7 +435,7 @@ NAN_METHOD(WebRtcConnection::addMediaStream) {
   obj->Ref();
   me->addMediaStream(ms).then(
     [persistent, obj] (boost::future<void>) {
-      obj->notifyFuture(persistent);
+      obj->notifyFuture(persistent, "");
     });
 
   info.GetReturnValue().Set(resolver->GetPromise());
@@ -452,7 +456,7 @@ NAN_METHOD(WebRtcConnection::removeMediaStream) {
   obj->Ref();
   me->removeMediaStream(stream_id).then(
     [persistent, obj] (boost::future<void>) {
-      obj->notifyFuture(persistent);
+      obj->notifyFuture(persistent, "");
     });
 
   info.GetReturnValue().Set(resolver->GetPromise());
@@ -490,12 +494,13 @@ NAUV_WORK_CB(WebRtcConnection::eventsCallback) {
   ELOG_DEBUG("%s, message: eventsCallback finished", obj->toLog());
 }
 
-void WebRtcConnection::notifyFuture(Nan::Persistent<v8::Promise::Resolver> *persistent) {
+void WebRtcConnection::notifyFuture(Nan::Persistent<v8::Promise::Resolver> *persistent, ResultVariant result) {
   boost::mutex::scoped_lock lock(mutex);
   if (!future_async_) {
     return;
   }
-  futures.push(persistent);
+  ResultPair result_pair(persistent, result);
+  futures.push(result_pair);
   future_async_->data = this;
   uv_async_send(future_async_);
 }
@@ -510,9 +515,21 @@ NAUV_WORK_CB(WebRtcConnection::promiseResolver) {
   ELOG_DEBUG("%s, message: promiseResolver", obj->toLog());
   obj->futures_manager_.cleanResolvedFutures();
   while (!obj->futures.empty()) {
-    auto persistent = obj->futures.front();
+    auto persistent = obj->futures.front().first;
     v8::Local<v8::Promise::Resolver> resolver = Nan::New(*persistent);
-    resolver->Resolve(Nan::GetCurrentContext(), Nan::New("").ToLocalChecked());
+    ResultVariant r = obj->futures.front().second;
+    if (boost::get<std::string>(&r) != nullptr) {
+      resolver->Resolve(Nan::GetCurrentContext(), Nan::New(boost::get<std::string>(r).c_str()).ToLocalChecked());
+    } else if (boost::get<std::shared_ptr<erizo::SdpInfo>>(&r) != nullptr) {
+      std::shared_ptr<erizo::SdpInfo> sdp_info = boost::get<std::shared_ptr<erizo::SdpInfo>>(r);
+      v8::Local<v8::Object> instance = ConnectionDescription::NewInstance();
+      ConnectionDescription* description = ObjectWrap::Unwrap<ConnectionDescription>(instance);
+      description->me = sdp_info;
+      resolver->Resolve(Nan::GetCurrentContext(), instance);
+    } else {
+      ELOG_WARN("%s, message: Resolving promise with no valid value, using empty string", obj->toLog());
+      resolver->Resolve(Nan::GetCurrentContext(), Nan::New("").ToLocalChecked());
+    }
     obj->futures.pop();
     obj->Unref();
   }

--- a/erizoAPI/WebRtcConnection.h
+++ b/erizoAPI/WebRtcConnection.h
@@ -123,7 +123,7 @@ class WebRtcConnection : public erizo::WebRtcConnectionEventListener,
     virtual void notifyEvent(erizo::WebRTCEvent event,
                              const std::string& message = "");
     virtual void notifyFuture(Nan::Persistent<v8::Promise::Resolver> *persistent,
-        ResultVariant result);
+        ResultVariant result = ResultVariant());
 };
 
 #endif  // ERIZOAPI_WEBRTCCONNECTION_H_

--- a/erizoAPI/WebRtcConnection.h
+++ b/erizoAPI/WebRtcConnection.h
@@ -4,6 +4,7 @@
 #include <nan.h>
 #include <WebRtcConnection.h>
 #include <logger.h>
+#include <boost/variant.hpp>
 #include "FuturesManager.h"
 #include "MediaDefinitions.h"
 #include "OneToManyProcessor.h"
@@ -12,6 +13,9 @@
 #include <queue>
 #include <string>
 #include <future>  // NOLINT
+
+typedef boost::variant<std::string, std::shared_ptr<erizo::SdpInfo>> ResultVariant;
+typedef std::pair<Nan::Persistent<v8::Promise::Resolver> *, ResultVariant> ResultPair;
 
 /*
  * Wrapper class of erizo::WebRtcConnection
@@ -28,7 +32,7 @@ class WebRtcConnection : public erizo::WebRtcConnectionEventListener,
     std::shared_ptr<erizo::WebRtcConnection> me;
     std::queue<int> event_status;
     std::queue<std::string> event_messages;
-    std::queue<Nan::Persistent<v8::Promise::Resolver> *> futures;
+    std::queue<ResultPair> futures;
     FuturesManager futures_manager_;
 
     boost::mutex mutex;
@@ -118,7 +122,8 @@ class WebRtcConnection : public erizo::WebRtcConnectionEventListener,
 
     virtual void notifyEvent(erizo::WebRTCEvent event,
                              const std::string& message = "");
-    virtual void notifyFuture(Nan::Persistent<v8::Promise::Resolver> *persistent);
+    virtual void notifyFuture(Nan::Persistent<v8::Promise::Resolver> *persistent,
+        ResultVariant result);
 };
 
 #endif  // ERIZOAPI_WEBRTCCONNECTION_H_

--- a/erizo_controller/test/utils.js
+++ b/erizo_controller/test/utils.js
@@ -161,7 +161,8 @@ module.exports.reset = () => {
     createOffer: sinon.stub(),
     setRemoteSdp: sinon.stub(),
     setRemoteDescription: sinon.stub(),
-    getLocalDescription: sinon.stub().returns(module.exports.ConnectionDescription),
+    getLocalDescription: sinon.stub()
+    .returns(Promise.resolve(module.exports.ConnectionDescription)),
     addRemoteCandidate: sinon.stub(),
     addMediaStream: sinon.stub().returns(Promise.resolve()),
     removeMediaStream: sinon.stub(),


### PR DESCRIPTION
**Description**

This PR addresses race conditions when getting and handling SdpInfo by making it run as an `asyncTask` in erizo. This involves also implementing a mechanism to return values when promises are resolved from ErizoAPI.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.