### PR TITLE
Fix/periodic plis keyframe check

### DIFF
--- a/erizo/src/erizo/rtp/PeriodicPliHandler.cpp
+++ b/erizo/src/erizo/rtp/PeriodicPliHandler.cpp
@@ -45,9 +45,15 @@ void PeriodicPliHandler::updateInterval(bool active, uint32_t interval_ms) {
 
 void PeriodicPliHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet) {
   if (enabled_ && packet->is_keyframe) {
-    keyframes_received_in_interval_++;
-    ELOG_DEBUG("%s, message: Received Keyframe, total in interval %u", stream_->toLog(),
-        keyframes_received_in_interval_);
+    std::for_each(packet->compatible_spatial_layers.begin(),
+        packet->compatible_spatial_layers.end(),
+        [this](const int spatial_layer) {
+          if (spatial_layer == 0) {
+            keyframes_received_in_interval_++;
+          }
+        });
+    ELOG_DEBUG("%s, message: Received Keyframe, total from lowest layer in interval %u",
+        stream_->toLog(), keyframes_received_in_interval_);
   }
   ctx->fireRead(std::move(packet));
 }


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

We were sending less PLIs than we needed for slideshow because we were not taking into account keyframes could belong from different simulcast layers. So, for instance, with two spatial layers in vp8 we would be receiving 2 keyframes per interval and the handler would skip the next PLI.

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.