### PR TITLE
Better handling of SSL errors

### DIFF
--- a/erizo/src/erizo/dtls/DtlsSocket.cpp
+++ b/erizo/src/erizo/dtls/DtlsSocket.cpp
@@ -120,11 +120,13 @@ void DtlsSocket::forceRetransmit() {
 
 void DtlsSocket::doHandshakeIteration() {
   boost::mutex::scoped_lock lock(handshakeMutex_);
-  int sslerr;
+  int ssl_error_code;
 
   if (mHandshakeCompleted) {
     return;
   }
+
+  int return_value = SSL_do_handshake(mSsl);
 
   // See what was written
   unsigned char *outBioData;
@@ -134,10 +136,8 @@ void DtlsSocket::doHandshakeIteration() {
         outBioLen, DTLS_MTU);
   }
 
-  int r = SSL_do_handshake(mSsl);
-
   // Now handle handshake errors */
-  switch (sslerr = SSL_get_error(mSsl, r)) {
+  switch (ssl_error_code = SSL_get_error(mSsl, return_value)) {
     case SSL_ERROR_NONE:
       mHandshakeCompleted = true;
       mSocketContext->handshakeCompleted();
@@ -145,10 +145,10 @@ void DtlsSocket::doHandshakeIteration() {
     case SSL_ERROR_WANT_READ:
       break;
     default:
-      ELOG_ERROR("SSL error %d", sslerr);
+      ELOG_ERROR("message: SSL error %d", ssl_error_code);
       char error_string_buffer[1024];
 
-      ERR_error_string_n(sslerr, error_string_buffer, sizeof(error_string_buffer));
+      ERR_error_string_n(ssl_error_code, error_string_buffer, sizeof(error_string_buffer));
 
       mSocketContext->handshakeFailed(error_string_buffer);
       // Note: need to fall through to propagate alerts, if any


### PR DESCRIPTION
**Description**

We need to better handling SSL errors because we are now seeing some crashes in production after having updated to a newer OpenSSL version.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.