### PR TITLE
Calculate target bitrate from max constrained layer

### DIFF
--- a/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
+++ b/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
@@ -20,7 +20,7 @@ LayerDetectorHandler::LayerDetectorHandler(std::shared_ptr<erizo::Clock> the_clo
   video_frame_height_list_ = std::vector<uint32_t>(kMaxSpatialLayers, 0);
   video_frame_width_list_ = std::vector<uint32_t>(kMaxSpatialLayers, 0);
   video_frame_rate_list_ = std::vector<MovingIntervalRateStat>();
-  for (int i = 0; i < kMaxTemporalLayers; i++) {
+  for (uint32_t i = 0; i < kMaxTemporalLayers; i++) {
     video_frame_rate_list_.emplace_back(MovingIntervalRateStat{std::chrono::milliseconds(500), 10, .5, clock_});
   }
 }

--- a/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
+++ b/erizo/src/erizo/rtp/LayerDetectorHandler.cpp
@@ -19,8 +19,10 @@ LayerDetectorHandler::LayerDetectorHandler(std::shared_ptr<erizo::Clock> the_clo
   video_ssrc_list_ = std::vector<uint32_t>(kMaxSpatialLayers, 0);
   video_frame_height_list_ = std::vector<uint32_t>(kMaxSpatialLayers, 0);
   video_frame_width_list_ = std::vector<uint32_t>(kMaxSpatialLayers, 0);
-  video_frame_rate_list_ = std::vector<MovingIntervalRateStat>(kMaxTemporalLayers,
-      MovingIntervalRateStat{std::chrono::milliseconds(500), 10, .5, clock_});
+  video_frame_rate_list_ = std::vector<MovingIntervalRateStat>();
+  for (int i = 0; i < kMaxTemporalLayers; i++) {
+    video_frame_rate_list_.emplace_back(MovingIntervalRateStat{std::chrono::milliseconds(500), 10, .5, clock_});
+  }
 }
 
 void LayerDetectorHandler::enable() {
@@ -55,7 +57,7 @@ void LayerDetectorHandler::notifyLayerInfoChangedEvent() {
   for (uint32_t temporal_layer = 0; temporal_layer < video_frame_rate_list_.size(); temporal_layer++) {
     video_frame_rate_list.push_back(video_frame_rate_list_[temporal_layer].value());
     ELOG_DEBUG("Temporal Layer (%u): %lu",
-              temporal_layer, video_frame_rate_list_[temporal_layer].value());
+              temporal_layer, video_frame_rate_list[temporal_layer]);
   }
 
   if (stream_) {

--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -153,26 +153,30 @@ bool QualityManager::doesLayerMeetConstraints(int spatial_layer, int temporal_la
 }
 
 void QualityManager::calculateMaxBitrateThatMeetsConstraints() {
-  int target_spatial_layer = 0;
-  int target_temporal_layer = 0;
-  int max_spatial_layer_with_info = 0;
-  if (video_frame_width_list_.size() > 0 && video_frame_height_list_.size() > 0) {
-    max_spatial_layer_with_info = std::min((int)video_frame_width_list_.size() - 1, (int)video_frame_height_list_.size() - 1);
-  }
-  int max_temporal_layer_with_info = std::max((int)video_frame_rate_list_.size() - 1, 0);
-  int max_spatial_layer_we_can_achive = std::min(max_spatial_layer_with_info, max_active_spatial_layer_);
-  int max_temporal_layer_we_can_achive = std::min(max_temporal_layer_with_info, max_active_temporal_layer_);
+  int max_available_spatial_layer_that_meets_constraints = 0;
+  int max_available_temporal_layer_that_meets_constraints = 0;
 
-  for (int spatial_layer = 0; spatial_layer <= max_spatial_layer_we_can_achive; spatial_layer++) {
-    for (int temporal_layer = 0; temporal_layer <= max_temporal_layer_we_can_achive; temporal_layer++) {
+  int max_spatial_layer_with_resolution_info = 0;
+  if (video_frame_width_list_.size() > 0 && video_frame_height_list_.size() > 0) {
+    max_spatial_layer_with_resolution_info = std::min(static_cast<int>(video_frame_width_list_.size()) - 1,
+                                                      static_cast<int>(video_frame_height_list_.size()) - 1);
+  }
+  int max_temporal_layer_with_frame_rate_info = std::max(static_cast<int>(video_frame_rate_list_.size()) - 1, 0);
+
+  int max_spatial_layer_available = std::min(max_spatial_layer_with_resolution_info, max_active_spatial_layer_);
+  int max_temporal_layer_available = std::min(max_temporal_layer_with_frame_rate_info, max_active_temporal_layer_);
+
+  for (int spatial_layer = 0; spatial_layer <= max_spatial_layer_available; spatial_layer++) {
+    for (int temporal_layer = 0; temporal_layer <= max_temporal_layer_available; temporal_layer++) {
       if (doesLayerMeetConstraints(spatial_layer, temporal_layer)) {
-        target_spatial_layer = spatial_layer;
-        target_temporal_layer = temporal_layer;
+        max_available_spatial_layer_that_meets_constraints = spatial_layer;
+        max_available_temporal_layer_that_meets_constraints = temporal_layer;
       }
     }
   }
 
-  stream_->setBitrateFromMaxQualityLayer(getInstantLayerBitrate(target_spatial_layer, target_temporal_layer));
+  stream_->setBitrateFromMaxQualityLayer(getInstantLayerBitrate(max_available_spatial_layer_that_meets_constraints,
+                                                                max_available_temporal_layer_that_meets_constraints));
 }
 
 void QualityManager::selectLayer(bool try_higher_layers) {

--- a/erizo/src/erizo/rtp/QualityManager.h
+++ b/erizo/src/erizo/rtp/QualityManager.h
@@ -43,6 +43,7 @@ class QualityManager: public Service, public std::enable_shared_from_this<Qualit
 
  private:
   void calculateMaxActiveLayer();
+  void calculateMaxBitrateThatMeetsConstraints();
   void selectLayer(bool try_higher_layers);
   uint64_t getInstantLayerBitrate(int spatial_layer, int temporal_layer);
   bool isInBaseLayer();

--- a/extras/basic_example/public/quality_layers.js
+++ b/extras/basic_example/public/quality_layers.js
@@ -242,7 +242,7 @@ const updateCharts = (stream) => {
         const bitrateEstimated = data[i].total.senderBitrateEstimation || 0;
         const remb = data[i].total.bandwidth || 0;
         const targetVideoBitrate = data[i].total.targetVideoBitrate || 0;
-        const numberOfStreams = data[i].total.numberOfStreams || 0;
+        const numberOfStreams = data[i].total.numberOfStreams || 0;
         const paddingBitrate = data[i].total.paddingBitrate || 0;
         const rtxBitrate = data[i].total.rtxBitrate || 0;
 

--- a/extras/basic_example/public/quality_layers.js
+++ b/extras/basic_example/public/quality_layers.js
@@ -230,14 +230,19 @@ const updateCharts = (stream) => {
                               maxActiveSpatialLayer >= spatialLayer);
             }
           }
-          if (qualityLayersData.selectedSpatialLayer) {
+          if (qualityLayersData.selectedSpatialLayer !== undefined) {
             selectedLayers += `Spatial: ${qualityLayersData.selectedSpatialLayer
                       } / Temporal: ${qualityLayersData.selectedTemporalLayer}`;
           }
         }
-
+        if (!data[i].total) {
+          return;
+        }
         const totalBitrate = data[i].total.bitrateCalculated || 0;
         const bitrateEstimated = data[i].total.senderBitrateEstimation || 0;
+        const remb = data[i].total.bandwidth || 0;
+        const targetVideoBitrate = data[i].total.targetVideoBitrate || 0;
+        const numberOfStreams = data[i].total.numberOfStreams || 0;
         const paddingBitrate = data[i].total.paddingBitrate || 0;
         const rtxBitrate = data[i].total.rtxBitrate || 0;
 
@@ -245,6 +250,12 @@ const updateCharts = (stream) => {
                   date, totalBitrate, selectedLayers);
         updateSeriesForKey(stream, subId, 'Estimated Bandwidth', undefined, undefined,
                   date, bitrateEstimated);
+        updateSeriesForKey(stream, subId, 'REMB Bandwidth', undefined, undefined,
+                  date, remb);
+        updateSeriesForKey(stream, subId, 'Target Video Bitrate', undefined, undefined,
+                  date, targetVideoBitrate);
+        updateSeriesForKey(stream, subId, 'Number Of Streams', undefined, undefined,
+                  date, numberOfStreams);
         updateSeriesForKey(stream, subId, 'Padding Bitrate', undefined, undefined,
                   date, paddingBitrate);
         updateSeriesForKey(stream, subId, 'Rtx Bitrate', undefined, undefined,


### PR DESCRIPTION
**Description**

We did not take into account constrains when calculating the target video bitrate in the BWE mechanisms.
I also fixed an issue by which we were not calculating the framerate properly.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.