### PR TITLE
Avoid audio drifting by updating audio SRs

### DIFF
--- a/erizo/src/erizo/OneToManyProcessor.cpp
+++ b/erizo/src/erizo/OneToManyProcessor.cpp
@@ -33,7 +33,8 @@ namespace erizo {
     RtcpHeader* chead = reinterpret_cast<RtcpHeader*>(audio_packet->data);
     for (it = subscribers.begin(); it != subscribers.end(); ++it) {
       if ((*it).second != nullptr) {
-        if (chead->isRtcp()) {
+        // Hack to avoid audio drifting in Chrome.
+        if (chead->isRtcp() && chead->isSDES()) {
           chead->setSSRC((*it).second->getAudioSinkSSRC());
         } else {
           head->setSSRC((*it).second->getAudioSinkSSRC());


### PR DESCRIPTION
**Description**

We are having audio drifting because we are not correctly handling timestamps in video. This is a quick hack to avoid sending audio SRs properly and use a best effort approach when syncing audio and video in Chrome. 

Another better solution that updates timestamps in video SRs in Simulcast is coming.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.