### PR TITLE
Add periodic Pli handler

### DIFF
--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -87,6 +87,7 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   void sendPLIToFeedback();
   void setQualityLayer(int spatial_layer, int temporal_layer);
   void enableSlideShowBelowSpatialLayer(bool enabled, int spatial_layer);
+  void setPeriodicKeyframeRequests(bool activate, uint32_t interval_in_ms = 0);
 
   WebRTCEvent getCurrentState();
 
@@ -141,6 +142,9 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   std::shared_ptr<SdpInfo> getRemoteSdpInfo() { return remote_sdp_; }
 
   virtual bool isSlideShowModeEnabled() { return slide_show_mode_; }
+
+  virtual bool isRequestingPeriodicKeyframes() { return periodic_keyframes_requested_; }
+  virtual uint32_t getPeriodicKeyframesRequesInterval() { return periodic_keyframe_interval_; }
 
   virtual bool isSimulcast() { return simulcast_; }
   void setSimulcast(bool simulcast) { simulcast_ = simulcast; }
@@ -230,6 +234,9 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   std::random_device random_device_;
   std::mt19937 random_generator_;
   uint64_t target_padding_bitrate_;
+  bool periodic_keyframes_requested_;
+  uint32_t periodic_keyframe_interval_;
+
  protected:
   std::shared_ptr<SdpInfo> remote_sdp_;
 };

--- a/erizo/src/erizo/rtp/PeriodicPliHandler.cpp
+++ b/erizo/src/erizo/rtp/PeriodicPliHandler.cpp
@@ -1,0 +1,95 @@
+#include "rtp/PeriodicPliHandler.h"
+
+#include "rtp/RtpUtils.h"
+#include "./MediaDefinitions.h"
+#include "./MediaStream.h"
+
+namespace erizo {
+
+DEFINE_LOGGER(PeriodicPliHandler, "rtp.PeriodicPliHandler");
+
+PeriodicPliHandler::PeriodicPliHandler(std::shared_ptr<erizo::Clock> the_clock)
+    : enabled_{true}, stream_{nullptr}, clock_{the_clock},
+      video_sink_ssrc_{0}, video_source_ssrc_{0}, keyframes_received_in_interval_{0},
+      requested_periodic_plis_{false}, has_scheduled_pli_{false} {}
+
+void PeriodicPliHandler::enable() {
+  enabled_ = true;
+}
+
+void PeriodicPliHandler::disable() {
+  enabled_ = false;
+}
+
+void PeriodicPliHandler::notifyUpdate() {
+  auto pipeline = getContext()->getPipelineShared();
+  if (pipeline && !stream_) {
+    stream_ = pipeline->getService<MediaStream>().get();
+    video_sink_ssrc_ = stream_->getVideoSinkSSRC();
+    video_source_ssrc_ = stream_->getVideoSourceSSRC();
+  }
+  // check if is actuve and start pliReuqests or update the variable so it stops on its own
+
+  updateInterval(stream_->isRequestingPeriodicKeyframes(), stream_->getPeriodicKeyframesRequesInterval());
+}
+
+void PeriodicPliHandler::updateInterval(bool active, uint32_t interval_ms) {
+  requested_periodic_plis_ = active;
+  requested_interval_ = std::chrono::milliseconds(interval_ms);
+  if (enabled_ && requested_periodic_plis_ && !has_scheduled_pli_) {
+    ELOG_DEBUG("%s, message: Updating interval, requested_periodic_plis_: %u, interval: %u", stream_->toLog(),
+        requested_periodic_plis_, requested_interval_);
+    scheduleNextPli(requested_interval_);
+    has_scheduled_pli_ = true;
+  }
+}
+
+void PeriodicPliHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet) {
+  if (enabled_ && packet->is_keyframe) {
+    ELOG_DEBUG("%s, message: Received Keyframe, total in interval %u", stream_->toLog(),
+        keyframes_received_in_interval_);
+    keyframes_received_in_interval_++;  // the pli counter because we have keyframe
+  }
+  ctx->fireRead(std::move(packet));
+}
+
+void PeriodicPliHandler::write(Context *ctx, std::shared_ptr<DataPacket> packet) {
+  ctx->fireWrite(std::move(packet));
+}
+
+void PeriodicPliHandler::sendPLI() {
+  getContext()->fireWrite(RtpUtils::createPLI(video_source_ssrc_, video_sink_ssrc_, HIGH_PRIORITY));
+}
+
+
+void PeriodicPliHandler::scheduleNextPli(duration next_pli_time) {
+  if (!enabled_) {
+    return;
+  }
+  ELOG_INFO("%s, message: scheduleNextKeyframe, keyframes_received_in_interval_: %u, next_keyframe %u",
+      stream_->toLog(), keyframes_received_in_interval_, ClockUtils::durationToMs(next_pli_time));;
+  std::weak_ptr<PeriodicPliHandler> weak_this = shared_from_this();
+  stream_->getWorker()->scheduleFromNow([weak_this] {
+    if (auto this_ptr = weak_this.lock()) {
+      if (this_ptr->requested_periodic_plis_) {
+        ELOG_DEBUG("%s, message: Maybe Sending PLI, keyframes_received_in_interval_: %u",
+            this_ptr->stream_->toLog(), this_ptr->keyframes_received_in_interval_);
+        if (this_ptr->keyframes_received_in_interval_ == 0) {
+          ELOG_DEBUG("%s, message: Will send PLI, keyframes_received_in_interval_: %u",
+              this_ptr->stream_->toLog(), this_ptr->keyframes_received_in_interval_);
+          this_ptr->sendPLI();
+        }
+        this_ptr->keyframes_received_in_interval_ = 0;
+        ELOG_DEBUG("%s, message: Scheduling next pli in : %u",
+            this_ptr->stream_->toLog(), ClockUtils::durationToMs(this_ptr->requested_interval_));
+        this_ptr->scheduleNextPli(this_ptr->requested_interval_);
+      } else {
+        ELOG_DEBUG("%s, message: Not scheduling more PLIs: %u",
+            this_ptr->stream_->toLog(), this_ptr->keyframes_received_in_interval_);
+        this_ptr->has_scheduled_pli_ = false;
+      }
+    }
+  }, next_pli_time);
+}
+}  // namespace erizo
+

