### PR TITLE
Fix the way we detect abs send time to update it

### DIFF
--- a/erizo/src/erizo/rtp/RtpExtensionProcessor.cpp
+++ b/erizo/src/erizo/rtp/RtpExtensionProcessor.cpp
@@ -92,7 +92,7 @@ uint32_t RtpExtensionProcessor::processRtpExtensions(std::shared_ptr<DataPacket>
         extId = extByte >> 4;
         extLength = extByte & 0x0F;
         if (extId != 0 && extMap[extId] != 0) {
-          switch (extId) {
+          switch (extMap[extId]) {
             case ABS_SEND_TIME:
               processAbsSendTime(extBuffer);
               break;


### PR DESCRIPTION
**Description**

We were not updating absolute send time RTP extension because we were not using the translated extension id. The result was that we were having lower video quality.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.