### PR TITLE
Fix Audio SDES packets that were corrupted in OTM

### DIFF
--- a/erizo/src/erizo/OneToManyProcessor.cpp
+++ b/erizo/src/erizo/OneToManyProcessor.cpp
@@ -30,9 +30,14 @@ namespace erizo {
 
     std::map<std::string, std::shared_ptr<MediaSink>>::iterator it;
     RtpHeader* head = reinterpret_cast<RtpHeader*>(audio_packet->data);
+    RtcpHeader* chead = reinterpret_cast<RtcpHeader*>(audio_packet->data);
     for (it = subscribers.begin(); it != subscribers.end(); ++it) {
       if ((*it).second != nullptr) {
-        head->setSSRC((*it).second->getAudioSinkSSRC());
+        if (chead->isRtcp()) {
+          chead->setSSRC((*it).second->getAudioSinkSSRC());
+        } else {
+          head->setSSRC((*it).second->getAudioSinkSSRC());
+        }
         // Note: deliverAudioData must copy the packet inmediately
         (*it).second->deliverAudioData(audio_packet);
       }

--- a/erizo/src/erizo/rtp/RtpHeaders.h
+++ b/erizo/src/erizo/rtp/RtpHeaders.h
@@ -377,6 +377,12 @@ class RtcpHeader {
       struct receiverReport_t rrlist[1];
     } senderReport;
 
+    struct sdes_t {
+      uint32_t type:8;
+      uint32_t length:8;
+      char data[1];
+    } sdes;
+
     struct genericNack_t {
       uint32_t ssrcsource;
       NackBlock nack_block;
@@ -413,6 +419,12 @@ class RtcpHeader {
   }
   inline bool isReceiverReport() {
     return packettype == RTCP_Receiver_PT;
+  }
+  inline bool isSenderReport() {
+    return packettype == RTCP_Sender_PT;
+  }
+  inline bool isSDES() {
+    return packettype == RTCP_SDES_PT;
   }
   inline bool isREMB() {
     return packettype == RTCP_PS_Feedback_PT && blockcount == RTCP_AFB;
@@ -573,6 +585,15 @@ class RtcpHeader {
   }
   inline void setFIRSequenceNumber(uint8_t seq_number) {
     report.fir.seqnumber = seq_number;
+  }
+  inline uint32_t getSDESType() {
+    return report.sdes.type;
+  }
+  inline uint32_t getSDESLength() {
+    return report.sdes.length;
+  }
+  inline char* getSDESData() {
+    return report.sdes.data;
   }
 };
 


### PR DESCRIPTION
**Description**

We were modifying the wrong SSRC field in RTCP packets sent through the OneToManyProcessor's deliverAudioData.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.