### PR TITLE
Add new Padding Manager in WebRtcConnection

### DIFF
--- a/erizo/src/erizo/MediaDefinitions.h
+++ b/erizo/src/erizo/MediaDefinitions.h
@@ -11,6 +11,7 @@
 
 #include "lib/Clock.h"
 #include "lib/ClockUtils.h"
+#include "rtp/RtpHeaders.h"
 
 namespace erizo {
 
@@ -25,19 +26,19 @@ struct DataPacket {
 
   DataPacket(int comp_, const char *data_, int length_, packetType type_, uint64_t received_time_ms_) :
     comp{comp_}, length{length_}, type{type_}, received_time_ms{received_time_ms_}, is_keyframe{false},
-    ending_of_layer_frame{false}, picture_id{-1}, tl0_pic_idx{-1} {
+    ending_of_layer_frame{false}, picture_id{-1}, tl0_pic_idx{-1}, is_padding{false} {
       memcpy(data, data_, length_);
   }
 
   DataPacket(int comp_, const char *data_, int length_, packetType type_) :
     comp{comp_}, length{length_}, type{type_}, received_time_ms{ClockUtils::timePointToMs(clock::now())},
-    is_keyframe{false}, ending_of_layer_frame{false}, picture_id{-1}, tl0_pic_idx{-1} {
+    is_keyframe{false}, ending_of_layer_frame{false}, picture_id{-1}, tl0_pic_idx{-1}, is_padding{false} {
       memcpy(data, data_, length_);
   }
 
   DataPacket(int comp_, const unsigned char *data_, int length_) :
     comp{comp_}, length{length_}, type{VIDEO_PACKET}, received_time_ms{ClockUtils::timePointToMs(clock::now())},
-    is_keyframe{false}, ending_of_layer_frame{false}, picture_id{-1}, tl0_pic_idx{-1} {
+    is_keyframe{false}, ending_of_layer_frame{false}, picture_id{-1}, tl0_pic_idx{-1}, is_padding{false} {
       memcpy(data, data_, length_);
   }
 
@@ -70,6 +71,7 @@ struct DataPacket {
   int tl0_pic_idx;
   std::string codec;
   unsigned int clock_rate = 0;
+  bool is_padding;
 };
 
 class Monitor {

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -657,7 +657,6 @@ uint32_t MediaStream::getTargetVideoBitrate() {
   if (slide_show_mode || !is_simulcast) {
     target_bitrate = std::min(bitrate_sent, max_bitrate);
   }
-  stats_->getNode()["total"].insertStat("targetVideoBitrate", CumulativeStat{target_bitrate});
   return target_bitrate;
 }
 

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -44,6 +44,7 @@ DEFINE_LOGGER(MediaStream, "MediaStream");
 log4cxx::LoggerPtr MediaStream::statsLogger = log4cxx::Logger::getLogger("StreamStats");
 
 static constexpr auto kStreamStatsPeriod = std::chrono::seconds(120);
+static constexpr uint64_t kInitialBitrate = 300000;
 
 MediaStream::MediaStream(std::shared_ptr<Worker> worker,
   std::shared_ptr<WebRtcConnection> connection,
@@ -656,6 +657,9 @@ uint32_t MediaStream::getTargetVideoBitrate() {
   }
   if (slide_show_mode || !is_simulcast) {
     target_bitrate = std::min(bitrate_sent, max_bitrate);
+  }
+  if (target_bitrate == 0) {
+    target_bitrate = kInitialBitrate;
   }
   return target_bitrate;
 }

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -64,7 +64,8 @@ MediaStream::MediaStream(std::shared_ptr<Worker> worker,
     simulcast_{false},
     bitrate_from_max_quality_layer_{0},
     video_bitrate_{0},
-    random_generator_{random_device_()} {
+    random_generator_{random_device_()},
+    target_padding_bitrate_{0} {
   if (is_publisher) {
     setVideoSinkSSRC(kDefaultVideoSinkSSRC);
     setAudioSinkSSRC(kDefaultAudioSinkSSRC);
@@ -635,6 +636,29 @@ void MediaStream::setSlideShowMode(bool state) {
   });
   slide_show_mode_ = state;
   notifyUpdateToHandlers();
+}
+
+void MediaStream::setTargetPaddingBitrate(uint64_t target_padding_bitrate) {
+  target_padding_bitrate_ = target_padding_bitrate;
+  notifyUpdateToHandlers();
+}
+
+uint32_t MediaStream::getTargetVideoBitrate() {
+  bool slide_show_mode = isSlideShowModeEnabled();
+  bool is_simulcast = isSimulcast();
+  uint32_t bitrate_sent = getVideoBitrate();
+  uint32_t max_bitrate = getMaxVideoBW();
+  uint32_t bitrate_from_max_quality_layer = getBitrateFromMaxQualityLayer();
+
+  uint32_t target_bitrate = max_bitrate;
+  if (is_simulcast) {
+    target_bitrate = std::min(bitrate_from_max_quality_layer, max_bitrate);
+  }
+  if (slide_show_mode || !is_simulcast) {
+    target_bitrate = std::min(bitrate_sent, max_bitrate);
+  }
+  stats_->getNode()["total"].insertStat("targetVideoBitrate", CumulativeStat{target_bitrate});
+  return target_bitrate;
 }
 
 void MediaStream::muteStream(bool mute_video, bool mute_audio) {

--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -155,6 +155,12 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   bool isSinkSSRC(uint32_t ssrc);
   void parseIncomingPayloadType(char *buf, int len, packetType type);
   void parseIncomingExtensionId(char *buf, int len, packetType type);
+  virtual void setTargetPaddingBitrate(uint64_t bitrate);
+  virtual uint64_t getTargetPaddingBitrate() {
+    return target_padding_bitrate_;
+  }
+
+  virtual uint32_t getTargetVideoBitrate();
 
   bool isPipelineInitialized() { return pipeline_initialized_; }
   bool isRunning() { return pipeline_initialized_ && sending_; }
@@ -223,6 +229,7 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   std::atomic<uint32_t> video_bitrate_;
   std::random_device random_device_;
   std::mt19937 random_generator_;
+  uint64_t target_padding_bitrate_;
  protected:
   std::shared_ptr<SdpInfo> remote_sdp_;
 };

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -35,6 +35,7 @@
 #include "rtp/QualityManager.h"
 #include "rtp/PliPacerHandler.h"
 #include "rtp/RtpPaddingGeneratorHandler.h"
+#include "rtp/RtpPaddingManagerHandler.h"
 #include "rtp/RtpUtils.h"
 
 namespace erizo {
@@ -121,6 +122,7 @@ void WebRtcConnection::initializePipeline() {
   pipeline_->addFront(std::make_shared<ConnectionPacketReader>(this));
 
   pipeline_->addFront(std::make_shared<SenderBandwidthEstimationHandler>());
+  pipeline_->addFront(std::make_shared<RtpPaddingManagerHandler>());
 
   pipeline_->addFront(std::make_shared<ConnectionPacketWriter>(this));
   pipeline_->finalize();

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -216,6 +216,10 @@ ConnectionQualityLevel WebRtcConnection::getConnectionQualityLevel() {
   return connection_quality_check_.getLevel();
 }
 
+bool WebRtcConnection::werePacketLossesRecently() {
+  return connection_quality_check_.werePacketLossesRecently();
+}
+
 boost::future<void> WebRtcConnection::addMediaStream(std::shared_ptr<MediaStream> media_stream) {
   return asyncTask([media_stream] (std::shared_ptr<WebRtcConnection> connection) {
     boost::mutex::scoped_lock lock(connection->update_state_mutex_);

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -171,6 +171,7 @@ class WebRtcConnection: public TransportListener, public LogContext, public Hand
   void write(std::shared_ptr<DataPacket> packet);
   void notifyUpdateToHandlers() override;
   ConnectionQualityLevel getConnectionQualityLevel();
+  bool werePacketLossesRecently();
   void getJSONStats(std::function<void(std::string)> callback);
 
  private:

--- a/erizo/src/erizo/bandwidth/ConnectionQualityCheck.h
+++ b/erizo/src/erizo/bandwidth/ConnectionQualityCheck.h
@@ -47,12 +47,14 @@ class ConnectionQualityCheck {
   virtual ~ConnectionQualityCheck() {}
   void onFeedback(std::shared_ptr<DataPacket> packet, const std::vector<std::shared_ptr<MediaStream>> &streams);
   ConnectionQualityLevel getLevel() { return quality_level_; }
+  bool werePacketLossesRecently();
  private:
   void maybeNotifyMediaStreamsAboutConnectionQualityLevel(const std::vector<std::shared_ptr<MediaStream>> &streams);
  private:
   ConnectionQualityLevel quality_level_;
   circular_buffer audio_buffer_;
   circular_buffer video_buffer_;
+  bool recent_packet_losses_;
 };
 
 }  // namespace erizo

--- a/erizo/src/erizo/bandwidth/TargetVideoBWDistributor.h
+++ b/erizo/src/erizo/bandwidth/TargetVideoBWDistributor.h
@@ -15,6 +15,7 @@ struct MediaStreamInfo {
   uint32_t bitrate_sent;
   uint32_t max_video_bw;
   uint32_t bitrate_from_max_quality_layer;
+  uint32_t target_video_bitrate;
 };
 
 class TargetVideoBWDistributor : public BandwidthDistributionAlgorithm {
@@ -23,8 +24,6 @@ class TargetVideoBWDistributor : public BandwidthDistributionAlgorithm {
   virtual ~TargetVideoBWDistributor() {}
   void distribute(uint32_t remb, uint32_t ssrc, std::vector<std::shared_ptr<MediaStream>> streams,
                   Transport *transport) override;
- private:
-  uint32_t getTargetVideoBW(const MediaStreamInfo &stream);
 };
 
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.h
+++ b/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.h
@@ -38,12 +38,9 @@ class RtpPaddingGeneratorHandler: public Handler, public std::enable_shared_from
   bool isHigherSequenceNumber(std::shared_ptr<DataPacket> packet);
   void onVideoPacket(std::shared_ptr<DataPacket> packet);
 
-  uint64_t getStat(std::string stat_name);
-  uint64_t getTargetBitrate();
   uint64_t getBurstSize();
 
-  bool isTimeToCalculateBitrate();
-  void recalculatePaddingRate();
+  void recalculatePaddingRate(uint64_t target_padding_bitrate);
 
   void enablePadding();
   void disablePadding();
@@ -53,13 +50,11 @@ class RtpPaddingGeneratorHandler: public Handler, public std::enable_shared_from
   SequenceNumberTranslator translator_;
   MediaStream* stream_;
   std::shared_ptr<Stats> stats_;
-  uint64_t max_video_bw_;
   uint16_t higher_sequence_number_;
   uint32_t video_sink_ssrc_;
   uint32_t audio_source_ssrc_;
   uint64_t number_of_full_padding_packets_;
   uint8_t last_padding_packet_size_;
-  time_point last_rate_calculation_time_;
   time_point started_at_;
   bool enabled_;
   bool first_packet_received_;

--- a/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
@@ -126,6 +126,8 @@ void RtpPaddingManagerHandler::distributeTotalTargetPaddingBitrate(int64_t bitra
         num_streams++;
       }
     });
+  stats_->getNode()["total"].insertStat("numberOfStreams",
+      CumulativeStat{static_cast<uint64_t>(num_streams)});
   if (num_streams == 0) {
     return;
   }
@@ -148,6 +150,9 @@ int64_t RtpPaddingManagerHandler::getTotalTargetBitrate() {
       }
       target_bitrate += media_stream->getTargetVideoBitrate();
     });
+  stats_->getNode()["total"].insertStat("targetBitrate",
+    CumulativeStat{static_cast<uint64_t>(target_bitrate)});
+
   return target_bitrate;
 }
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
@@ -1,0 +1,135 @@
+#include "rtp/RtpPaddingManagerHandler.h"
+
+#include <algorithm>
+#include <string>
+#include <inttypes.h>
+
+#include "./MediaDefinitions.h"
+#include "./WebRtcConnection.h"
+#include "./MediaStream.h"
+#include "./RtpUtils.h"
+
+namespace erizo {
+
+DEFINE_LOGGER(RtpPaddingManagerHandler, "rtp.RtpPaddingManagerHandler");
+
+constexpr duration kStatsPeriod = std::chrono::milliseconds(100);
+constexpr double kBitrateComparisonMargin = 1.3;
+constexpr uint64_t kInitialBitrate = 300000;
+
+RtpPaddingManagerHandler::RtpPaddingManagerHandler(std::shared_ptr<erizo::Clock> the_clock) :
+  clock_{the_clock}, last_rate_calculation_time_{clock_->now()}, connection_{nullptr} {
+}
+
+void RtpPaddingManagerHandler::enable() {
+}
+
+void RtpPaddingManagerHandler::disable() {
+}
+
+void RtpPaddingManagerHandler::notifyUpdate() {
+  auto pipeline = getContext()->getPipelineShared();
+  if (pipeline && !connection_) {
+    connection_ = pipeline->getService<WebRtcConnection>().get();
+    stats_ = pipeline->getService<Stats>();
+    stats_->getNode()["total"].insertStat("paddingBitrate",
+        MovingIntervalRateStat{std::chrono::milliseconds(100), 30, 8., clock_});
+    stats_->getNode()["total"].insertStat("videoBitrate",
+        MovingIntervalRateStat{std::chrono::milliseconds(100), 30, 8., clock_});
+  }
+
+  if (!connection_) {
+    return;
+  }
+}
+
+bool RtpPaddingManagerHandler::isTimeToCalculateBitrate() {
+  return (clock_->now() - last_rate_calculation_time_) >= kStatsPeriod;
+}
+
+void RtpPaddingManagerHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet) {
+  ctx->fireRead(std::move(packet));
+}
+
+void RtpPaddingManagerHandler::write(Context *ctx, std::shared_ptr<DataPacket> packet) {
+  RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
+  if (packet->is_padding) {
+    stats_->getNode()["total"]["paddingBitrate"] += packet->length;
+  } else if (packet->type == VIDEO_PACKET && !chead->isRtcp()) {
+    stats_->getNode()["total"]["videoBitrate"] += packet->length;
+  }
+
+  recalculatePaddingRate();
+
+  ctx->fireWrite(packet);
+}
+
+void RtpPaddingManagerHandler::recalculatePaddingRate() {
+  if (!isTimeToCalculateBitrate()) {
+    return;
+  }
+
+  last_rate_calculation_time_ = clock_->now();
+  StatNode &total = stats_->getNode()["total"];
+
+  int64_t media_bitrate = total["videoBitrate"].value();
+  int64_t estimated_bandwidth = total["senderBitrateEstimation"].value();
+
+  int64_t target_bitrate = getTotalTargetBitrate();
+
+  if (target_bitrate == 0) {
+    target_bitrate = kInitialBitrate;
+  }
+
+  int64_t target_padding_bitrate = std::max(target_bitrate - media_bitrate, int64_t(0));
+  target_padding_bitrate = std::min(target_padding_bitrate, estimated_bandwidth - media_bitrate);
+
+  bool can_send_more_bitrate = (kBitrateComparisonMargin * media_bitrate) < estimated_bandwidth;
+  bool estimated_is_high_enough = estimated_bandwidth > (target_bitrate * kBitrateComparisonMargin);
+  if (!can_send_more_bitrate || estimated_is_high_enough) {
+    target_padding_bitrate = 0;
+  }
+  ELOG_DEBUG("%s Calculated: target %d, bwe %d, media %d, target %d, can send more %d, bwe enough %d",
+    connection_->toLog(),
+    target_padding_bitrate,
+    estimated_bandwidth,
+    media_bitrate,
+    target_bitrate,
+    can_send_more_bitrate,
+    estimated_is_high_enough);
+  distributeTotalTargetPaddingBitrate(target_padding_bitrate);
+}
+
+void RtpPaddingManagerHandler::distributeTotalTargetPaddingBitrate(int64_t bitrate) {
+  size_t num_streams = 0;
+  connection_->forEachMediaStream([&num_streams]
+    (std::shared_ptr<MediaStream> media_stream) {
+      if (!media_stream->isPublisher()) {
+        num_streams++;
+      }
+    });
+  if (num_streams == 0) {
+    return;
+  }
+  int64_t bitrate_per_stream = bitrate / num_streams;
+  connection_->forEachMediaStreamAsync([bitrate_per_stream]
+    (std::shared_ptr<MediaStream> media_stream) {
+      if (media_stream->isPublisher()) {
+        return;
+      }
+      media_stream->setTargetPaddingBitrate(bitrate_per_stream);
+  });
+}
+
+int64_t RtpPaddingManagerHandler::getTotalTargetBitrate() {
+  int64_t target_bitrate = 0;
+  connection_->forEachMediaStream([&target_bitrate]
+    (std::shared_ptr<MediaStream> media_stream) {
+      if (media_stream->isPublisher()) {
+        return;
+      }
+      target_bitrate += media_stream->getTargetVideoBitrate();
+    });
+  return target_bitrate;
+}
+}  // namespace erizo

--- a/erizo/src/erizo/rtp/RtpPaddingManagerHandler.h
+++ b/erizo/src/erizo/rtp/RtpPaddingManagerHandler.h
@@ -39,6 +39,7 @@ class RtpPaddingManagerHandler: public Handler, public std::enable_shared_from_t
   int64_t getTotalTargetBitrate();
 
  private:
+  bool initialized_;
   std::shared_ptr<erizo::Clock> clock_;
   time_point last_rate_calculation_time_;
   WebRtcConnection* connection_;

--- a/erizo/src/erizo/rtp/RtpPaddingManagerHandler.h
+++ b/erizo/src/erizo/rtp/RtpPaddingManagerHandler.h
@@ -42,8 +42,10 @@ class RtpPaddingManagerHandler: public Handler, public std::enable_shared_from_t
   bool initialized_;
   std::shared_ptr<erizo::Clock> clock_;
   time_point last_rate_calculation_time_;
+  time_point last_time_with_packet_losses_;
   WebRtcConnection* connection_;
   std::shared_ptr<Stats> stats_;
+  int64_t last_estimated_bandwidth_;
 };
 
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/RtpPaddingManagerHandler.h
+++ b/erizo/src/erizo/rtp/RtpPaddingManagerHandler.h
@@ -1,0 +1,50 @@
+#ifndef ERIZO_SRC_ERIZO_RTP_RTPPADDINGMANAGERHANDLER_H_
+#define ERIZO_SRC_ERIZO_RTP_RTPPADDINGMANAGERHANDLER_H_
+
+#include <string>
+
+#include "./logger.h"
+#include "pipeline/Handler.h"
+#include "lib/Clock.h"
+#include "lib/TokenBucket.h"
+#include "thread/Worker.h"
+#include "rtp/SequenceNumberTranslator.h"
+#include "./Stats.h"
+
+namespace erizo {
+
+class WebRtcConnection;
+
+class RtpPaddingManagerHandler: public Handler, public std::enable_shared_from_this<RtpPaddingManagerHandler> {
+  DECLARE_LOGGER();
+
+ public:
+  explicit RtpPaddingManagerHandler(std::shared_ptr<erizo::Clock> the_clock = std::make_shared<erizo::SteadyClock>());
+
+  void enable() override;
+  void disable() override;
+
+  std::string getName() override {
+    return "padding-calculator";
+  }
+
+  void read(Context *ctx, std::shared_ptr<DataPacket> packet) override;
+  void write(Context *ctx, std::shared_ptr<DataPacket> packet) override;
+  void notifyUpdate() override;
+
+ private:
+  bool isTimeToCalculateBitrate();
+  void recalculatePaddingRate();
+  void distributeTotalTargetPaddingBitrate(int64_t bitrate);
+  int64_t getTotalTargetBitrate();
+
+ private:
+  std::shared_ptr<erizo::Clock> clock_;
+  time_point last_rate_calculation_time_;
+  WebRtcConnection* connection_;
+  std::shared_ptr<Stats> stats_;
+};
+
+}  // namespace erizo
+
+#endif  // ERIZO_SRC_ERIZO_RTP_RTPPADDINGMANAGERHANDLER_H_

--- a/erizo/src/erizo/rtp/RtpUtils.cpp
+++ b/erizo/src/erizo/rtp/RtpUtils.cpp
@@ -169,7 +169,9 @@ std::shared_ptr<DataPacket> RtpUtils::makePaddingPacket(std::shared_ptr<DataPack
   new_header->setMarker(false);
   packet_buffer[packet_length - 1] = padding_size;
 
-  return std::make_shared<DataPacket>(packet->comp, packet_buffer, packet_length, packet->type);
+  auto padding_packet = std::make_shared<DataPacket>(packet->comp, packet_buffer, packet_length, packet->type);
+  padding_packet->is_padding = true;
+  return padding_packet;
 }
 
 std::shared_ptr<DataPacket> RtpUtils::makeVP8BlackKeyframePacket(std::shared_ptr<DataPacket> packet) {

--- a/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
@@ -13,7 +13,7 @@ SenderBandwidthEstimationHandler::SenderBandwidthEstimationHandler(std::shared_p
   connection_{nullptr}, bwe_listener_{nullptr}, clock_{the_clock}, initialized_{false}, enabled_{true},
   received_remb_{false}, period_packets_sent_{0}, estimated_bitrate_{0}, estimated_loss_{0},
   estimated_rtt_{0}, last_estimate_update_{clock::now()}, sender_bwe_{new SendSideBandwidthEstimation()} {
-    sender_bwe_->SetSendBitrate(kStartSendBitrate);
+    sender_bwe_->SetBitrates(kStartSendBitrate, kMinSendBitrate, kMaxSendBitrate);
   };
 
 SenderBandwidthEstimationHandler::SenderBandwidthEstimationHandler(const SenderBandwidthEstimationHandler&& handler) :  // NOLINT

--- a/erizo/src/erizo/rtp/SenderBandwidthEstimationHandler.h
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimationHandler.h
@@ -25,6 +25,8 @@ class SenderBandwidthEstimationHandler : public Handler,
  public:
   static const uint16_t kMaxSrListSize = 20;
   static const uint32_t kStartSendBitrate = 300000;
+  static const uint32_t kMinSendBitrate = 30000;
+  static const uint32_t kMaxSendBitrate = 1000000000;
   static constexpr duration kMinUpdateEstimateInterval = std::chrono::milliseconds(25);
 
  public:

--- a/erizo/src/test/WebRtcConnectionTest.cpp
+++ b/erizo/src/test/WebRtcConnectionTest.cpp
@@ -17,6 +17,8 @@ using testing::Return;
 using testing::Eq;
 using testing::Args;
 using testing::AtLeast;
+using testing::ResultOf;
+using testing::Invoke;
 using erizo::DataPacket;
 using erizo::ExtMap;
 using erizo::IceConfig;
@@ -24,12 +26,12 @@ using erizo::RtpMap;
 using erizo::RtpUtils;
 using erizo::WebRtcConnection;
 
-typedef std::vector<uint32_t> MaxList;
+typedef std::vector<uint32_t> BitrateList;
 typedef std::vector<bool>     EnabledList;
 typedef std::vector<int32_t>  ExpectedList;
 
 class WebRtcConnectionTest :
-  public ::testing::TestWithParam<std::tr1::tuple<MaxList,
+  public ::testing::TestWithParam<std::tr1::tuple<BitrateList,
                                                   uint32_t,
                                                   EnabledList,
                                                   ExpectedList>> {
@@ -48,7 +50,7 @@ class WebRtcConnectionTest :
     connection->setTransport(transport);
     connection->updateState(TRANSPORT_READY, transport.get());
     connection->init();
-    max_video_bw_list = std::tr1::get<0>(GetParam());
+    video_bitrate_list = std::tr1::get<0>(GetParam());
     bitrate_value = std::tr1::get<1>(GetParam());
     add_to_remb_list = std::tr1::get<2>(GetParam());
     expected_bitrates = std::tr1::get<3>(GetParam());
@@ -57,12 +59,12 @@ class WebRtcConnectionTest :
   }
 
   void setUpStreams() {
-    for (uint32_t max_video_bw : max_video_bw_list) {
-      streams.push_back(addMediaStream(false, max_video_bw));
+    for (uint32_t video_bitrate : video_bitrate_list) {
+      streams.push_back(addMediaStream(false, video_bitrate));
     }
   }
 
-  std::shared_ptr<erizo::MockMediaStream> addMediaStream(bool is_publisher, uint32_t max_video_bw) {
+  std::shared_ptr<erizo::MockMediaStream> addMediaStream(bool is_publisher, uint32_t video_bitrate) {
     std::string id = std::to_string(index);
     std::string label = std::to_string(index);
     uint32_t video_sink_ssrc = getSsrcFromIndex(index);
@@ -77,7 +79,13 @@ class WebRtcConnectionTest :
     media_stream->setAudioSourceSSRC(audio_source_ssrc);
     connection->addMediaStream(media_stream);
     simulated_worker->executeTasks();
-    EXPECT_CALL(*media_stream, getMaxVideoBW()).Times(AtLeast(0)).WillRepeatedly(Return(max_video_bw));
+    EXPECT_CALL(*media_stream, isSlideShowModeEnabled()).WillRepeatedly(Return(false));
+    EXPECT_CALL(*media_stream, isSimulcast()).WillRepeatedly(Return(false));
+    EXPECT_CALL(*media_stream, getVideoBitrate()).WillRepeatedly(Return(video_bitrate));
+    EXPECT_CALL(*media_stream, getMaxVideoBW()).WillRepeatedly(Return(video_bitrate));
+    EXPECT_CALL(*media_stream, getBitrateFromMaxQualityLayer()).WillRepeatedly(Return(0));
+    EXPECT_CALL(*media_stream, getTargetVideoBitrate()).WillRepeatedly(
+      Invoke(media_stream.get(), &erizo::MockMediaStream::MediaStream_getTargetVideoBitrate));
     index++;
     return media_stream;
   }
@@ -117,7 +125,7 @@ class WebRtcConnectionTest :
   }
 
   std::vector<std::shared_ptr<erizo::MockMediaStream>> streams;
-  MaxList max_video_bw_list;
+  BitrateList video_bitrate_list;
   uint32_t bitrate_value;
   EnabledList add_to_remb_list;
   ExpectedList expected_bitrates;
@@ -134,12 +142,16 @@ class WebRtcConnectionTest :
   std::queue<std::shared_ptr<DataPacket>> packet_queue;
 };
 
+uint32_t HasRembWithValue(std::tuple<std::shared_ptr<erizo::DataPacket>> arg) {
+  return (reinterpret_cast<erizo::RtcpHeader*>(std::get<0>(arg)->data))->getREMBBitRate();
+}
+
 TEST_P(WebRtcConnectionTest, forwardRembToStreams_When_StreamTheyExist) {
   uint32_t index = 0;
   for (int32_t expected_bitrate : expected_bitrates) {
     if (expected_bitrate > 0) {
       EXPECT_CALL(*(streams[index]), onTransportData(_, _))
-        .With(Args<0>(erizo::RembHasBitrateValue(static_cast<uint32_t>(expected_bitrate)))).Times(1);
+         .With(Args<0>(ResultOf(&HasRembWithValue, Eq(static_cast<uint32_t>(expected_bitrate))))).Times(1);
     } else {
       EXPECT_CALL(*streams[index], onTransportData(_, _)).Times(0);
     }
@@ -151,33 +163,34 @@ TEST_P(WebRtcConnectionTest, forwardRembToStreams_When_StreamTheyExist) {
 
 INSTANTIATE_TEST_CASE_P(
   REMB_values, WebRtcConnectionTest, testing::Values(
-    std::make_tuple(MaxList{300},      100, EnabledList{1},    ExpectedList{100}),
-    std::make_tuple(MaxList{300},      600, EnabledList{1},    ExpectedList{300}),
+    //                bitrate_list     remb    streams enabled,    expected remb
+    std::make_tuple(BitrateList{300},      100, EnabledList{1},    ExpectedList{100}),
+    std::make_tuple(BitrateList{300},      600, EnabledList{1},    ExpectedList{300}),
 
-    std::make_tuple(MaxList{300, 300}, 300, EnabledList{1, 0}, ExpectedList{300, -1}),
-    std::make_tuple(MaxList{300, 300}, 300, EnabledList{0, 1}, ExpectedList{-1, 300}),
-    std::make_tuple(MaxList{300, 300}, 300, EnabledList{1, 1}, ExpectedList{150, 150}),
-    std::make_tuple(MaxList{100, 300}, 300, EnabledList{1, 1}, ExpectedList{100, 200}),
-    std::make_tuple(MaxList{300, 100}, 300, EnabledList{1, 1}, ExpectedList{200, 100}),
-    std::make_tuple(MaxList{100, 100}, 300, EnabledList{1, 1}, ExpectedList{100, 100}),
+    std::make_tuple(BitrateList{300, 300}, 300, EnabledList{1, 0}, ExpectedList{300, -1}),
+    std::make_tuple(BitrateList{300, 300}, 300, EnabledList{0, 1}, ExpectedList{-1, 300}),
+    std::make_tuple(BitrateList{300, 300}, 300, EnabledList{1, 1}, ExpectedList{150, 150}),
+    std::make_tuple(BitrateList{100, 300}, 300, EnabledList{1, 1}, ExpectedList{100, 200}),
+    std::make_tuple(BitrateList{300, 100}, 300, EnabledList{1, 1}, ExpectedList{200, 100}),
+    std::make_tuple(BitrateList{100, 100}, 300, EnabledList{1, 1}, ExpectedList{100, 100}),
 
-    std::make_tuple(MaxList{300, 300, 300}, 300, EnabledList{1, 0, 0}, ExpectedList{300,  -1, -1}),
-    std::make_tuple(MaxList{300, 300, 300}, 300, EnabledList{0, 1, 0}, ExpectedList{ -1, 300, -1}),
-    std::make_tuple(MaxList{300, 300, 300}, 300, EnabledList{1, 1, 0}, ExpectedList{150, 150, -1}),
-    std::make_tuple(MaxList{100, 300, 300}, 300, EnabledList{1, 1, 0}, ExpectedList{100, 200, -1}),
-    std::make_tuple(MaxList{300, 100, 300}, 300, EnabledList{1, 1, 0}, ExpectedList{200, 100, -1}),
-    std::make_tuple(MaxList{100, 100, 300}, 300, EnabledList{1, 1, 0}, ExpectedList{100, 100, -1}),
+    std::make_tuple(BitrateList{300, 300, 300}, 300, EnabledList{1, 0, 0}, ExpectedList{300,  -1, -1}),
+    std::make_tuple(BitrateList{300, 300, 300}, 300, EnabledList{0, 1, 0}, ExpectedList{ -1, 300, -1}),
+    std::make_tuple(BitrateList{300, 300, 300}, 300, EnabledList{1, 1, 0}, ExpectedList{150, 150, -1}),
+    std::make_tuple(BitrateList{100, 300, 300}, 300, EnabledList{1, 1, 0}, ExpectedList{100, 200, -1}),
+    std::make_tuple(BitrateList{300, 100, 300}, 300, EnabledList{1, 1, 0}, ExpectedList{200, 100, -1}),
+    std::make_tuple(BitrateList{100, 100, 300}, 300, EnabledList{1, 1, 0}, ExpectedList{100, 100, -1}),
 
-    std::make_tuple(MaxList{300, 300, 300}, 300, EnabledList{0, 1, 0}, ExpectedList{-1, 300,  -1}),
-    std::make_tuple(MaxList{300, 300, 300}, 300, EnabledList{0, 0, 1}, ExpectedList{-1,  -1, 300}),
-    std::make_tuple(MaxList{300, 300, 300}, 300, EnabledList{0, 1, 1}, ExpectedList{-1, 150, 150}),
-    std::make_tuple(MaxList{300, 100, 300}, 300, EnabledList{0, 1, 1}, ExpectedList{-1, 100, 200}),
-    std::make_tuple(MaxList{300, 300, 100}, 300, EnabledList{0, 1, 1}, ExpectedList{-1, 200, 100}),
-    std::make_tuple(MaxList{300, 100, 100}, 300, EnabledList{0, 1, 1}, ExpectedList{-1, 100, 100}),
+    std::make_tuple(BitrateList{300, 300, 300}, 300, EnabledList{0, 1, 0}, ExpectedList{-1, 300,  -1}),
+    std::make_tuple(BitrateList{300, 300, 300}, 300, EnabledList{0, 0, 1}, ExpectedList{-1,  -1, 300}),
+    std::make_tuple(BitrateList{300, 300, 300}, 300, EnabledList{0, 1, 1}, ExpectedList{-1, 150, 150}),
+    std::make_tuple(BitrateList{300, 100, 300}, 300, EnabledList{0, 1, 1}, ExpectedList{-1, 100, 200}),
+    std::make_tuple(BitrateList{300, 300, 100}, 300, EnabledList{0, 1, 1}, ExpectedList{-1, 200, 100}),
+    std::make_tuple(BitrateList{300, 100, 100}, 300, EnabledList{0, 1, 1}, ExpectedList{-1, 100, 100}),
 
-    std::make_tuple(MaxList{100, 100, 100}, 300, EnabledList{1, 1, 1}, ExpectedList{100, 100, 100}),
-    std::make_tuple(MaxList{100, 100, 100}, 600, EnabledList{1, 1, 1}, ExpectedList{100, 100, 100}),
-    std::make_tuple(MaxList{300, 300, 300}, 600, EnabledList{1, 1, 1}, ExpectedList{200, 200, 200}),
-    std::make_tuple(MaxList{100, 200, 300}, 600, EnabledList{1, 1, 1}, ExpectedList{100, 200, 300}),
-    std::make_tuple(MaxList{300, 200, 100}, 600, EnabledList{1, 1, 1}, ExpectedList{300, 200, 100}),
-    std::make_tuple(MaxList{100, 500, 500}, 800, EnabledList{1, 1, 1}, ExpectedList{100, 350, 350})));
+    std::make_tuple(BitrateList{100, 100, 100}, 300, EnabledList{1, 1, 1}, ExpectedList{100, 100, 100}),
+    std::make_tuple(BitrateList{100, 100, 100}, 600, EnabledList{1, 1, 1}, ExpectedList{100, 100, 100}),
+    std::make_tuple(BitrateList{300, 300, 300}, 600, EnabledList{1, 1, 1}, ExpectedList{200, 200, 200}),
+    std::make_tuple(BitrateList{100, 200, 300}, 600, EnabledList{1, 1, 1}, ExpectedList{100, 200, 300}),
+    std::make_tuple(BitrateList{300, 200, 100}, 600, EnabledList{1, 1, 1}, ExpectedList{300, 200, 100}),
+    std::make_tuple(BitrateList{100, 500, 500}, 800, EnabledList{1, 1, 1}, ExpectedList{100, 350, 350})));

--- a/erizo/src/test/rtp/RtpPaddingGeneratorHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpPaddingGeneratorHandlerTest.cpp
@@ -42,22 +42,11 @@ class RtpPaddingGeneratorHandlerTest : public erizo::HandlerTest {
 
  protected:
   void setHandler() {
-    EXPECT_CALL(*processor.get(), getMaxVideoBW()).Times(AtLeast(0));
-    EXPECT_CALL(*quality_manager.get(), isPaddingEnabled()).Times(AtLeast(0));
     clock = std::make_shared<erizo::SimulatedClock>();
     padding_generator_handler = std::make_shared<RtpPaddingGeneratorHandler>(clock);
     pipeline->addBack(padding_generator_handler);
-
-    stats->getNode()[erizo::kVideoSsrc].insertStat("bitrateCalculated",
-            MovingIntervalRateStat{std::chrono::milliseconds(100), 10, 1., clock});
-    stats->getNode()["total"].insertStat("senderBitrateEstimation",
-            MovingIntervalRateStat{std::chrono::milliseconds(100), 10, 1., clock});
-
-    EXPECT_CALL(*quality_manager.get(), isPaddingEnabled()).WillRepeatedly(Return(true));
-
-    EXPECT_CALL(*processor.get(), getMaxVideoBW()).WillRepeatedly(Return(100000));
-    stats->getNode()[erizo::kVideoSsrc]["bitrateCalculated"]       += 40000 * 2 / 10;
-    stats->getNode()["total"]["senderBitrateEstimation"] += 60000 * 2 / 10;
+    EXPECT_CALL(*media_stream.get(), getTargetPaddingBitrate()).WillRepeatedly(Return(0));
+    EXPECT_CALL(*media_stream.get(), isSlideShowModeEnabled()).WillRepeatedly(Return(false));
   }
 
   std::shared_ptr<RtpPaddingGeneratorHandler> padding_generator_handler;
@@ -83,6 +72,9 @@ TEST_F(RtpPaddingGeneratorHandlerTest, basicBehaviourShouldWritePackets) {
 TEST_F(RtpPaddingGeneratorHandlerTest, shouldSendPaddingWhenEnabled) {
   EXPECT_CALL(*writer.get(), write(_, _)).Times(AtLeast(3));
 
+  EXPECT_CALL(*media_stream.get(), getTargetPaddingBitrate()).WillRepeatedly(Return(uint64_t(10000)));
+  pipeline->notifyUpdate();
+
   pipeline->write(erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber, true, true));
 
   clock->advanceTime(std::chrono::milliseconds(200));
@@ -91,7 +83,7 @@ TEST_F(RtpPaddingGeneratorHandlerTest, shouldSendPaddingWhenEnabled) {
 
 TEST_F(RtpPaddingGeneratorHandlerTest, shouldNotSendPaddingWhenDisabled) {
   EXPECT_CALL(*writer.get(), write(_, _)).Times(2);
-  EXPECT_CALL(*quality_manager.get(), isPaddingEnabled()).WillRepeatedly(Return(false));
+  EXPECT_CALL(*media_stream.get(), getTargetPaddingBitrate()).WillRepeatedly(Return(0));
   pipeline->notifyUpdate();
 
   pipeline->write(erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber, true, true));
@@ -102,26 +94,11 @@ TEST_F(RtpPaddingGeneratorHandlerTest, shouldNotSendPaddingWhenDisabled) {
 
 TEST_F(RtpPaddingGeneratorHandlerTest, shouldNotSendPaddingAfterNotMarkers) {
   EXPECT_CALL(*writer.get(), write(_, _)).Times(2);
+  EXPECT_CALL(*media_stream.get(), getTargetPaddingBitrate()).WillRepeatedly(Return(uint64_t(10000)));
+  pipeline->notifyUpdate();
 
-  pipeline->write(erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber, true, true));
+  pipeline->write(erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber, true, false));
 
   clock->advanceTime(std::chrono::milliseconds(200));
   pipeline->write(erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber + 1, true, false));
-}
-
-TEST_F(RtpPaddingGeneratorHandlerTest, shouldNotSendPaddingIfBitrateIsHigherThanBitrateEstimation) {
-  const uint32_t kFractionLost = .1 * 255;
-  EXPECT_CALL(*writer.get(), write(_, _)).Times(2);
-
-  stats->getNode()[erizo::kVideoSsrc]["bitrateCalculated"] += 70000;
-  stats->getNode()["total"]["senderBitrateEstimation"]     += 60000;
-
-  pipeline->read(erizo::PacketTools::createReceiverReport(erizo::kAudioSsrc, erizo::kAudioSsrc,
-                                                          erizo::kArbitrarySeqNumber, VIDEO_PACKET, 0, kFractionLost));
-
-  pipeline->write(erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber, true, true));
-
-  clock->advanceTime(std::chrono::milliseconds(1000));
-
-  pipeline->write(erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber + 1, true, true));
 }

--- a/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
@@ -1,0 +1,239 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <rtp/RtpPaddingManagerHandler.h>
+#include <rtp/RtpHeaders.h>
+#include <MediaDefinitions.h>
+#include <WebRtcConnection.h>
+#include <stats/StatNode.h>
+#include <Stats.h>
+
+#include <queue>
+#include <string>
+#include <vector>
+
+#include "../utils/Mocks.h"
+#include "../utils/Tools.h"
+#include "../utils/Matchers.h"
+
+using ::testing::_;
+using ::testing::IsNull;
+using ::testing::Args;
+using ::testing::Return;
+using ::testing::AtLeast;
+using erizo::DataPacket;
+using erizo::packetType;
+using erizo::AUDIO_PACKET;
+using erizo::VIDEO_PACKET;
+using erizo::MovingIntervalRateStat;
+using erizo::IceConfig;
+using erizo::RtpMap;
+using erizo::RtpPaddingManagerHandler;
+using erizo::WebRtcConnection;
+using erizo::Pipeline;
+using erizo::InboundHandler;
+using erizo::OutboundHandler;
+using erizo::CumulativeStat;
+using erizo::Worker;
+using std::queue;
+using erizo::MediaStream;
+
+
+
+class RtpPaddingManagerHandlerBaseTest : public erizo::BaseHandlerTest {
+ public:
+  RtpPaddingManagerHandlerBaseTest() {}
+
+ protected:
+  void internalSetHandler() {
+    clock = std::make_shared<erizo::SimulatedClock>();
+    padding_calculator_handler = std::make_shared<RtpPaddingManagerHandler>(clock);
+    pipeline->addBack(padding_calculator_handler);
+  }
+
+  void whenSubscribersWithTargetBitrate(std::vector<uint32_t> subscriber_bitrates) {
+    int i = 0;
+    std::for_each(subscriber_bitrates.begin(), subscriber_bitrates.end(), [this, &i](uint32_t bitrate) {
+      addMediaStreamToConnection("sub" + std::to_string(i), false, bitrate);
+      simulated_worker->executeTasks();
+      i++;
+    });
+  }
+
+  void whenPublishers(uint num_publishers) {
+    for (uint i = 0; i < num_publishers; i++) {
+      addMediaStreamToConnection("pub" + std::to_string(i), true, 0);
+      simulated_worker->executeTasks();
+    }
+  }
+
+  void whenBandwidthEstimationIs(uint32_t bitrate) {
+    stats->getNode()["total"].insertStat("senderBitrateEstimation", CumulativeStat{bitrate});
+  }
+
+  void whenCurrentTotalVideoBitrateIs(uint32_t bitrate) {
+    stats->getNode()["total"].insertStat("videoBitrate", CumulativeStat{bitrate});
+  }
+
+  void internalTearDown() {
+    std::for_each(subscribers.begin(), subscribers.end(),
+      [this](const std::shared_ptr<erizo::MockMediaStream> &stream) {
+        connection->removeMediaStream(stream->getId());
+      });
+    std::for_each(publishers.begin(), publishers.end(),
+      [this](const std::shared_ptr<erizo::MockMediaStream> &stream) {
+        connection->removeMediaStream(stream->getId());
+      });
+    simulated_worker->executeTasks();
+  }
+
+  std::shared_ptr<erizo::MockMediaStream> addMediaStreamToConnection(std::string id,
+      bool is_publisher, uint32_t bitrate) {
+    auto media_stream =
+      std::make_shared<erizo::MockMediaStream>(simulated_worker, connection, id, id, rtp_maps, is_publisher);
+    std::shared_ptr<erizo::MediaStream> stream_ptr = std::dynamic_pointer_cast<erizo::MediaStream>(media_stream);
+    connection->addMediaStream(stream_ptr);
+    EXPECT_CALL(*media_stream.get(), getTargetVideoBitrate()).WillRepeatedly(Return(bitrate));
+    if (is_publisher) {
+      publishers.push_back(media_stream);
+    } else {
+      subscribers.push_back(media_stream);
+    }
+
+    return media_stream;
+  }
+
+  void expectPaddingBitrate(uint32_t bitrate) {
+    std::for_each(subscribers.begin(), subscribers.end(),
+      [bitrate](const std::shared_ptr<erizo::MockMediaStream> &stream) {
+        EXPECT_CALL(*stream.get(), setTargetPaddingBitrate(_)).With(Args<0>(bitrate)).Times(1);
+      });
+
+    std::for_each(publishers.begin(), publishers.end(),
+      [bitrate](const std::shared_ptr<erizo::MockMediaStream> &stream) {
+        EXPECT_CALL(*stream.get(), setTargetPaddingBitrate(_)).Times(0);
+      });
+  }
+
+  std::vector<std::shared_ptr<erizo::MockMediaStream>> subscribers;
+  std::vector<std::shared_ptr<erizo::MockMediaStream>> publishers;
+  std::shared_ptr<RtpPaddingManagerHandler> padding_calculator_handler;
+  std::shared_ptr<erizo::SimulatedClock> clock;
+};
+
+class RtpPaddingManagerHandlerTest : public ::testing::Test, public RtpPaddingManagerHandlerBaseTest {
+ public:
+  RtpPaddingManagerHandlerTest() {}
+
+  void setHandler() override {
+    internalSetHandler();
+  }
+
+ protected:
+  virtual void SetUp() {
+    internalSetUp();
+  }
+
+  void TearDown() override {
+    internalTearDown();
+  }
+};
+
+TEST_F(RtpPaddingManagerHandlerTest, basicBehaviourShouldReadPackets) {
+  auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+  EXPECT_CALL(*reader.get(), read(_, _)).
+    With(Args<1>(erizo::RtpHasSequenceNumber(erizo::kArbitrarySeqNumber))).Times(1);
+  pipeline->read(packet);
+}
+
+TEST_F(RtpPaddingManagerHandlerTest, basicBehaviourShouldWritePackets) {
+  auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+  EXPECT_CALL(*writer.get(), write(_, _)).
+    With(Args<1>(erizo::RtpHasSequenceNumber(erizo::kArbitrarySeqNumber))).Times(1);
+  pipeline->write(packet);
+}
+
+TEST_F(RtpPaddingManagerHandlerTest, shouldDistributePaddingEvenlyAmongStreamsWithoutPublishers) {
+  auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+  whenSubscribersWithTargetBitrate({200, 200, 200, 200, 200});
+  whenPublishers(0);
+  whenBandwidthEstimationIs(600);
+  whenCurrentTotalVideoBitrateIs(100);
+
+  expectPaddingBitrate(100);
+
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+}
+
+typedef std::vector<uint32_t> SubscriberBitratesList;
+
+class RtpPaddingManagerHandlerTestWithParam : public RtpPaddingManagerHandlerBaseTest,
+  public ::testing::TestWithParam<std::tr1::tuple<SubscriberBitratesList, uint32_t, uint32_t, uint32_t>> {
+ public:
+  RtpPaddingManagerHandlerTestWithParam() {
+    subscribers = std::tr1::get<0>(GetParam());
+    bw_estimation = std::tr1::get<1>(GetParam());
+    video_bitrate = std::tr1::get<2>(GetParam());
+    expected_padding_bitrate = std::tr1::get<3>(GetParam());
+  }
+
+ protected:
+  void setHandler() override {
+    internalSetHandler();
+  }
+
+  virtual void SetUp() {
+    internalSetUp();
+  }
+
+  void TearDown() override {
+    internalTearDown();
+  }
+
+  SubscriberBitratesList subscribers;
+  uint32_t bw_estimation;
+  uint32_t video_bitrate;
+  uint32_t expected_padding_bitrate;
+};
+
+TEST_P(RtpPaddingManagerHandlerTestWithParam, shouldDistributePaddingWithPublishers) {
+  auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+  whenSubscribersWithTargetBitrate(subscribers);
+  whenPublishers(10);
+  whenBandwidthEstimationIs(bw_estimation);
+  whenCurrentTotalVideoBitrateIs(video_bitrate);
+
+  expectPaddingBitrate(expected_padding_bitrate);
+
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+}
+
+TEST_P(RtpPaddingManagerHandlerTestWithParam, shouldDistributePaddingWithNoPublishers) {
+  auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+  whenSubscribersWithTargetBitrate(subscribers);
+  whenPublishers(0);
+  whenBandwidthEstimationIs(bw_estimation);
+  whenCurrentTotalVideoBitrateIs(video_bitrate);
+
+  expectPaddingBitrate(expected_padding_bitrate);
+
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+}
+
+INSTANTIATE_TEST_CASE_P(
+  Padding_values, RtpPaddingManagerHandlerTestWithParam, testing::Values(
+    //                                          targetBitrates,       bwe, bitrate, expectedPaddingBitrate
+    std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200},  600,     100,                    100),
+    std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200}, 1500,     100,                      0),
+    std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200},   99,     100,                      0),
+    std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200},  600,     600,                      0),
+    std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200},    0,     100,                      0),
+    std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200}, 1200,       0,                    200)));

