### PR TITLE
Add Nuve and Basic Example ports to licode config

### DIFF
--- a/extras/basic_example/basicServer.js
+++ b/extras/basic_example/basicServer.js
@@ -200,9 +200,9 @@ app.use((req, res, next) => {
 cleanExampleRooms(() => {
   getOrCreateRoom(defaultRoomName, undefined, undefined, (roomId) => {
     defaultRoom = roomId;
-    app.listen(3001);
+    app.listen(config.basicExample.port || 3001);
     const server = https.createServer(options, app);
     console.log('BasicExample started');
-    server.listen(3004);
+    server.listen(config.basicExample.tlsPort || 3004);
   });
 });

--- a/nuve/nuveAPI/nuve.js
+++ b/nuve/nuveAPI/nuve.js
@@ -6,6 +6,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const rpc = require('./rpc/rpc');
 
+// eslint-disable-next-line import/no-unresolved
 const config = require('./../../licode_config');
 
 const app = express();

--- a/nuve/nuveAPI/nuve.js
+++ b/nuve/nuveAPI/nuve.js
@@ -6,6 +6,8 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const rpc = require('./rpc/rpc');
 
+const config = require('./../../licode_config');
+
 const app = express();
 
 rpc.connect();
@@ -78,4 +80,6 @@ app.use((req, res) => {
   res.status(404).send('Resource not found');
 });
 
-app.listen(3000);
+const nuvePort = config.nuve.port || 3000;
+
+app.listen(nuvePort);

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -29,6 +29,7 @@ config.nuve.superserviceKey = '_auto_generated_KEY_'; // default value: ''
 config.nuve.testErizoController = 'localhost:8080'; // default value: 'localhost:8080'
 // Nuve Cloud Handler policies are in nuve/nuveAPI/ch_policies/ folder
 config.nuve.cloudHandlerPolicy = 'default_policy.js'; // default value: 'default_policy.js'
+config.nuve.port = 3000; // default value: 3000
 
 
 /*********************************************************
@@ -191,6 +192,9 @@ config.erizo.useNicer = false;  // default value: false
 
 config.erizo.disabledHandlers = []; // there are no handlers disabled by default
 
+/*********************************************************
+ ROV CONFIGURATION
+**********************************************************/
 config.rov = {};
 // The stats gathering period in ms
 config.rov.statsPeriod = 20000;
@@ -198,6 +202,14 @@ config.rov.statsPeriod = 20000;
 config.rov.serverPort = 3005;
 // A prefix for the prometheus stats
 config.rov.statsPrefix = "licode_";
+
+/*********************************************************
+ BASIC EXAMPLE CONFIGURATION
+**********************************************************/
+config.basicExample = {};
+config.basicExample.port = 3001;  // default value: 3001
+config.basicExample.tlsPort = 3004; // default value: 3004
+
 /***** END *****/
 // Following lines are always needed.
 var module = module || {};


### PR DESCRIPTION
**Description**

This PRs gives more flexibility when executing Nuve and Basic Example.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.