### PR TITLE
Remove useNicer from licode configuration

### DIFF
--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -187,8 +187,6 @@ config.erizo.networkinterface = ''; //default value: ''
 config.erizo.minport = 0; // default value: 0
 config.erizo.maxport = 0; // default value: 0
 
-//Use of internal nICEr library instead of libNice.
-config.erizo.useNicer = true;  // default value: true
 config.erizo.useConnectionQualityCheck = true; // default value: false
 
 config.erizo.disabledHandlers = []; // there are no handlers disabled by default


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
`useNicer` is no longer needed.
[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.