### PR TITLE
Reduce MediaStream stats frequency

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -44,7 +44,7 @@ namespace erizo {
 DEFINE_LOGGER(MediaStream, "MediaStream");
 log4cxx::LoggerPtr MediaStream::statsLogger = log4cxx::Logger::getLogger("StreamStats");
 
-static constexpr auto kStreamStatsPeriod = std::chrono::seconds(30);
+static constexpr auto kStreamStatsPeriod = std::chrono::seconds(120);
 
 MediaStream::MediaStream(std::shared_ptr<Worker> worker,
   std::shared_ptr<WebRtcConnection> connection,


### PR DESCRIPTION
**Description**

Reduce Media Stream stats frecuency as it seems to reduce efficiency in DB queries.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.