### PR TITLE
Fix mongojs version used in nuve

### DIFF
--- a/nuve/installNuve.sh
+++ b/nuve/installNuve.sh
@@ -19,14 +19,8 @@ cd nuveAPI
 
 echo [nuve] Installing node_modules for nuve
 
-MONGO_VERSION=""
-
-if [[ $NODE_VERSION == *"0.10"* ]]
-then
-  MONGO_VERSION="@2.3.0"
-fi
 nvm use
-npm install --loglevel error amqp express mongojs$MONGO_VERSION aws-sdk log4js@1.0.1 node-getopt body-parser
+npm install --loglevel error amqp express mongojs@2.6.0 aws-sdk log4js@1.0.1 node-getopt body-parser
 npm install --loglevel error -g google-closure-compiler-js@20180204
 echo [nuve] Done, node_modules installed
 


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR forces the use of mongojs version 2.6. Nuve is not compatible with version 3.0.


[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.