### PR TITLE
Fix Stats retrieved from Ackuaria when connection is closed

### DIFF
--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -385,6 +385,7 @@ class Connection extends events.EventEmitter {
 
   getStats(callback) {
     if (!this.wrtc) {
+      callback('{}');
       return true;
     }
     return this.wrtc.getStats(callback);


### PR DESCRIPTION
**Description**

Fix Stats retrieved from Ackuaria when connection is closed

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.