### PR TITLE
Log the right message when media is rejected

### DIFF
--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -202,8 +202,8 @@ const Stream = (altConnectionHelpers, specInput) => {
             };
           });
         }, (error) => {
-          Logger.error(`Failed to get access to local media. Error code was ${
-                           error.code}.`);
+          Logger.error(`Failed to get access to local media. Error was ${
+                           error.name} with message ${error.message}.`);
           const streamEvent = StreamEvent({ type: 'access-denied', msg: error });
           that.dispatchEvent(streamEvent);
         });


### PR DESCRIPTION
**Description**

We were printing the wrong data when access to media was rejected in the browser.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.