--- a/erizo/src/erizo/rtp/PeriodicPliHandler.cpp
+++ b/erizo/src/erizo/rtp/PeriodicPliHandler.cpp
@@ -28,7 +28,6 @@ void PeriodicPliHandler::notifyUpdate() {
     video_sink_ssrc_ = stream_->getVideoSinkSSRC();
     video_source_ssrc_ = stream_->getVideoSourceSSRC();
   }
-  // check if is actuve and start pliReuqests or update the variable so it stops on its own
 
   updateInterval(stream_->isRequestingPeriodicKeyframes(), stream_->getPeriodicKeyframesRequesInterval());
 }
@@ -46,9 +45,9 @@ void PeriodicPliHandler::updateInterval(bool active, uint32_t interval_ms) {
 
 void PeriodicPliHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet) {
   if (enabled_ && packet->is_keyframe) {
+    keyframes_received_in_interval_++;
     ELOG_DEBUG("%s, message: Received Keyframe, total in interval %u", stream_->toLog(),
         keyframes_received_in_interval_);
-    keyframes_received_in_interval_++;  // the pli counter because we have keyframe
   }
   ctx->fireRead(std::move(packet));
 }

--- a/erizo/src/erizo/rtp/PeriodicPliHandler.cpp
+++ b/erizo/src/erizo/rtp/PeriodicPliHandler.cpp
@@ -87,6 +87,7 @@ void PeriodicPliHandler::scheduleNextPli(duration next_pli_time) {
         ELOG_DEBUG("%s, message: Not scheduling more PLIs: %u",
             this_ptr->stream_->toLog(), this_ptr->keyframes_received_in_interval_);
         this_ptr->has_scheduled_pli_ = false;
+        this_ptr->sendPLI();
       }
     }
   }, next_pli_time);

--- a/erizo/src/erizo/rtp/PeriodicPliHandler.h
+++ b/erizo/src/erizo/rtp/PeriodicPliHandler.h
@@ -1,0 +1,53 @@
+#ifndef ERIZO_SRC_ERIZO_RTP_PERIODICPLIHANDLER_H_
+#define ERIZO_SRC_ERIZO_RTP_PERIODICPLIHANDLER_H_
+
+#include <string>
+
+#include "./logger.h"
+#include "pipeline/Handler.h"
+#include "thread/Worker.h"
+#include "lib/Clock.h"
+
+namespace erizo {
+
+class MediaStream;
+
+class PeriodicPliHandler: public Handler, public std::enable_shared_from_this<PeriodicPliHandler> {
+  DECLARE_LOGGER();
+
+ public:
+  explicit PeriodicPliHandler(std::shared_ptr<erizo::Clock> the_clock = std::make_shared<SteadyClock>());
+
+  void enable() override;
+  void disable() override;
+
+  std::string getName() override {
+    return "periodic-pli";
+  }
+
+  void read(Context *ctx, std::shared_ptr<DataPacket> packet) override;
+  void write(Context *ctx, std::shared_ptr<DataPacket> packet) override;
+  void notifyUpdate() override;
+  void updateInterval(bool active, uint32_t interval_ms);
+
+ private:
+  void scheduleNextPli(duration next_pli_time);
+  void sendPLI();
+
+ private:
+  bool enabled_;
+  MediaStream* stream_;
+  std::shared_ptr<erizo::Clock> clock_;
+  uint32_t video_sink_ssrc_;
+  uint32_t video_source_ssrc_;
+  uint32_t keyframes_received_in_interval_;
+  duration requested_interval_;
+  bool requested_periodic_plis_;
+
+  bool has_scheduled_pli_;
+};
+
+}  // namespace erizo
+
+#endif  // ERIZO_SRC_ERIZO_RTP_PERIODICPLIHANDLER_H_
+

