### PR TITLE
Fix crashes when getting local sdp

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -275,9 +275,10 @@ boost::future<std::shared_ptr<SdpInfo>> WebRtcConnection::getLocalSdpInfo() {
   worker_->task([weak_this, task_promise] {
     std::shared_ptr<SdpInfo> info;
     if (auto this_ptr = weak_this.lock()) {
-      info = this_ptr->getLocalSdpInfoSync();
+      auto temp_info = this_ptr->getLocalSdpInfoSync();
+      info = std::make_shared<SdpInfo>(*temp_info);
     } else {
-      ELOG_WARN("%s message: Error trying to getLocalSdpInfo, returning empty", this_ptr->toLog());
+      ELOG_WARN("message: Error trying to getLocalSdpInfo - cannot lock WebrtcConnection, returning empty");
     }
     task_promise->set_value(info);
   });

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -275,8 +275,7 @@ boost::future<std::shared_ptr<SdpInfo>> WebRtcConnection::getLocalSdpInfo() {
   worker_->task([weak_this, task_promise] {
     std::shared_ptr<SdpInfo> info;
     if (auto this_ptr = weak_this.lock()) {
-      auto temp_info = this_ptr->getLocalSdpInfoSync();
-      info = std::make_shared<SdpInfo>(*temp_info);
+      info = this_ptr->getLocalSdpInfoSync();
     } else {
       ELOG_WARN("message: Error trying to getLocalSdpInfo - cannot lock WebrtcConnection, returning empty");
     }
@@ -332,7 +331,8 @@ std::shared_ptr<SdpInfo> WebRtcConnection::getLocalSdpInfoSync() {
     local_sdp_->videoDirection = erizo::SENDRECV;
   }
 
-  return local_sdp_;
+  auto local_sdp_copy = std::make_shared<SdpInfo>(*local_sdp_.get());
+  return local_sdp_copy;
 }
 
 boost::future<void> WebRtcConnection::setRemoteSdp(const std::string &sdp) {

--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -356,9 +356,14 @@ NAN_METHOD(WebRtcConnection::getLocalDescription) {
 
   me->getLocalSdpInfo().then(
       [persistent, obj] (boost::future<std::shared_ptr<erizo::SdpInfo>> fut) {
-        std::shared_ptr<erizo::SdpInfo> sdp_info = std::make_shared<erizo::SdpInfo>(*fut.get().get());
-        ResultVariant result = sdp_info;
-        obj->notifyFuture(persistent, result);
+        std::shared_ptr<erizo::SdpInfo> sdp_info = fut.get();
+        if (sdp_info) {
+          std::shared_ptr<erizo::SdpInfo> sdp_info_copy = std::make_shared<erizo::SdpInfo>(*sdp_info.get());
+          ResultVariant result = sdp_info_copy;
+          obj->notifyFuture(persistent, result);
+        } else {
+          obj->notifyFuture(persistent);
+        }
         });
   info.GetReturnValue().Set(resolver->GetPromise());
 }

--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -143,6 +143,10 @@ class Connection extends events.EventEmitter {
 
   getLocalSdp() {
     return this.wrtc.getLocalDescription().then((desc) => {
+      if (!desc) {
+        log.error('Cannot get local description');
+        return '';
+      }
       this.wrtc.localDescription = new SessionDescription(desc);
       const sdp = this.wrtc.localDescription.getSdp(this.sessionVersion);
       this.sessionVersion += 1;
@@ -180,6 +184,10 @@ class Connection extends events.EventEmitter {
       return Promise.reject('fail');
     }
     return this.wrtc.getLocalDescription().then((localDescription) => {
+      if (!localDescription) {
+        log.error('message: _resendLastAnswer, Cannot get local description');
+        return Promise.reject('fail');
+      }
       this.wrtc.localDescription = new SessionDescription(localDescription);
       const sdp = this.wrtc.localDescription.getSdp(this.sessionVersion);
       const stream = sdp.getStream(label);


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR fixes two possible crashes in the life of SdpInfo in getLocalDescription:
1. The path when we cannot call `getLocalSdpInfoSync` would crash because `this_ptr` would not be present.
2. We made the copy of SdpInfo when the promise is resolved in `ErizoAPI`, we could be potentially modifying that data structure in another thread at the same time.


[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.