### PR TITLE
Fix audio/video only streams with Firefox

### DIFF
--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -246,6 +246,9 @@ namespace erizo {
         case RECVONLY:
           sdp << "a=recvonly" << endl;
           break;
+        case INACTIVE:
+          sdp << "a=inactive" << endl;
+          break;
       }
 
       ELOG_DEBUG("Writing Extmap for AUDIO %lu", extMapVector.size());
@@ -367,6 +370,9 @@ namespace erizo {
           break;
         case RECVONLY:
           sdp << "a=recvonly" << endl;
+          break;
+        case INACTIVE:
+          sdp << "a=inactive" << endl;
           break;
       }
       for (uint8_t i = 0; i < bundleTags.size(); i++) {
@@ -544,6 +550,9 @@ namespace erizo {
       case SENDRECV:
         this->videoDirection = SENDRECV;
         break;
+      case INACTIVE:
+        this->videoDirection = INACTIVE;
+        break;
       default:
         this->videoDirection = SENDRECV;
         break;
@@ -557,6 +566,9 @@ namespace erizo {
         break;
       case SENDRECV:
         this->audioDirection = SENDRECV;
+        break;
+      case INACTIVE:
+        this->audioDirection = INACTIVE;
         break;
       default:
         this->audioDirection = SENDRECV;

--- a/erizo/src/erizo/SdpInfo.h
+++ b/erizo/src/erizo/SdpInfo.h
@@ -31,7 +31,7 @@ enum MediaType {
  * Stream directions
  */
 enum StreamDirection {
-  SENDRECV, SENDONLY, RECVONLY
+  SENDRECV, SENDONLY, RECVONLY, INACTIVE
 };
 /**
  * Simulcast rid direction

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -354,8 +354,17 @@ std::shared_ptr<SdpInfo> WebRtcConnection::getLocalSdpInfoSync() {
   bool sending_audio = local_sdp_->audio_ssrc_map.size() > 0;
   bool sending_video = local_sdp_->video_ssrc_map.size() > 0;
 
-  bool receiving_audio = remote_sdp_->audio_ssrc_map.size() > 0;
-  bool receiving_video = remote_sdp_->video_ssrc_map.size() > 0;
+  int audio_sources = 0;
+  for (auto iterator = remote_sdp_->audio_ssrc_map.begin(), itr_end = remote_sdp_->audio_ssrc_map.end(); iterator != itr_end; ++iterator) {
+    audio_sources++;
+  }
+  int video_sources = 0;
+  for (auto iterator = remote_sdp_->video_ssrc_map.begin(), itr_end = remote_sdp_->video_ssrc_map.end(); iterator != itr_end; ++iterator) {
+    video_sources += iterator->second->size();
+  }
+
+  bool receiving_audio = audio_sources > 0;
+  bool receiving_video = video_sources > 0;
 
   audio_enabled_ = sending_audio || receiving_audio;
   video_enabled_ = sending_video || receiving_video;
@@ -364,16 +373,20 @@ std::shared_ptr<SdpInfo> WebRtcConnection::getLocalSdpInfoSync() {
     local_sdp_->audioDirection = erizo::RECVONLY;
   } else if (sending_audio && !receiving_audio) {
     local_sdp_->audioDirection = erizo::SENDONLY;
-  } else {
+  } else if (sending_audio && receiving_audio) {
     local_sdp_->audioDirection = erizo::SENDRECV;
+  } else {
+    local_sdp_->audioDirection = erizo::INACTIVE;
   }
 
   if (!sending_video && receiving_video) {
     local_sdp_->videoDirection = erizo::RECVONLY;
   } else if (sending_video && !receiving_video) {
     local_sdp_->videoDirection = erizo::SENDONLY;
-  } else {
+  } else if (sending_video && receiving_video) {
     local_sdp_->videoDirection = erizo::SENDRECV;
+  } else {
+    local_sdp_->videoDirection = erizo::INACTIVE;
   }
 
   auto local_sdp_copy = std::make_shared<SdpInfo>(*local_sdp_.get());

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -355,11 +355,13 @@ std::shared_ptr<SdpInfo> WebRtcConnection::getLocalSdpInfoSync() {
   bool sending_video = local_sdp_->video_ssrc_map.size() > 0;
 
   int audio_sources = 0;
-  for (auto iterator = remote_sdp_->audio_ssrc_map.begin(), itr_end = remote_sdp_->audio_ssrc_map.end(); iterator != itr_end; ++iterator) {
+  for (auto iterator = remote_sdp_->audio_ssrc_map.begin(), itr_end = remote_sdp_->audio_ssrc_map.end();
+      iterator != itr_end; ++iterator) {
     audio_sources++;
   }
   int video_sources = 0;
-  for (auto iterator = remote_sdp_->video_ssrc_map.begin(), itr_end = remote_sdp_->video_ssrc_map.end(); iterator != itr_end; ++iterator) {
+  for (auto iterator = remote_sdp_->video_ssrc_map.begin(), itr_end = remote_sdp_->video_ssrc_map.end();
+      iterator != itr_end; ++iterator) {
     video_sources += iterator->second->size();
   }
 

--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -362,7 +362,7 @@ std::shared_ptr<SdpInfo> WebRtcConnection::getLocalSdpInfoSync() {
   int video_sources = 0;
   for (auto iterator = remote_sdp_->video_ssrc_map.begin(), itr_end = remote_sdp_->video_ssrc_map.end();
       iterator != itr_end; ++iterator) {
-    video_sources += iterator->second->size();
+    video_sources += iterator->second.size();
   }
 
   bool receiving_audio = audio_sources > 0;

--- a/erizoAPI/ConnectionDescription.cc
+++ b/erizoAPI/ConnectionDescription.cc
@@ -337,6 +337,8 @@ NAN_METHOD(ConnectionDescription::setVideoDirection) {
     sdp->videoDirection = erizo::SENDRECV;
   } else if (direction == "recvonly") {
     sdp->videoDirection = erizo::RECVONLY;
+  } else if (direction == "inactive") {
+    sdp->videoDirection = erizo::INACTIVE;
   }
 }
 
@@ -350,6 +352,8 @@ NAN_METHOD(ConnectionDescription::setAudioDirection) {
     sdp->audioDirection = erizo::SENDRECV;
   } else if (direction == "recvonly") {
     sdp->audioDirection = erizo::RECVONLY;
+  } else if (direction == "inactive") {
+    sdp->audioDirection = erizo::INACTIVE;
   }
 }
 
@@ -369,6 +373,9 @@ NAN_METHOD(ConnectionDescription::getDirection) {
       break;
     case erizo::SENDRECV:
       value = "sendrecv";
+      break;
+    case erizo::INACTIVE:
+      value = "inactive";
       break;
     case erizo::RECVONLY:
     default:


### PR DESCRIPTION
**Description**

Fixes #1466 

Firefox expects an answer with a=inactive when there is no audio or video in an SDP negotiation.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.