### PR TITLE
Do not count padding bitrate as video bitrate stat

### DIFF
--- a/erizo/src/erizo/rtp/StatsHandler.cpp
+++ b/erizo/src/erizo/rtp/StatsHandler.cpp
@@ -50,11 +50,16 @@ void StatsCalculator::processRtpPacket(std::shared_ptr<DataPacket> packet) {
     }
     getStatsInfo()[ssrc].insertStat("bitrateCalculated", MovingIntervalRateStat{kRateStatIntervalSize,
         kRateStatIntervals, 8.});
+    getStatsInfo()[ssrc].insertStat("mediaBitrateCalculated", MovingIntervalRateStat{kRateStatIntervalSize,
+        kRateStatIntervals, 8.});
   }
   getStatsInfo()[ssrc]["bitrateCalculated"] += len;
   getStatsInfo()["total"]["bitrateCalculated"] += len;
+  if (!packet->is_padding) {
+    getStatsInfo()[ssrc]["mediaBitrateCalculated"] += len;
+  }
   if (packet->type == VIDEO_PACKET) {
-    stream_->setVideoBitrate(getStatsInfo()[ssrc]["bitrateCalculated"].value());
+    stream_->setVideoBitrate(getStatsInfo()[ssrc]["mediaBitrateCalculated"].value());
     if (packet->is_keyframe) {
       incrStat(ssrc, "keyFrames");
     }


### PR DESCRIPTION
**Description**

This PR is a small fix of the mechanism we use to use the maximum bandwidth available in the conneciton. We were counting padding as media bitrate, so it was used by the internal BW estimation to know the maximum bitrate we want to send, but padding bitrate should not be part of that equation.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.