### PR TITLE
Add commit and public ip info to prometheus metrics

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           command: |
             echo Building lynckia/licode:develop
             SHORT_GIT_HASH="$(echo ${CIRCLE_SHA1} | cut -c -7)"
-            docker build --label COMMIT=${SHORT_GIT_HASH} --cache-from lynckia/licode:develop -t lynckia/licode:develop .
+            docker build --label COMMIT=${SHORT_GIT_HASH} --build-arg COMMIT=${SHORT_GIT_HASH} --cache-from lynckia/licode:develop -t lynckia/licode:develop .
 
       - run:
           name: Lint Erizo

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,9 @@ RUN ./installErizo.sh -dfeacs && \
 
 WORKDIR /opt/licode
 
-RUN cat ${SHORT_GIT_HASH} > RELEASE
+RUN cat $SHORT_GIT_HASH > RELEASE
 RUN date --rfc-3339='seconds' >> RELEASE
+RUN cat RELEASE
 
 WORKDIR /opt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN ./installErizo.sh -dfeacs && \
 
 WORKDIR /opt/licode
 
-RUN cat $SHORT_GIT_HASH > RELEASE
+RUN cat $COMMIT > RELEASE
 RUN date --rfc-3339='seconds' >> RELEASE
 RUN cat RELEASE
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,11 @@ RUN ./installErizo.sh -dfeacs && \
     ./../nuve/installNuve.sh && \
     ./installBasicExample.sh
 
