### PR TITLE
Add a client API to update simulcast layer bitrate

### DIFF
--- a/doc/client_api.md
+++ b/doc/client_api.md
@@ -88,7 +88,8 @@ In the next table we can see the functions of this class:
 | [setAttributes()](#set-the-attributes-object)                                    | It sets new attributes to the local stream that are spread to the room. |
 | [getVideoFrame()](#set-the-attributes-object)                                    | It gets a Bitmap from the video.                                        |
 | [getVideoFrameURL()](#get-the-url-of-a-frame-from-the-video)                     | It gets the URL of a Bitmap from the video.                             |
-| [updateConfiguration(config, callback)](#get-the-url-of-a-frame-from-the-video)  | Updates the spec of a stream.                                           |
+| [updateConfiguration(config, callback)](#update-the-spec-of-a-stream)            | Updates the spec of a stream.                                           |
+| [updateSimulcastLayersBitrate(config)](#update-simulcast-layers-bitrate)         | Updates the bitrates for each simulcast layer.                          |
 
 ## Check if the stream has audio, video and/or data active
 
@@ -310,6 +311,15 @@ remoteStream.updateConfiguration({slideShowMode:true}, function (result){
 console.log(result);
 });
 ```
+
+## Update Simulcast Layers Bitrate
+
+It allows us to change the max bitrate assigned for each spatial layer in Simulcast. It can only be applied to publishers.
+```
+localStream.updateSimulcastLayersBitrate({0: 80000, 1: 430000});
+```
+
+In this example we are configuring 2 spatial layers bitrates, limiting the lower layer to 80 Kbps and the higher to 430 Kbps.
 
 # Room
 

--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -138,6 +138,10 @@ class ErizoConnection extends EventEmitterConst {
   updateSpec(configInput, streamId, callback) {
     this.stack.updateSpec(configInput, streamId, callback);
   }
+
+  updateSimulcastLayersBitrate(bitrates) {
+    this.stack.updateSimulcastLayersBitrate(bitrates);
+  }
 }
 
 class ErizoConnectionManager {

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -466,6 +466,12 @@ const Stream = (altConnectionHelpers, specInput) => {
     controlHandler(handlers, publisherSide, true);
   };
 
+  that.updateSimulcastLayersBitrate = (bitrates) => {
+    if (that.pc && that.local) {
+      that.pc.updateSimulcastLayersBitrate(bitrates);
+    }
+  };
+
   that.updateConfiguration = (config, callback = () => {}) => {
     if (config === undefined) { return; }
     if (that.pc) {

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -532,6 +532,13 @@ const BaseStack = (specInput) => {
     return sdpInput;
   };
 
+  that.updateSimulcastLayersBitrate = (bitrates) => {
+    if (that.simulcast) {
+      that.simulcast.spatialLayerBitrates = bitrates;
+      that.setSimulcastLayersBitrate();
+    }
+  };
+
   that.setSimulcastLayersBitrate = () => {
     Logger.error('Simulcast not implemented');
   };

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -218,7 +218,7 @@ exports.ErizoJSController = (erizoJSId, threadPool, ioThreadPool) => {
       return;
     }
 
-    if (publisher.cliendId === clientId) {
+    if (publisher.clientId === clientId) {
       node = publisher;
     } else if (publisher.hasSubscriber(clientId)) {
       node = publisher.getSubscriber(clientId);

--- a/erizo_controller/test/erizoJS/erizoJSController.js
+++ b/erizo_controller/test/erizoJS/erizoJSController.js
@@ -573,7 +573,7 @@ describe('Erizo JS Controller', () => {
         });
 
         it('should mute and unmute publisher stream', () => {
-          controller.processStreamMessage(kArbitraryErizoControllerId, undefined,
+          controller.processStreamMessage(kArbitraryErizoControllerId, kArbitraryClientId,
             kArbitraryStreamId, {
               type: 'updatestream',
               config: {
@@ -583,7 +583,7 @@ describe('Erizo JS Controller', () => {
                 },
               } });
 
-          controller.processStreamMessage(kArbitraryErizoControllerId, undefined,
+          controller.processStreamMessage(kArbitraryErizoControllerId, kArbitraryClientId,
             kArbitraryStreamId, {
               type: 'updatestream',
               config: {


### PR DESCRIPTION
**Description**

Adds a client API to update simulcast layer bitrate.

Note: It also fixes an issue with the updateConfiguration when run for publishers.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

This is the new API in the cliend side.

```
localStream.updateSimulcastLayersBitrate({0: 80000, 1: 430000});
```

In this example we are configuring 2 spatial layers bitrates, limiting the lower layer to 80 Kbps and the higher to 430 Kbps.

- [x] It includes documentation for these changes in `/doc`.