--- a/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
@@ -106,7 +106,7 @@ class RtpPaddingManagerHandlerBaseTest : public erizo::BaseHandlerTest {
   void expectPaddingBitrate(uint64_t bitrate) {
     std::for_each(subscribers.begin(), subscribers.end(),
       [bitrate](const std::shared_ptr<erizo::MockMediaStream> &stream) {
-        EXPECT_CALL(*stream.get(), setTargetPaddingBitrate(_)).With(Args<0>(bitrate)).Times(1);
+        EXPECT_CALL(*stream.get(), setTargetPaddingBitrate(testing::Eq(bitrate))).Times(1);
       });
 
     std::for_each(publishers.begin(), publishers.end(),

--- a/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
@@ -103,7 +103,7 @@ class RtpPaddingManagerHandlerBaseTest : public erizo::BaseHandlerTest {
     return media_stream;
   }
 
-  void expectPaddingBitrate(uint32_t bitrate) {
+  void expectPaddingBitrate(uint64_t bitrate) {
     std::for_each(subscribers.begin(), subscribers.end(),
       [bitrate](const std::shared_ptr<erizo::MockMediaStream> &stream) {
         EXPECT_CALL(*stream.get(), setTargetPaddingBitrate(_)).With(Args<0>(bitrate)).Times(1);
@@ -172,7 +172,7 @@ TEST_F(RtpPaddingManagerHandlerTest, shouldDistributePaddingEvenlyAmongStreamsWi
 typedef std::vector<uint32_t> SubscriberBitratesList;
 
 class RtpPaddingManagerHandlerTestWithParam : public RtpPaddingManagerHandlerBaseTest,
-  public ::testing::TestWithParam<std::tr1::tuple<SubscriberBitratesList, uint32_t, uint32_t, uint32_t>> {
+  public ::testing::TestWithParam<std::tr1::tuple<SubscriberBitratesList, uint32_t, uint32_t, uint64_t>> {
  public:
   RtpPaddingManagerHandlerTestWithParam() {
     subscribers = std::tr1::get<0>(GetParam());
@@ -197,7 +197,7 @@ class RtpPaddingManagerHandlerTestWithParam : public RtpPaddingManagerHandlerBas
   SubscriberBitratesList subscribers;
   uint32_t bw_estimation;
   uint32_t video_bitrate;
-  uint32_t expected_padding_bitrate;
+  uint64_t expected_padding_bitrate;
 };
 
 TEST_P(RtpPaddingManagerHandlerTestWithParam, shouldDistributePaddingWithPublishers) {

--- a/erizo/src/test/utils/Mocks.h
+++ b/erizo/src/test/utils/Mocks.h
@@ -116,10 +116,17 @@ class MockMediaStream: public MediaStream {
   MOCK_METHOD0(isSimulcast, bool());
   MOCK_METHOD2(onTransportData, void(std::shared_ptr<DataPacket>, Transport*));
   MOCK_METHOD1(deliverEventInternal, void(MediaEventPtr));
+  MOCK_METHOD0(getTargetPaddingBitrate, uint64_t());
+  MOCK_METHOD1(setTargetPaddingBitrate, void(uint64_t));
+  MOCK_METHOD0(getTargetVideoBitrate, uint32_t());
 
   int deliverEvent_(MediaEventPtr event) override {
     deliverEventInternal(event);
     return 0;
+  }
+
+  uint32_t MediaStream_getTargetVideoBitrate() {
+    return MediaStream::getTargetVideoBitrate();
   }
 };
 

--- a/erizo/src/test/utils/Tools.h
+++ b/erizo/src/test/utils/Tools.h
@@ -316,6 +316,7 @@ class BaseHandlerTest  {
 
     std::shared_ptr<erizo::WebRtcConnection> connection_ptr = std::dynamic_pointer_cast<WebRtcConnection>(connection);
     std::shared_ptr<erizo::MediaStream> stream_ptr = std::dynamic_pointer_cast<MediaStream>(media_stream);
+    pipeline->addService(connection_ptr);
     pipeline->addService(stream_ptr);
     pipeline->addService(std::dynamic_pointer_cast<RtcpProcessor>(processor));
     pipeline->addService(std::dynamic_pointer_cast<QualityManager>(quality_manager));

--- a/erizo_controller/erizoAgent/log4cxx.properties
+++ b/erizo_controller/erizoAgent/log4cxx.properties
@@ -70,4 +70,5 @@ log4j.logger.rtp.StatsCalculator=WARN
 log4j.logger.rtp.LayerDetectorHandler=WARN
 log4j.logger.rtp.PliPacerHandler=WARN
 log4j.logger.rtp.RtpPaddingGeneratorHandler=WARN
+log4j.logger.rtp.RtpPaddingManagerHandler=WARN
 log4j.logger.rtp.PacketCodecParser=WARN

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -101,7 +101,7 @@ const startBasicExample = () => {
     req.send(JSON.stringify(roomData));
   };
 
-  const roomData = { username: 'user' + parseInt(Math.random() * 100),
+  const roomData = { username: `user ${parseInt(Math.random() * 100, 10)}`,
     role: 'presenter',
     room: roomName,
     type: roomType,

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -101,7 +101,7 @@ const startBasicExample = () => {
     req.send(JSON.stringify(roomData));
   };
 
-  const roomData = { username: 'user',
+  const roomData = { username: 'user' + parseInt(Math.random() * 100),
     role: 'presenter',
     room: roomName,
     type: roomType,


### PR DESCRIPTION
**Description**

I'm moving the logic that decides whether to enable or disable padding to the WebRtcConnection. It will also decide how much bitrate will be used and will distribute it among the subscribed streams in the same single peer connection.

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.