### PR TITLE
Update RTCP SR timestamps in Simulcast

### DIFF
--- a/erizo/src/erizo/OneToManyProcessor.cpp
+++ b/erizo/src/erizo/OneToManyProcessor.cpp
@@ -33,8 +33,7 @@ namespace erizo {
     RtcpHeader* chead = reinterpret_cast<RtcpHeader*>(audio_packet->data);
     for (it = subscribers.begin(); it != subscribers.end(); ++it) {
       if ((*it).second != nullptr) {
-        // Hack to avoid audio drifting in Chrome.
-        if (chead->isRtcp() && chead->isSDES()) {
+        if (chead->isRtcp()) {
           chead->setSSRC((*it).second->getAudioSinkSSRC());
         } else {
           head->setSSRC((*it).second->getAudioSinkSSRC());

--- a/erizo/src/erizo/rtp/QualityFilterHandler.cpp
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.cpp
@@ -220,9 +220,13 @@ void QualityFilterHandler::write(Context *ctx, std::shared_ptr<DataPacket> packe
       tl0_pic_idx_sent : last_tl0_pic_idx_sent_;
     updateTL0PicIdx(packet, tl0_pic_idx_sent);
     // removeVP8OptionalPayload(packet);  // TODO(javier): uncomment this line in case of issues with pictureId
+  } else if (is_scalable_ && enabled_ && chead->isRtcp() && chead->isSenderReport()) {
+    uint32_t ssrc = chead->getSSRC();
+    if (video_sink_ssrc_ == ssrc) {
+      uint32_t sr_timestamp = chead->getTimestamp();
+      chead->setTimestamp(sr_timestamp + timestamp_offset_);
+    }
   }
-
-  // TODO(javier): Handle SRs?
 
   ctx->fireWrite(packet);
 }

--- a/erizo/src/erizo/rtp/RtpHeaders.h
+++ b/erizo/src/erizo/rtp/RtpHeaders.h
@@ -526,6 +526,12 @@ class RtcpHeader {
     uint64_t middle = (report.senderReport.ntptimestamp << 16) >> 32;
     return ntohl(middle);
   }
+  inline void setTimestamp(uint32_t timestamp) {
+    report.senderReport.rtprts = htonl(timestamp);
+  }
+  inline uint32_t getTimestamp() {
+    return ntohl(report.senderReport.rtprts);
+  }
   inline uint16_t getNackPid() {
     return report.nackPacket.nack_block.getNackPid();
   }


### PR DESCRIPTION
**Description**

This PR updates Sender Reports in Simulcast by calculating the new timestamp. This is a solution better than the quick fix implemented yesterday.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.