--- a/erizo/src/test/rtp/PeriodicPliHandlerTest.cpp
+++ b/erizo/src/test/rtp/PeriodicPliHandlerTest.cpp
@@ -1,0 +1,114 @@
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <rtp/PeriodicPliHandler.h>
+#include <rtp/RtpHeaders.h>
+#include <MediaDefinitions.h>
+#include <WebRtcConnection.h>
+
+#include <queue>
+#include <string>
+#include <vector>
+
+#include "../utils/Mocks.h"
+#include "../utils/Tools.h"
+#include "../utils/Matchers.h"
+
+using ::testing::_;
+using ::testing::IsNull;
+using ::testing::Args;
+using ::testing::Return;
+using erizo::DataPacket;
+using erizo::packetType;
+using erizo::AUDIO_PACKET;
+using erizo::VIDEO_PACKET;
+using erizo::IceConfig;
+using erizo::RtpMap;
+using erizo::PeriodicPliHandler;
+using erizo::SimulatedClock;
+using erizo::WebRtcConnection;
+using erizo::Pipeline;
+using erizo::InboundHandler;
+using erizo::OutboundHandler;
+using erizo::Worker;
+using std::queue;
+
+constexpr int kArbitraryKeyframePeriodMs = 1000;
+
+
+class PeriodicPliHandlerTest : public erizo::HandlerTest {
+ public:
+  PeriodicPliHandlerTest() {}
+
+ protected:
+  void setHandler() {
+    periodic_pli_handler = std::make_shared<PeriodicPliHandler>(simulated_clock);
+    pipeline->addBack(periodic_pli_handler);
+  }
+
+  std::shared_ptr<PeriodicPliHandler> periodic_pli_handler;
+};
+
+
+TEST_F(PeriodicPliHandlerTest, basicBehaviourShouldReadPackets) {
+    auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+    EXPECT_CALL(*reader.get(), read(_, _)).
+      With(Args<1>(erizo::RtpHasSequenceNumber(erizo::kArbitrarySeqNumber))).Times(1);
+    pipeline->read(packet);
+}
+
+TEST_F(PeriodicPliHandlerTest, basicBehaviourShouldWritePackets) {
+    auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+    EXPECT_CALL(*writer.get(), write(_, _)).
+      With(Args<1>(erizo::RtpHasSequenceNumber(erizo::kArbitrarySeqNumber))).Times(1);
+    pipeline->write(packet);
+}
+
+TEST_F(PeriodicPliHandlerTest, shouldSendPliEveryInterval) {
+    periodic_pli_handler->updateInterval(true, kArbitraryKeyframePeriodMs);
+    EXPECT_CALL(*writer.get(), write(_, _)).With(Args<1>(erizo::IsPLI())).Times(2);
+    executeTasksInNextMs(kArbitraryKeyframePeriodMs+1);
+    executeTasksInNextMs(kArbitraryKeyframePeriodMs+1);
+}
+
+TEST_F(PeriodicPliHandlerTest, shouldNotSendPliIfDeactivated) {
+    periodic_pli_handler->updateInterval(false, 0);
+    EXPECT_CALL(*writer.get(), write(_, _)).With(Args<1>(erizo::IsPLI())).Times(0);
+
+    executeTasksInNextMs(kArbitraryKeyframePeriodMs+1);
+    executeTasksInNextMs(kArbitraryKeyframePeriodMs+1);
+}
+
+TEST_F(PeriodicPliHandlerTest, shouldUpdateIntervalIfRequested) {
+    periodic_pli_handler->updateInterval(true, kArbitraryKeyframePeriodMs);
+    EXPECT_CALL(*writer.get(), write(_, _)).With(Args<1>(erizo::IsPLI())).Times(2);
+
+    executeTasksInNextMs(kArbitraryKeyframePeriodMs+1);
+    periodic_pli_handler->updateInterval(true, 2*kArbitraryKeyframePeriodMs);
+    executeTasksInNextMs(2*kArbitraryKeyframePeriodMs+1);
+}
+
+TEST_F(PeriodicPliHandlerTest, shouldNotSendPLIIfKeyframeIsReceivedInPeriod) {
+    auto keyframe = erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber, true, true);
+
+    EXPECT_CALL(*writer.get(), write(_, _)).With(Args<1>(erizo::IsPLI())).Times(0);
+    EXPECT_CALL(*reader.get(), read(_, _)).
+      With(Args<1>(erizo::RtpHasSequenceNumber(erizo::kArbitrarySeqNumber))).Times(1);
+
+    periodic_pli_handler->updateInterval(true, kArbitraryKeyframePeriodMs);
+    executeTasksInNextMs(kArbitraryKeyframePeriodMs/2);
+    pipeline->read(keyframe);
+    executeTasksInNextMs(kArbitraryKeyframePeriodMs/2 + 1);
+}
+
+
+TEST_F(PeriodicPliHandlerTest, shouldNotSchedulePlisWhenDisabled) {
+    periodic_pli_handler->disable();
+
+    periodic_pli_handler->updateInterval(true, kArbitraryKeyframePeriodMs);
+    EXPECT_CALL(*writer.get(), write(_, _)).With(Args<1>(erizo::IsPLI())).Times(0);
+    executeTasksInNextMs(kArbitraryKeyframePeriodMs+1);
+    executeTasksInNextMs(kArbitraryKeyframePeriodMs+1);
+}

