### PR TITLE
Add networkInterface as an option to docker run

### DIFF
--- a/extras/docker/initDockerLicode.sh
+++ b/extras/docker/initDockerLicode.sh
@@ -167,16 +167,16 @@ if [ "$ERIZOCONTROLLER" == "true" ]; then
 fi
 
 if [ "$ERIZOAGENT" == "true" ]; then
-  if [[ -z "$PUBLIC_IP" ]]; then
+  if [[ ! -z "$PUBLIC_IP" ]]; then
     echo "config.erizoAgent.publicIP = '$PUBLIC_IP';" >> /opt/licode/licode_config.js
   fi
-  if [[ -z "$MIN_PORT" ]]; then
+  if [[ ! -z "$MIN_PORT" ]]; then
     echo "config.erizo.minport = '$MIN_PORT';" >> /opt/licode/licode_config.js
   fi
-  if [[ -z "$MAX_PORT" ]]; then
+  if [[ ! -z "$MAX_PORT" ]]; then
     echo "config.erizo.maxport = '$MAX_PORT';" >> /opt/licode/licode_config.js
   fi
-  if [[ -z "$NETWORK_INTERFACE" ]]; then
+  if [[ ! -z "$NETWORK_INTERFACE" ]]; then
     echo "config.erizo.networkinterface = '$NETWORK_INTERFACE';" >> /opt/licode/licode_config.js
   fi
   run_erizoAgent

--- a/extras/docker/initDockerLicode.sh
+++ b/extras/docker/initDockerLicode.sh
@@ -167,9 +167,18 @@ if [ "$ERIZOCONTROLLER" == "true" ]; then
 fi
 
 if [ "$ERIZOAGENT" == "true" ]; then
-  echo "config.erizoAgent.publicIP = '$PUBLIC_IP';" >> /opt/licode/licode_config.js
-  echo "config.erizo.minport = '$MIN_PORT';" >> /opt/licode/licode_config.js
-  echo "config.erizo.maxport = '$MAX_PORT';" >> /opt/licode/licode_config.js
+  if [[ -z "$PUBLIC_IP" ]]; then
+    echo "config.erizoAgent.publicIP = '$PUBLIC_IP';" >> /opt/licode/licode_config.js
+  fi
+  if [[ -z "$MIN_PORT" ]]; then
+    echo "config.erizo.minport = '$MIN_PORT';" >> /opt/licode/licode_config.js
+  fi
+  if [[ -z "$MAX_PORT" ]]; then
+    echo "config.erizo.maxport = '$MAX_PORT';" >> /opt/licode/licode_config.js
+  fi
+  if [[ -z "$NETWORK_INTERFACE" ]]; then
+    echo "config.erizo.networkinterface = '$NETWORK_INTERFACE';" >> /opt/licode/licode_config.js
+  fi
   run_erizoAgent
 fi
 


### PR DESCRIPTION
**Description**

Issue #1512 might be caused by a wrong network interface configuration. I added it also as an option when we run the docker image.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.