### PR TITLE
Fix PT negotiation with format parameters

### DIFF
--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -954,7 +954,7 @@ namespace erizo {
             }
           }
         }
-        negotiated_map.format_parameters = internal_map.format_parameters;
+        negotiated_map.format_parameters = negotiated_parameters;
         if (internal_map.format_parameters.empty() ||
             parsed_map.format_parameters.size() == negotiated_parameters.size()) {
           if (negotiated_map.media_type == VIDEO_TYPE) {

--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -919,25 +919,8 @@ namespace erizo {
           rtx_maps.push_back(parsed_map);
           continue;
         }
-        if (parsed_map.format_parameters.size() == internal_map.format_parameters.size()) {
-          bool matches_parameters = true;
-          for (auto& parameter : internal_map.format_parameters) {
-            if (parsed_map.format_parameters.at(parameter.first) != parameter.second) {
-              matches_parameters = false;
-              break;
-            }
-          }
-          if (!matches_parameters) {
-            continue;
-          }
-        }
         RtpMap negotiated_map(parsed_map);
-        outInPTMap[parsed_map.payload_type] = internal_map.payload_type;
-        inOutPTMap[internal_map.payload_type] = parsed_map.payload_type;
         negotiated_map.channels = internal_map.channels;
-        ELOG_DEBUG("Mapping %s/%d:%d to %s/%d:%d",
-            parsed_map.encoding_name.c_str(), parsed_map.clock_rate, parsed_map.payload_type,
-            internal_map.encoding_name.c_str(), internal_map.clock_rate, internal_map.payload_type);
 
 
         ELOG_DEBUG("message: Checking feedback types, parsed: %lu, internal:%lu", parsed_map.feedback_types.size(),
@@ -971,16 +954,20 @@ namespace erizo {
             }
           }
         }
-        negotiated_map.format_parameters = negotiated_parameters;
-
-        if (negotiated_map.media_type == VIDEO_TYPE) {
-          videoCodecs++;
-        } else {
-          audioCodecs++;
-        }
+        negotiated_map.format_parameters = internal_map.format_parameters;
         if (internal_map.format_parameters.empty() ||
             parsed_map.format_parameters.size() == negotiated_parameters.size()) {
+          if (negotiated_map.media_type == VIDEO_TYPE) {
+            videoCodecs++;
+          } else {
+            audioCodecs++;
+          }
+          ELOG_DEBUG("Mapping %s/%d:%d to %s/%d:%d",
+              parsed_map.encoding_name.c_str(), parsed_map.clock_rate, parsed_map.payload_type,
+              internal_map.encoding_name.c_str(), internal_map.clock_rate, internal_map.payload_type);
           payloadVector.push_back(negotiated_map);
+          outInPTMap[parsed_map.payload_type] = internal_map.payload_type;
+          inOutPTMap[internal_map.payload_type] = parsed_map.payload_type;
         }
       }
     }

--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -919,10 +919,7 @@ namespace erizo {
           rtx_maps.push_back(parsed_map);
           continue;
         }
-        if (internal_map.format_parameters.size() > 0) {
-          if (parsed_map.format_parameters.size() != internal_map.format_parameters.size()) {
-            continue;
-          }
+        if (parsed_map.format_parameters.size() == internal_map.format_parameters.size()) {
           bool matches_parameters = true;
           for (auto& parameter : internal_map.format_parameters) {
             if (parsed_map.format_parameters.at(parameter.first) != parameter.second) {

--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -919,6 +919,21 @@ namespace erizo {
           rtx_maps.push_back(parsed_map);
           continue;
         }
+        if (internal_map.format_parameters.size() > 0) {
+          if (parsed_map.format_parameters.size() != internal_map.format_parameters.size()) {
+            continue;
+          }
+          bool matches_parameters = true;
+          for (auto& parameter : internal_map.format_parameters) {
+            if (parsed_map.format_parameters.at(parameter.first) != parameter.second) {
+              matches_parameters = false;
+              break;
+            }
+          }
+          if (!matches_parameters) {
+            continue;
+          }
+        }
         RtpMap negotiated_map(parsed_map);
         outInPTMap[parsed_map.payload_type] = internal_map.payload_type;
         inOutPTMap[internal_map.payload_type] = parsed_map.payload_type;

--- a/erizo/src/erizo/SdpInfo.h
+++ b/erizo/src/erizo/SdpInfo.h
@@ -339,6 +339,10 @@ class SdpInfo {
   std::string stringifyCandidate(const CandidateInfo & candidate);
   void gen_random(char* s, int len);
   void maybeAddSsrcToList(uint32_t ssrc);
+  std::vector<std::string> negotiateFeedback(const RtpMap& parsed_map,
+      const RtpMap& internal_map);
+  std::map<std::string, std::string> maybeCopyFormatParameters(const RtpMap& parsed_map,
+      const RtpMap& internal_map);
 };
 }  // namespace erizo
 #endif  // ERIZO_SRC_ERIZO_SDPINFO_H_


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
This PR fixes some problems with the media_parameters negotiation. Before this, a codec that we didn't support parameters for could get in the negotiated payloadVector.
Furthermore, if several instances of the same codec but with different parameters and PT were in the offer, we would only keep the last PT

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.