### PR TITLE
Resolve getStats promise even if the MediaStream cannot be locked

### DIFF
--- a/erizoAPI/MediaStream.cc
+++ b/erizoAPI/MediaStream.cc
@@ -31,6 +31,8 @@ void StatCallWorker::Execute() {
     stream->getJSONStats([&stat_promise] (std::string stats) {
       stat_promise.set_value(stats);
     });
+  } else {
+    stat_promise.set_value(std::string("{}"));
   }
   stat_future.wait();
   stat_ = stat_future.get();


### PR DESCRIPTION
**Description**
This PR addresses an issue that affects the stats calls in ErizoJSController since potentially some of the promises for the stats call would not resolve.

This fixes an issue with Ackuaria not displaying stats for publishers in some situations.

We probably still need to investigate if this happens more than it should - the erizoAPI MediaStream structure still being alive while the erizo one is already destroyed.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.