### PR TITLE
Call getStats callback even if mediaStream is not present or is closed

### DIFF
--- a/erizoAPI/MediaStream.cc
+++ b/erizoAPI/MediaStream.cc
@@ -392,10 +392,14 @@ NAN_METHOD(MediaStream::enableSlideShowBelowSpatialLayer) {
 
 NAN_METHOD(MediaStream::getStats) {
   MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  Nan::Callback *callback = new Nan::Callback(info[0].As<Function>());
   if (!obj->me || info.Length() != 1 || obj->closed_) {
+    Local<Value> argv[] = {
+      Nan::New<v8::String>("{}").ToLocalChecked()
+    };
+    Nan::Call(*callback, 1, argv);
     return;
   }
-  Nan::Callback *callback = new Nan::Callback(info[0].As<Function>());
   AsyncQueueWorker(new StatCallWorker(callback, obj->me));
 }
 


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

If the underlying mediaStream is not present or has been closed, `getStats` was not calling back. This PR fixes this, avoiding keeping pending promises in `ErizoJS`

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.