### PR TITLE
Fix intervals in periodic Plis

### DIFF
--- a/erizo/src/erizo/rtp/PeriodicPliHandler.cpp
+++ b/erizo/src/erizo/rtp/PeriodicPliHandler.cpp
@@ -37,7 +37,7 @@ void PeriodicPliHandler::updateInterval(bool active, uint32_t interval_ms) {
   requested_interval_ = std::chrono::milliseconds(interval_ms);
   if (enabled_ && requested_periodic_plis_ && !has_scheduled_pli_) {
     ELOG_DEBUG("%s, message: Updating interval, requested_periodic_plis_: %u, interval: %u", stream_->toLog(),
-        requested_periodic_plis_, requested_interval_);
+        requested_periodic_plis_, ClockUtils::durationToMs(requested_interval_));
     scheduleNextPli(requested_interval_);
     has_scheduled_pli_ = true;
   }
@@ -73,7 +73,7 @@ void PeriodicPliHandler::scheduleNextPli(duration next_pli_time) {
       if (this_ptr->requested_periodic_plis_) {
         ELOG_DEBUG("%s, message: Maybe Sending PLI, keyframes_received_in_interval_: %u",
             this_ptr->stream_->toLog(), this_ptr->keyframes_received_in_interval_);
-        if (this_ptr->keyframes_received_in_interval_ == 0) {
+        if (this_ptr->keyframes_received_in_interval_ <= 1) {
           ELOG_DEBUG("%s, message: Will send PLI, keyframes_received_in_interval_: %u",
               this_ptr->stream_->toLog(), this_ptr->keyframes_received_in_interval_);
           this_ptr->sendPLI();

--- a/erizo/src/test/rtp/PeriodicPliHandlerTest.cpp
+++ b/erizo/src/test/rtp/PeriodicPliHandlerTest.cpp
@@ -90,8 +90,9 @@ TEST_F(PeriodicPliHandlerTest, shouldUpdateIntervalIfRequested) {
     executeTasksInNextMs(2*kArbitraryKeyframePeriodMs+1);
 }
 
-TEST_F(PeriodicPliHandlerTest, shouldNotSendPliIfKeyframeIsReceivedInPeriod) {
+TEST_F(PeriodicPliHandlerTest, shouldNotSendPliIfMoreThanOneKeyframeIsReceivedInPeriod) {
     auto keyframe = erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber, true, true);
+    auto keyframe2 = erizo::PacketTools::createVP8Packet(erizo::kArbitrarySeqNumber + 1, true, true);
 
     EXPECT_CALL(*writer.get(), write(_, _)).With(Args<1>(erizo::IsPLI())).Times(0);
     EXPECT_CALL(*reader.get(), read(_, _)).
@@ -100,6 +101,7 @@ TEST_F(PeriodicPliHandlerTest, shouldNotSendPliIfKeyframeIsReceivedInPeriod) {
     periodic_pli_handler->updateInterval(true, kArbitraryKeyframePeriodMs);
     executeTasksInNextMs(kArbitraryKeyframePeriodMs/2);
     pipeline->read(keyframe);
+    pipeline->read(keyframe2);
     executeTasksInNextMs(kArbitraryKeyframePeriodMs/2 + 1);
 }
 


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR fixes a bug where the periodicPliHandler would only request a PLI every other interval in ideal conditions.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.