### PR TITLE
Implement Pli Priority Handler

### DIFF
--- a/erizo/src/erizo/MediaDefinitions.h
+++ b/erizo/src/erizo/MediaDefinitions.h
@@ -20,24 +20,31 @@ enum packetType {
     OTHER_PACKET
 };
 
+enum packetPriority {
+  HIGH_PRIORITY,
+  LOW_PRIORITY
+};
+
 struct DataPacket {
   DataPacket() = default;
 
   DataPacket(int comp_, const char *data_, int length_, packetType type_, uint64_t received_time_ms_) :
-    comp{comp_}, length{length_}, type{type_}, received_time_ms{received_time_ms_}, is_keyframe{false},
-    ending_of_layer_frame{false}, picture_id{-1}, tl0_pic_idx{-1} {
+    comp{comp_}, length{length_}, type{type_}, priority{HIGH_PRIORITY}, received_time_ms{received_time_ms_},
+    is_keyframe{false}, ending_of_layer_frame{false}, picture_id{-1}, tl0_pic_idx{-1} {
       memcpy(data, data_, length_);
   }
 
   DataPacket(int comp_, const char *data_, int length_, packetType type_) :
-    comp{comp_}, length{length_}, type{type_}, received_time_ms{ClockUtils::timePointToMs(clock::now())},
-    is_keyframe{false}, ending_of_layer_frame{false}, picture_id{-1}, tl0_pic_idx{-1} {
+    comp{comp_}, length{length_}, type{type_}, priority{HIGH_PRIORITY},
+    received_time_ms{ClockUtils::timePointToMs(clock::now())}, is_keyframe{false},
+    ending_of_layer_frame{false}, picture_id{-1}, tl0_pic_idx{-1} {
       memcpy(data, data_, length_);
   }
 
   DataPacket(int comp_, const unsigned char *data_, int length_) :
-    comp{comp_}, length{length_}, type{VIDEO_PACKET}, received_time_ms{ClockUtils::timePointToMs(clock::now())},
-    is_keyframe{false}, ending_of_layer_frame{false}, picture_id{-1}, tl0_pic_idx{-1} {
+    comp{comp_}, length{length_}, type{VIDEO_PACKET}, priority{HIGH_PRIORITY},
+    received_time_ms{ClockUtils::timePointToMs(clock::now())}, is_keyframe{false}, ending_of_layer_frame{false},
+    picture_id{-1}, tl0_pic_idx{-1} {
       memcpy(data, data_, length_);
   }
 
@@ -61,6 +68,7 @@ struct DataPacket {
   char data[1500];
   int length;
   packetType type;
+  packetPriority priority;
   uint64_t received_time_ms;
   std::vector<int> compatible_spatial_layers;
   std::vector<int> compatible_temporal_layers;

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -34,6 +34,7 @@
 #include "rtp/LayerBitrateCalculationHandler.h"
 #include "rtp/QualityFilterHandler.h"
 #include "rtp/QualityManager.h"
+#include "rtp/PliPriorityHandler.h"
 #include "rtp/PliPacerHandler.h"
 #include "rtp/RtpPaddingGeneratorHandler.h"
 #include "rtp/RtpUtils.h"
@@ -396,6 +397,7 @@ void MediaStream::initializePipeline() {
   pipeline_->addFront(std::make_shared<RtpTrackMuteHandler>());
   pipeline_->addFront(std::make_shared<RtpSlideShowHandler>());
   pipeline_->addFront(std::make_shared<RtpPaddingGeneratorHandler>());
+  pipeline_->addFront(std::make_shared<PliPriorityHandler>());
   pipeline_->addFront(std::make_shared<PliPacerHandler>());
   pipeline_->addFront(std::make_shared<RtpPaddingRemovalHandler>());
   pipeline_->addFront(std::make_shared<BandwidthEstimationHandler>());

--- a/erizo/src/erizo/rtp/PliPacerHandler.cpp
+++ b/erizo/src/erizo/rtp/PliPacerHandler.cpp
@@ -76,8 +76,10 @@ void PliPacerHandler::scheduleNextPLI() {
 void PliPacerHandler::write(Context *ctx, std::shared_ptr<DataPacket> packet) {
   if (enabled_ && RtpUtils::isPLI(packet)) {
     if (waiting_for_keyframe_) {
+      ELOG_DEBUG("%s, message: Discarding PLI - waiting for keyframe %d", stream_->toLog(), packet->priority);
       return;
     }
+    ELOG_DEBUG("%s, message: Sending and scheduling PLI, priority %d", stream_->toLog(), packet->priority);
     waiting_for_keyframe_ = true;
     scheduleNextPLI();
   }

--- a/erizo/src/erizo/rtp/PliPriorityHandler.cpp
+++ b/erizo/src/erizo/rtp/PliPriorityHandler.cpp
@@ -1,0 +1,86 @@
+#include "rtp/PliPriorityHandler.h"
+
+#include "rtp/RtpUtils.h"
+#include "./MediaDefinitions.h"
+#include "./MediaStream.h"
+
+namespace erizo {
+
+DEFINE_LOGGER(PliPriorityHandler, "rtp.PliPriorityHandler");
+
+constexpr duration PliPriorityHandler::kLowPriorityPliPeriod;
+
+PliPriorityHandler::PliPriorityHandler(std::shared_ptr<erizo::Clock> the_clock)
+    : enabled_{true}, stream_{nullptr}, clock_{the_clock},
+      video_sink_ssrc_{0}, video_source_ssrc_{0}, plis_received_in_interval_{0}, first_received_{false} {}
+
+void PliPriorityHandler::enable() {
+  enabled_ = true;
+}
+
+void PliPriorityHandler::disable() {
+  enabled_ = false;
+}
+
+void PliPriorityHandler::notifyUpdate() {
+  auto pipeline = getContext()->getPipelineShared();
+  if (pipeline && !stream_) {
+    stream_ = pipeline->getService<MediaStream>().get();
+    video_sink_ssrc_ = stream_->getVideoSinkSSRC();
+    video_source_ssrc_ = stream_->getVideoSourceSSRC();
+  }
+}
+
+void PliPriorityHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet) {
+  ctx->fireRead(std::move(packet));
+}
+
+void PliPriorityHandler::write(Context *ctx, std::shared_ptr<DataPacket> packet) {
+  if (enabled_ && RtpUtils::isPLI(packet)) {
+    if (packet->priority == LOW_PRIORITY) {
+      if (!first_received_) {
+        ELOG_DEBUG("%s, message: First PLI received - sending it, %d", stream_->toLog(), packet->priority);
+        first_received_ = true;
+        sendPLI();
+        schedulePeriodicPlis();
+        return;
+      }
+      plis_received_in_interval_++;
+      ELOG_DEBUG("%s, message: Accounting received PLI, priority %d, total %u",
+          stream_->toLog(), packet->priority, plis_received_in_interval_);
+      return;
+    }
+  }
+  ctx->fireWrite(std::move(packet));
+}
+
+void PliPriorityHandler::sendPLI() {
+  getContext()->fireWrite(RtpUtils::createPLI(video_source_ssrc_, video_sink_ssrc_, LOW_PRIORITY));
+}
+
+void PliPriorityHandler::schedulePeriodicPlis() {
+  if (!enabled_) {
+    return;
+  }
+  ELOG_INFO("%s, message: Starting low priority plis scheduler, plis_received_in_interval_: %u",
+      stream_->toLog(), plis_received_in_interval_);
+  std::weak_ptr<PliPriorityHandler> weak_this = shared_from_this();
+  stream_->getWorker()->scheduleEvery([weak_this] {
+    if (auto this_ptr = weak_this.lock()) {
+      if (this_ptr->plis_received_in_interval_ > 0) {
+        ELOG_DEBUG("%s, message: Sending Low priority PLI, plis_received_in_interval_: %u",
+            this_ptr->stream_->toLog(), this_ptr->plis_received_in_interval_);
+        this_ptr->plis_received_in_interval_ = 0;
+        this_ptr->sendPLI();
+        return true;
+      } else {
+        ELOG_DEBUG("%s, message: No Low priority Plis to send, plis_received_in_interval_: %u",
+            this_ptr->stream_->toLog(), this_ptr->plis_received_in_interval_);
+        return true;
+      }
+    }
+    return false;
+  }, kLowPriorityPliPeriod);
+}
+}  // namespace erizo
+

--- a/erizo/src/erizo/rtp/PliPriorityHandler.h
+++ b/erizo/src/erizo/rtp/PliPriorityHandler.h
@@ -1,0 +1,52 @@
+#ifndef ERIZO_SRC_ERIZO_RTP_PLIPRIORITYHANDLER_H_
+#define ERIZO_SRC_ERIZO_RTP_PLIPRIORITYHANDLER_H_
+
+#include <string>
+
+#include "./logger.h"
+#include "pipeline/Handler.h"
+#include "thread/Worker.h"
+#include "lib/Clock.h"
+
+namespace erizo {
+
+class MediaStream;
+
+class PliPriorityHandler: public Handler, public std::enable_shared_from_this<PliPriorityHandler> {
+  DECLARE_LOGGER();
+
+ public:
+  static constexpr duration kLowPriorityPliPeriod = std::chrono::seconds(3);
+
+ public:
+  explicit PliPriorityHandler(std::shared_ptr<erizo::Clock> the_clock = std::make_shared<SteadyClock>());
+
+  void enable() override;
+  void disable() override;
+
+  std::string getName() override {
+    return "pli-priority";
+  }
+
+  void read(Context *ctx, std::shared_ptr<DataPacket> packet) override;
+  void write(Context *ctx, std::shared_ptr<DataPacket> packet) override;
+  void notifyUpdate() override;
+
+ private:
+  void schedulePeriodicPlis();
+  void sendPLI();
+
+ private:
+  bool enabled_;
+  MediaStream* stream_;
+  std::shared_ptr<erizo::Clock> clock_;
+  uint32_t video_sink_ssrc_;
+  uint32_t video_source_ssrc_;
+  uint32_t plis_received_in_interval_;
+  bool first_received_;
+};
+
+}  // namespace erizo
+
+#endif  // ERIZO_SRC_ERIZO_RTP_PLIPRIORITYHANDLER_H_
+

--- a/erizo/src/erizo/rtp/QualityFilterHandler.h
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.h
@@ -35,7 +35,7 @@ class QualityFilterHandler: public Handler, public std::enable_shared_from_this<
   void notifyUpdate() override;
 
  private:
-  void sendPLI();
+  void sendPLI(packetPriority priority = HIGH_PRIORITY);
   void checkLayers();
   void handleFeedbackPackets(const std::shared_ptr<DataPacket> &packet);
   bool checkSSRCChange(uint32_t ssrc);

--- a/erizo/src/erizo/rtp/RtpUtils.cpp
+++ b/erizo/src/erizo/rtp/RtpUtils.cpp
@@ -67,7 +67,8 @@ bool RtpUtils::isFIR(std::shared_ptr<DataPacket> packet) {
   return is_fir;
 }
 
-std::shared_ptr<DataPacket> RtpUtils::createPLI(uint32_t source_ssrc, uint32_t sink_ssrc) {
+std::shared_ptr<DataPacket> RtpUtils::createPLI(uint32_t source_ssrc, uint32_t sink_ssrc,
+    packetPriority priority) {
   RtcpHeader pli;
   pli.setPacketType(RTCP_PS_Feedback_PT);
   pli.setBlockCount(RTCP_PLI_FMT);
@@ -76,7 +77,9 @@ std::shared_ptr<DataPacket> RtpUtils::createPLI(uint32_t source_ssrc, uint32_t s
   pli.setLength(2);
   char *buf = reinterpret_cast<char*>(&pli);
   int len = (pli.getLength() + 1) * 4;
-  return std::make_shared<DataPacket>(0, buf, len, VIDEO_PACKET);
+  auto packet = std::make_shared<DataPacket>(0, buf, len, VIDEO_PACKET);
+  packet->priority = priority;
+  return packet;
 }
 
 std::shared_ptr<DataPacket> RtpUtils::createFIR(uint32_t source_ssrc, uint32_t sink_ssrc, uint8_t seq_number) {

--- a/erizo/src/erizo/rtp/RtpUtils.h
+++ b/erizo/src/erizo/rtp/RtpUtils.h
@@ -27,7 +27,8 @@ class RtpUtils {
 
   static void forEachNack(RtcpHeader *chead, std::function<void(uint16_t, uint16_t, RtcpHeader*)> f);
 
-  static std::shared_ptr<DataPacket> createPLI(uint32_t source_ssrc, uint32_t sink_ssrc);
+  static std::shared_ptr<DataPacket> createPLI(uint32_t source_ssrc, uint32_t sink_ssrc,
+      packetPriority priority = HIGH_PRIORITY);
 
   static std::shared_ptr<DataPacket> createFIR(uint32_t source_ssrc, uint32_t sink_ssrc, uint8_t seq_number);
   static std::shared_ptr<DataPacket> createREMB(uint32_t ssrc, std::vector<uint32_t> ssrc_list, uint32_t bitrate);

--- a/erizo/src/test/rtp/PliPriorityHandlerTest.cpp
+++ b/erizo/src/test/rtp/PliPriorityHandlerTest.cpp
@@ -1,0 +1,121 @@
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <rtp/PliPriorityHandler.h>
+#include <rtp/RtpHeaders.h>
+#include <MediaDefinitions.h>
+#include <WebRtcConnection.h>
+
+#include <queue>
+#include <string>
+#include <vector>
+
+#include "../utils/Mocks.h"
+#include "../utils/Tools.h"
+#include "../utils/Matchers.h"
+
+using ::testing::_;
+using ::testing::IsNull;
+using ::testing::Args;
+using ::testing::Return;
+using erizo::DataPacket;
+using erizo::packetType;
+using erizo::AUDIO_PACKET;
+using erizo::VIDEO_PACKET;
+using erizo::IceConfig;
+using erizo::RtpMap;
+using erizo::PliPriorityHandler;
+using erizo::SimulatedClock;
+using erizo::WebRtcConnection;
+using erizo::Pipeline;
+using erizo::InboundHandler;
+using erizo::OutboundHandler;
+using erizo::Worker;
+using std::queue;
+
+constexpr int kShortPeriodMs =
+  std::chrono::duration_cast<std::chrono::milliseconds>(PliPriorityHandler::kLowPriorityPliPeriod).count() / 3;
+
+constexpr int kLowPriorityPliPeriodMs =
+  std::chrono::duration_cast<std::chrono::milliseconds>(PliPriorityHandler::kLowPriorityPliPeriod).count();
+
+class PliPriorityHandlerTest : public erizo::HandlerTest {
+ public:
+  PliPriorityHandlerTest() {}
+
+ protected:
+  void setHandler() {
+    pli_priority_handler = std::make_shared<PliPriorityHandler>(simulated_clock);
+    pipeline->addBack(pli_priority_handler);
+  }
+
+  std::shared_ptr<PliPriorityHandler> pli_priority_handler;
+};
+
+TEST_F(PliPriorityHandlerTest, basicBehaviourShouldReadPackets) {
+    auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+    EXPECT_CALL(*reader.get(), read(_, _)).
+      With(Args<1>(erizo::RtpHasSequenceNumber(erizo::kArbitrarySeqNumber))).Times(1);
+    pipeline->read(packet);
+}
+
+TEST_F(PliPriorityHandlerTest, basicBehaviourShouldWritePackets) {
+    auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+    EXPECT_CALL(*writer.get(), write(_, _)).
+      With(Args<1>(erizo::RtpHasSequenceNumber(erizo::kArbitrarySeqNumber))).Times(1);
+    pipeline->write(packet);
+}
+
+TEST_F(PliPriorityHandlerTest, shouldSendTheFirstPLIInmediately) {
+    auto pli1 = erizo::PacketTools::createPLI(erizo::LOW_PRIORITY);
+
+    EXPECT_CALL(*writer.get(), write(_, _)).Times(1);
+    pipeline->write(pli1);
+}
+
+TEST_F(PliPriorityHandlerTest, shouldSendASinglePLIWhenReceivingSeveralInAShortPeriod) {
+    auto pli1 = erizo::PacketTools::createPLI(erizo::LOW_PRIORITY);
+    auto pli2 = erizo::PacketTools::createPLI(erizo::LOW_PRIORITY);
+    auto pli3 = erizo::PacketTools::createPLI(erizo::LOW_PRIORITY);
+    auto pli4 = erizo::PacketTools::createPLI(erizo::LOW_PRIORITY);
+
+    EXPECT_CALL(*writer.get(), write(_, _)).Times(2);
+    pipeline->write(pli1);
+    executeTasksInNextMs(kShortPeriodMs);
+    pipeline->write(pli2);
+    executeTasksInNextMs(kShortPeriodMs);
+    pipeline->write(pli3);
+    pipeline->write(pli4);
+    executeTasksInNextMs(kShortPeriodMs);
+}
+
+TEST_F(PliPriorityHandlerTest, shouldNotStopHighPriorityPlis) {
+    auto pli1 = erizo::PacketTools::createPLI(erizo::HIGH_PRIORITY);
+    auto pli2 = erizo::PacketTools::createPLI(erizo::HIGH_PRIORITY);
+    auto pli3 = erizo::PacketTools::createPLI(erizo::HIGH_PRIORITY);
+
+    EXPECT_CALL(*writer.get(), write(_, _)).Times(3);
+    pipeline->write(pli1);
+    executeTasksInNextMs(kShortPeriodMs);
+    pipeline->write(pli2);
+    executeTasksInNextMs(kShortPeriodMs);
+    pipeline->write(pli3);
+    executeTasksInNextMs(kShortPeriodMs);
+}
+
+TEST_F(PliPriorityHandlerTest, shouldAlwaysSendPLIsWhenDisabled) {
+    pli_priority_handler->disable();
+    auto pli1 = erizo::PacketTools::createPLI(erizo::LOW_PRIORITY);
+    auto pli2 = erizo::PacketTools::createPLI(erizo::LOW_PRIORITY);
+    auto pli3 = erizo::PacketTools::createPLI(erizo::LOW_PRIORITY);
+
+    EXPECT_CALL(*writer.get(), write(_, _)).Times(3);
+    pipeline->write(pli1);
+    executeTasksInNextMs(kShortPeriodMs);
+    pipeline->write(pli2);
+    executeTasksInNextMs(kShortPeriodMs);
+    pipeline->write(pli3);
+    executeTasksInNextMs(kShortPeriodMs);
+}

--- a/erizo/src/test/utils/Tools.h
+++ b/erizo/src/test/utils/Tools.h
@@ -263,7 +263,7 @@ class PacketTools {
     return packet;
   }
 
-  static std::shared_ptr<erizo::DataPacket> createPLI() {
+  static std::shared_ptr<erizo::DataPacket> createPLI(erizo::packetPriority priority = erizo::HIGH_PRIORITY) {
     erizo::RtcpHeader *pli = new erizo::RtcpHeader();
     pli->setPacketType(RTCP_PS_Feedback_PT);
     pli->setBlockCount(1);
@@ -273,6 +273,7 @@ class PacketTools {
     char *buf = reinterpret_cast<char*>(pli);
     int len = (pli->getLength() + 1) * 4;
     auto packet = std::make_shared<erizo::DataPacket>(0, buf, len, erizo::OTHER_PACKET);
+    packet->priority = priority;
     delete pli;
     return packet;
   }

--- a/erizo_controller/erizoAgent/log4cxx.properties
+++ b/erizo_controller/erizoAgent/log4cxx.properties
@@ -9,6 +9,7 @@ log4j.appender.A1.layout=org.apache.log4j.PatternLayout
 # Print the date in ISO 8601 format
 log4j.appender.A1.layout.ConversionPattern=%d  - %p [%t] %c - %m%n
 
+log4j.logger.ErizoAPI.OneToManyProcessor=DEBUG
 log4j.logger.ErizoAPI.WebRtcConnection=DEBUG
 log4j.logger.ErizoAPI.MediaStream=DEBUG
 
@@ -27,14 +28,13 @@ log4j.logger.WebRtcConnection=DEBUG
 log4j.logger.dtls.DtlsSocket=WARN
 log4j.logger.dtls.DtlsFactory=WARN
 log4j.logger.dtls.DtlsSocketContext=WARN
-log4j.logger.dtls.SSL=WARN
+log4j.logger.dtls.SSL=ERROR
 
 log4j.logger.media.ExternalInput=WARN
 log4j.logger.media.ExternalOutput=WARN
 log4j.logger.media.InputProcessor=WARN
 log4j.logger.media.OneToManyTranscoder=WARN
 log4j.logger.media.OutputProcessor=WARN
-
 
 log4j.logger.media.codecs.VideoEncoder=WARN
 log4j.logger.media.codecs.VideoDecoder=WARN
@@ -43,7 +43,6 @@ log4j.logger.media.codecs.AudioDecoder=WARN
 
 log4j.logger.media.mixers.VideoMixer=WARN
 log4j.logger.media.mixers.VideoUtils=WARN
-
 
 log4j.logger.rtp.PacketBufferService=WARN
 log4j.logger.rtp.QualityManager=WARN
@@ -69,5 +68,8 @@ log4j.logger.rtp.SenderBandwidthEstimationHandler=WARN
 log4j.logger.rtp.StatsCalculator=WARN
 log4j.logger.rtp.LayerDetectorHandler=WARN
 log4j.logger.rtp.PliPacerHandler=WARN
+log4j.logger.rtp.PliPriorityHandler=WARN
 log4j.logger.rtp.RtpPaddingGeneratorHandler=WARN
 log4j.logger.rtp.PacketCodecParser=WARN
+
+

--- a/erizo_controller/erizoAgent/log4cxx.properties
+++ b/erizo_controller/erizoAgent/log4cxx.properties
@@ -28,7 +28,7 @@ log4j.logger.WebRtcConnection=DEBUG
 log4j.logger.dtls.DtlsSocket=WARN
 log4j.logger.dtls.DtlsFactory=WARN
 log4j.logger.dtls.DtlsSocketContext=WARN
-log4j.logger.dtls.SSL=ERROR
+log4j.logger.dtls.SSL=WARN
 
 log4j.logger.media.ExternalInput=WARN
 log4j.logger.media.ExternalOutput=WARN


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR implements a handler that throttles PLI requests based on priority.
All PLI packets are marked with high or low priority. High priority PLIs go directly through the handler but low priority ones are throttled so only 1 is sent every 3 seconds.
Currently the only PLI packets that are marked as low priority are those requested when switching to a higher layer.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.