+WORKDIR /opt/licode
+
+RUN cat ${SHORT_GIT_HASH} > RELEASE
+RUN date --rfc-3339='seconds' > RELEASE
+
 WORKDIR /opt
 
 ENTRYPOINT ["./licode/extras/docker/initDockerLicode.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER Lynckia
 
 WORKDIR /opt
 
+ARG COMMIT
+
 # Download latest version of the code and install dependencies
 RUN  apt-get update && apt-get install -y git wget curl
 
@@ -30,7 +32,7 @@ RUN ./installErizo.sh -dfeacs && \
 
 WORKDIR /opt/licode
 
-RUN cat $COMMIT > RELEASE
+RUN echo $COMMIT > RELEASE
 RUN date --rfc-3339='seconds' >> RELEASE
 RUN cat RELEASE
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN ./installErizo.sh -dfeacs && \
 WORKDIR /opt/licode
 
 RUN cat ${SHORT_GIT_HASH} > RELEASE
-RUN date --rfc-3339='seconds' > RELEASE
+RUN date --rfc-3339='seconds' >> RELEASE
 
 WORKDIR /opt
 

--- a/erizo_controller/ROV/rovMetricsGatherer.js
+++ b/erizo_controller/ROV/rovMetricsGatherer.js
@@ -1,5 +1,7 @@
 const readline = require('readline');
 const fs = require('fs');
+
+// eslint-disable-next-line global-require, import/no-extraneous-dependencies
 const AWS = require('aws-sdk');
 
 // eslint-disable-next-line import/no-unresolved

--- a/erizo_controller/ROV/rovMetricsGatherer.js
+++ b/erizo_controller/ROV/rovMetricsGatherer.js
@@ -12,7 +12,7 @@ class RovMetricsGatherer {
     this.rovClient = rovClient;
     this.prefix = statsPrefix;
     this.prometheusMetrics = {
-      release: new promClient.Gauge({ name: this.getNameWithPrefix('release_commit'), help: 'commit short hash', labelNames: ['commit', 'date', 'ip'] }),
+      release: new promClient.Gauge({ name: this.getNameWithPrefix('release_info'), help: 'commit short hash', labelNames: ['commit', 'date', 'ip'] }),
       activeRooms: new promClient.Gauge({ name: this.getNameWithPrefix('active_rooms'), help: 'active rooms in all erizoControllers' }),
       activeClients: new promClient.Gauge({ name: this.getNameWithPrefix('active_clients'), help: 'active clients in all erizoControllers' }),
       totalPublishers: new promClient.Gauge({ name: this.getNameWithPrefix('total_publishers'), help: 'total active publishers' }),

--- a/erizo_controller/ROV/rovMetricsGatherer.js
+++ b/erizo_controller/ROV/rovMetricsGatherer.js
@@ -1,8 +1,16 @@
+const readline = require('readline');
+const fs = require('fs');
+const AWS = require('aws-sdk');
+
+// eslint-disable-next-line import/no-unresolved
+const config = require('../../licode_config');
+
 class RovMetricsGatherer {
   constructor(rovClient, promClient, statsPrefix, logger) {
     this.rovClient = rovClient;
     this.prefix = statsPrefix;
     this.prometheusMetrics = {
+      release: new promClient.Gauge({ name: this.getNameWithPrefix('release_commit'), help: 'commit short hash', labelNames: ['commit', 'date', 'ip'] }),
       activeRooms: new promClient.Gauge({ name: this.getNameWithPrefix('active_rooms'), help: 'active rooms in all erizoControllers' }),
       activeClients: new promClient.Gauge({ name: this.getNameWithPrefix('active_clients'), help: 'active clients in all erizoControllers' }),
       totalPublishers: new promClient.Gauge({ name: this.getNameWithPrefix('total_publishers'), help: 'total active publishers' }),
@@ -21,10 +29,77 @@ class RovMetricsGatherer {
       totalSubscribersInErizoJS: new promClient.Gauge({ name: this.getNameWithPrefix('total_subscribers_erizojs'), help: 'total active subscribers in erizo js' }),
     };
     this.log = logger;
+    this.releaseInfoRead = false;
+    if (config && config.erizoAgent) {
+      this.publicIP = config.erizoAgent.publicIP;
+    }
   }
 
   getNameWithPrefix(name) {
     return `${this.prefix}${name}`;
+  }
+
+  getIP() {
+    // Here we assume that ROV runs in the same instance than Erizo Controller
+    if (config && config.cloudProvider && config.cloudProvider.name === 'amazon') {
+      return new Promise((resolve) => {
+        new AWS.MetadataService({
+          httpOptions: {
+            timeout: 5000,
+          },
+        }).request('/latest/meta-data/public-ipv4', (err, data) => {
+          if (err) {
+            this.log.error('Error: ', err);
+          } else {
+            this.publicIP = data;
+          }
+          resolve();
+        });
+      });
+    }
+    return Promise.resolve();
+  }
+
+  getReleaseInfo() {
+    this.log.debug('Getting release info');
+    if (!this.releaseInfoRead) {
+      this.releaseInfoRead = true;
+      try {
+        return new Promise((resolve) => {
+          const input = fs.createReadStream('../../RELEASE');
+
+          input.on('error', (e) => {
+            this.log.error('Error reading release file', e);
+            resolve();
+          });
+          const fileReader = readline.createInterface({
+            input,
+            output: process.stdout,
+            console: false,
+          });
+          let lineNumber = 0;
+          let releaseCommit = '';
+          let releaseDate = '';
+          fileReader.on('line', (line) => {
+            this.log.info(line);
+            if (lineNumber === 0) {
+              releaseCommit = line;
+            } else {
+              releaseDate = line;
+            }
+            lineNumber += 1;
+          });
+
+          fileReader.once('close', () => {
+            this.prometheusMetrics.release.labels(releaseCommit, releaseDate, this.publicIP).set(1);
+            resolve();
+          });
+        });
+      } catch (e) {
+        this.log.error('Error reading release file', e);
+      }
+    }
+    return Promise.resolve();
   }
 
   getTotalRooms() {
@@ -128,7 +203,9 @@ class RovMetricsGatherer {
   }
 
   gatherMetrics() {
-    return this.rovClient.updateComponentsList()
+    return this.getIP()
+      .then(() => this.getReleaseInfo())
+      .then(() => this.rovClient.updateComponentsList())
       .then(() => this.getTotalRooms())
       .then(() => this.getTotalClients())
       .then(() => this.getTotalPublishersAndSubscribers())


### PR DESCRIPTION
**Description**

Here we will start to add more information to prometheus metrics:
- Commit short hash.
- Commit date.
- Public IP as we provide it in the config file or we obtain from AWS.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.