### PR TITLE
Fix arguments for removeSubscriber in removeSubscriptions

### DIFF
--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -847,7 +847,7 @@ class Client extends events.EventEmitter {
     log.info(`message: removeSubscriptions, clientId: ${this.id}`);
     this.room.streamManager.forEachPublishedStream((stream) => {
       if (stream.hasAvSubscriber(this.id)) {
-        this.room.controller.removeSubscriber(stream.id, this.id);
+        this.room.controller.removeSubscriber(this.id, stream.id);
         stream.removeAvSubscriber(this.id);
       }
     });


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR fixes an issue that caused removeSubscriptions not to work. The parameters were in the wrong order.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.