--- a/erizo/src/test/rtp/PeriodicPliHandlerTest.cpp
+++ b/erizo/src/test/rtp/PeriodicPliHandlerTest.cpp
@@ -90,7 +90,7 @@ TEST_F(PeriodicPliHandlerTest, shouldUpdateIntervalIfRequested) {
     executeTasksInNextMs(2*kArbitraryKeyframePeriodMs+1);
 }
 
-TEST_F(PeriodicPliHandlerTest, shouldNotSendPLIIfKeyframeIsReceivedInPeriod) {
+TEST_F(PeriodicPliHandlerTest, shouldNotSendPliIfKeyframeIsReceivedInPeriod) {
     auto keyframe = erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber, true, true);
 
     EXPECT_CALL(*writer.get(), write(_, _)).With(Args<1>(erizo::IsPLI())).Times(0);
@@ -103,6 +103,16 @@ TEST_F(PeriodicPliHandlerTest, shouldNotSendPLIIfKeyframeIsReceivedInPeriod) {
     executeTasksInNextMs(kArbitraryKeyframePeriodMs/2 + 1);
 }
 
+TEST_F(PeriodicPliHandlerTest, shouldSendPliWhenRequestedToStop) {
+    auto keyframe = erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber, true, true);
+
+    EXPECT_CALL(*writer.get(), write(_, _)).With(Args<1>(erizo::IsPLI())).Times(1);
+
+    periodic_pli_handler->updateInterval(true, kArbitraryKeyframePeriodMs);
+    executeTasksInNextMs(kArbitraryKeyframePeriodMs/3);
+    periodic_pli_handler->updateInterval(false, 0);
+    executeTasksInNextMs(kArbitraryKeyframePeriodMs*2 + 1);
+}
 
 TEST_F(PeriodicPliHandlerTest, shouldNotSchedulePlisWhenDisabled) {
     periodic_pli_handler->disable();

--- a/erizoAPI/MediaStream.cc
+++ b/erizoAPI/MediaStream.cc
@@ -141,6 +141,8 @@ NAN_MODULE_INIT(MediaStream::Init) {
   Nan::SetPrototypeMethod(tpl, "onMediaStreamEvent", onMediaStreamEvent);
   Nan::SetPrototypeMethod(tpl, "setVideoConstraints", setVideoConstraints);
   Nan::SetPrototypeMethod(tpl, "setMetadata", setMetadata);
+  Nan::SetPrototypeMethod(tpl, "setPeriodicKeyframeRequests", setPeriodicKeyframeRequests);
+  Nan::SetPrototypeMethod(tpl, "hasPeriodicKeyframeRequests", hasPeriodicKeyframeRequests);
   Nan::SetPrototypeMethod(tpl, "enableHandler", enableHandler);
   Nan::SetPrototypeMethod(tpl, "disableHandler", disableHandler);
 
@@ -388,6 +390,32 @@ NAN_METHOD(MediaStream::enableSlideShowBelowSpatialLayer) {
   bool enabled = info[0]->BooleanValue();
   int spatial_layer = info[1]->IntegerValue();
   me->enableSlideShowBelowSpatialLayer(enabled, spatial_layer);
+}
+
+NAN_METHOD(MediaStream::setPeriodicKeyframeRequests) {
+  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  std::shared_ptr<erizo::MediaStream> me = obj->me;
+  if (!me || obj->closed_) {
+    return;
+  }
+
+  bool activated = info[0]->BooleanValue();
+  int interval = 0;
+  if (info.Length() > 1) {
+    interval = info[1]->IntegerValue();
+  }
+  me->setPeriodicKeyframeRequests(activated, interval);
+}
+
+NAN_METHOD(MediaStream::hasPeriodicKeyframeRequests) {
+  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  std::shared_ptr<erizo::MediaStream> me = obj->me;
+  if (!me || obj->closed_) {
+    return;
+  }
+
+  bool has_periodic_requests = me->isRequestingPeriodicKeyframes();
+  info.GetReturnValue().Set(Nan::New(has_periodic_requests));
 }
 
 NAN_METHOD(MediaStream::getStats) {

--- a/erizoAPI/MediaStream.h
+++ b/erizoAPI/MediaStream.h
@@ -147,6 +147,8 @@ class MediaStream : public MediaSink, public erizo::MediaStreamStatsListener, pu
      * Param: An object with metadata {key1:value1, key2: value2}
      */
     static NAN_METHOD(setMetadata);
+    static NAN_METHOD(setPeriodicKeyframeRequests);
+    static NAN_METHOD(hasPeriodicKeyframeRequests);
     /*
      * Enable a specific Handler in the pipeline
      * Param: Name of the handler

--- a/erizo_controller/erizoAgent/log4cxx.properties
+++ b/erizo_controller/erizoAgent/log4cxx.properties
@@ -67,6 +67,7 @@ log4j.logger.rtp.BandwidthEstimationHandler=WARN
 log4j.logger.rtp.SenderBandwidthEstimationHandler=WARN
 log4j.logger.rtp.StatsCalculator=WARN
 log4j.logger.rtp.LayerDetectorHandler=WARN
+log4j.logger.rtp.PeriodicPliHandler=WARN
 log4j.logger.rtp.PliPacerHandler=WARN
 log4j.logger.rtp.PliPriorityHandler=WARN
 log4j.logger.rtp.RtpPaddingGeneratorHandler=WARN

--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -255,7 +255,6 @@ class Source extends NodeClass {
       period = period < MIN_SLIDESHOW_PERIOD ? MIN_SLIDESHOW_PERIOD : period;
       period = period > MAX_SLIDESHOW_PERIOD ? MAX_SLIDESHOW_PERIOD : period;
       Source._updateMediaStreamSubscriberSlideshow(subscriber, true, isFallback);
-      this.mediaStream.setPeriodicKeyframeRequests(true, period);
       if (this.ei) {
         if (this.mediaStream.periodicPlis) {
           clearInterval(this.mediaStream.periodicPlis);
@@ -264,6 +263,8 @@ class Source extends NodeClass {
         this.mediaStream.periodicPlis = setInterval(() => {
           this.ei.generatePLIPacket();
         }, period);
+      } else {
+        this.mediaStream.setPeriodicKeyframeRequests(true, period);
       }
     } else {
       const result = Source._updateMediaStreamSubscriberSlideshow(subscriber, false, isFallback);
@@ -271,8 +272,6 @@ class Source extends NodeClass {
         for (let pliIndex = 0; pliIndex < PLIS_TO_RECOVER; pliIndex += 1) {
           if (this.ei) {
             this.ei.generatePLIPacket();
-          } else if (this.mediaStream) {
-            this.mediaStream.generatePLIPacket();
           }
         }
       }

--- a/erizo_controller/test/utils.js
+++ b/erizo_controller/test/utils.js
@@ -182,6 +182,7 @@ module.exports.reset = () => {
     getPeriodicStats: sinon.stub(),
     generatePLIPacket: sinon.stub(),
     setSlideShowMode: sinon.stub(),
+    setPeriodicKeyframeRequests: sinon.stub(),
     muteStream: sinon.stub(),
     onMediaStreamEvent: sinon.stub(),
   };


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
This PR optimizes the way we request keyframes when in slideshow. Instead of using an Interval in ErizoJS, this implements a handler in C++ erizo that periodically checks if a new keyframe is needed and requests it.

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.