### PR TITLE
Ensure we use Setup actpass role when setting remote offers in ErizoClient

### DIFF
--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -326,6 +326,14 @@ const BaseStack = (specInput) => {
       latestSessionVersion = sessionVersion;
 
       SdpHelpers.setMaxBW(remoteSdp, specBase);
+
+      // Hack to ensure that the offer has the right setup.
+      remoteSdp.medias.forEach((media) => {
+        if (media.getSetup() !== Setup.ACTPASS) {
+          media.setSetup(Setup.ACTPASS);
+        }
+      });
+
       msg.sdp = remoteSdp.toString();
       that.remoteSdp = remoteSdp;
       const rejectMessage = [];


### PR DESCRIPTION
**Description**

It seems that there is still some case where we are not setting Setup=actpass in the Erizo offers. This PR aims to fix those cases.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.