### PR TITLE
Move SenderBandwidthEstimationHandler to WebRtcConnection

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -30,7 +30,6 @@
 #include "rtp/FakeKeyframeGeneratorHandler.h"
 #include "rtp/StatsHandler.h"
 #include "rtp/SRPacketHandler.h"
-#include "rtp/SenderBandwidthEstimationHandler.h"
 #include "rtp/LayerDetectorHandler.h"
 #include "rtp/LayerBitrateCalculationHandler.h"
 #include "rtp/QualityFilterHandler.h"

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -403,7 +403,6 @@ void MediaStream::initializePipeline() {
   pipeline_->addFront(std::make_shared<RtcpFeedbackGenerationHandler>());
   pipeline_->addFront(std::make_shared<RtpRetransmissionHandler>());
   pipeline_->addFront(std::make_shared<SRPacketHandler>());
-  pipeline_->addFront(std::make_shared<SenderBandwidthEstimationHandler>());
   pipeline_->addFront(std::make_shared<LayerDetectorHandler>());
   pipeline_->addFront(std::make_shared<OutgoingStatsHandler>());
   pipeline_->addFront(std::make_shared<PacketCodecParser>());

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -116,8 +116,11 @@ void WebRtcConnection::initializePipeline() {
   handler_manager_ = std::make_shared<HandlerManager>(shared_from_this());
   pipeline_->addService(shared_from_this());
   pipeline_->addService(handler_manager_);
+  pipeline_->addService(stats_);
 
   pipeline_->addFront(std::make_shared<ConnectionPacketReader>(this));
+
+  pipeline_->addFront(std::make_shared<SenderBandwidthEstimationHandler>());
 
   pipeline_->addFront(std::make_shared<ConnectionPacketWriter>(this));
   pipeline_->finalize();

--- a/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
@@ -167,8 +167,10 @@ void SenderBandwidthEstimationHandler::analyzeSr(RtcpHeader* chead) {
 void SenderBandwidthEstimationHandler::updateEstimate() {
   sender_bwe_->CurrentEstimate(&estimated_bitrate_, &estimated_loss_,
       &estimated_rtt_);
-  stats_->getNode()["total"].insertStat("senderBitrateEstimation",
+  if (stats_) {
+    stats_->getNode()["total"].insertStat("senderBitrateEstimation",
       CumulativeStat{static_cast<uint64_t>(estimated_bitrate_)});
+  }
   ELOG_DEBUG("%s message: estimated bitrate %d, loss %u, rtt %ld",
       connection_->toLog(), estimated_bitrate_, estimated_loss_, estimated_rtt_);
   if (bwe_listener_) {

--- a/erizo/src/erizo/rtp/SenderBandwidthEstimationHandler.h
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimationHandler.h
@@ -3,7 +3,6 @@
 #include "pipeline/Handler.h"
 #include "./logger.h"
 #include "./WebRtcConnection.h"
-#include "./rtp/RtcpProcessor.h"
 #include "lib/Clock.h"
 
 #include "webrtc/modules/bitrate_controller/send_side_bandwidth_estimation.h"
@@ -52,7 +51,6 @@ class SenderBandwidthEstimationHandler : public Handler,
 
  private:
   WebRtcConnection* connection_;
-  std::shared_ptr<RtcpProcessor> processor_;
   SenderBandwidthEstimationListener* bwe_listener_;
   std::shared_ptr<Clock> clock_;
   bool initialized_;

--- a/erizo/src/erizo/rtp/SenderBandwidthEstimationHandler.h
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimationHandler.h
@@ -2,7 +2,7 @@
 #define ERIZO_SRC_ERIZO_RTP_SENDERBANDWIDTHESTIMATIONHANDLER_H_
 #include "pipeline/Handler.h"
 #include "./logger.h"
-#include "./MediaStream.h"
+#include "./WebRtcConnection.h"
 #include "./rtp/RtcpProcessor.h"
 #include "lib/Clock.h"
 
@@ -51,7 +51,7 @@ class SenderBandwidthEstimationHandler : public Handler,
   }
 
  private:
-  MediaStream* stream_;
+  WebRtcConnection* connection_;
   std::shared_ptr<RtcpProcessor> processor_;
   SenderBandwidthEstimationListener* bwe_listener_;
   std::shared_ptr<Clock> clock_;

--- a/erizo/src/erizo/rtp/StatsHandler.cpp
+++ b/erizo/src/erizo/rtp/StatsHandler.cpp
@@ -83,7 +83,7 @@ void StatsCalculator::processRtcpPacket(std::shared_ptr<DataPacket> packet) {
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(movingBuf);
   if (chead->isFeedback()) {
     ssrc = chead->getSourceSSRC();
-    if (!stream_->isSinkSSRC(ssrc)) {
+    if (stream_->isPublisher()) {
       is_feedback_on_publisher = true;
     }
   } else {
@@ -149,6 +149,7 @@ void StatsCalculator::processRtcpPacket(std::shared_ptr<DataPacket> packet) {
               if (is_feedback_on_publisher) {
                 break;
               }
+              ssrc = chead->getREMBFeedSSRC(0);
               ELOG_DEBUG("REMB Packet, SSRC %u, sourceSSRC %u", chead->getSSRC(), chead->getSourceSSRC());
               char *uniqueId = reinterpret_cast<char*>(&chead->report.rembPacket.uniqueid);
               if (!strncmp(uniqueId, "REMB", 4)) {

--- a/erizo/src/erizo/rtp/StatsHandler.cpp
+++ b/erizo/src/erizo/rtp/StatsHandler.cpp
@@ -157,6 +157,7 @@ void StatsCalculator::processRtcpPacket(std::shared_ptr<DataPacket> packet) {
                 // ELOG_DEBUG("REMB Packet numSSRC %u mantissa %u exp %u, tot %lu bps",
                 //             chead->getREMBNumSSRC(), chead->getBrMantis(), chead->getBrExp(), bitrate);
                 getStatsInfo()[ssrc].insertStat("bandwidth", CumulativeStat{bitrate});
+                getStatsInfo()["total"].insertStat("senderBitrateEstimation", CumulativeStat{bitrate});
               } else {
                 ELOG_DEBUG("Unsupported AFB Packet not REMB")
               }

--- a/erizo/src/test/utils/Mocks.h
+++ b/erizo/src/test/utils/Mocks.h
@@ -2,6 +2,7 @@
 #define ERIZO_SRC_TEST_UTILS_MOCKS_H_
 
 #include <WebRtcConnection.h>
+#include <MediaStream.h>
 #include <pipeline/Handler.h>
 #include <rtp/RtcpProcessor.h>
 #include <rtp/QualityManager.h>


### PR DESCRIPTION
**Description**

This PR moves the SenderBandwidthEstimationHandler to WebRtcConncetion to better estimate bandwidth when there are multiple streams involved.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.