### PR TITLE
Enabling GetDisplayMedia for screensharing

### DIFF
--- a/erizo_controller/erizoClient/src/utils/ConnectionHelpers.js
+++ b/erizo_controller/erizoClient/src/utils/ConnectionHelpers.js
@@ -29,8 +29,11 @@ const GetUserMedia = (config, callback = () => {}, error = () => {}) => {
     navigator.mediaDevices.getUserMedia(userMediaConfig).then(cb).catch(errorCb);
   };
 
+  const getDisplayMedia = (userMediaConfig, cb, errorCb) => {
+    navigator.mediaDevices.getDisplayMedia(userMediaConfig).then(cb).catch(errorCb);
+  };
+
   const configureScreensharing = () => {
-    Logger.debug('Screen access requested');
     switch (getBrowser()) {
       case 'electron' :
         Logger.debug('Screen sharing in Electron');
@@ -110,7 +113,13 @@ const GetUserMedia = (config, callback = () => {}, error = () => {}) => {
   };
 
   if (config.screen) {
-    configureScreensharing();
+    if (config.desktopStreamId || config.extensionId) {
+      Logger.debug('Screen access requested using GetUserMedia');
+      configureScreensharing();
+    } else {
+      Logger.debug('Screen access requested using GetDisplayMedia');
+      getDisplayMedia(config, callback, error);
+    }
   } else if (typeof module !== 'undefined' && module.exports) {
     Logger.error('Video/audio streams not supported in erizofc yet');
   } else {


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

This PR enables the use of MediaDevices.getDisplayMedia() for screensharing. If an extensionId or desktopStreamId are specified in the Stream options, the GetUserMedia() method is still used. 

<!--
Add a short description here, please.
If the contribution needs and includes Unit Tests check the box below.
-->

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.