### PR TITLE
Fix issues with video mute in trackMuteHandler

### DIFF
--- a/erizo/src/erizo/rtp/RtpTrackMuteHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpTrackMuteHandler.cpp
@@ -7,7 +7,8 @@ namespace erizo {
 
 DEFINE_LOGGER(RtpTrackMuteHandler, "rtp.RtpTrackMuteHandler");
 
-RtpTrackMuteHandler::RtpTrackMuteHandler() : audio_info_{"audio"}, video_info_{"video"}, stream_{nullptr} {}
+RtpTrackMuteHandler::RtpTrackMuteHandler(std::shared_ptr<erizo::Clock> the_clock) : audio_info_{"audio"},
+  video_info_{"video"}, clock_{the_clock}, stream_{nullptr} {}
 
 void RtpTrackMuteHandler::enable() {
 }
@@ -37,35 +38,34 @@ void RtpTrackMuteHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet)
 }
 
 void RtpTrackMuteHandler::handleFeedback(const TrackMuteInfo &info, const std::shared_ptr<DataPacket> &packet) {
-  RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
-  uint16_t offset = info.seq_num_offset;
-  if (offset > 0) {
-    char* buf = packet->data;
-    char* report_pointer = buf;
-    int rtcp_length = 0;
-    int total_length = 0;
-    do {
-      report_pointer += rtcp_length;
-      chead = reinterpret_cast<RtcpHeader*>(report_pointer);
-      rtcp_length = (ntohs(chead->length) + 1) * 4;
-      total_length += rtcp_length;
-      switch (chead->packettype) {
-        case RTCP_Receiver_PT:
-          if ((chead->getHighestSeqnum() + offset) < chead->getHighestSeqnum()) {
-            // The seqNo adjustment causes a wraparound, add to cycles
-            chead->setSeqnumCycles(chead->getSeqnumCycles() + 1);
+  RtpUtils::forEachRtcpBlock(packet, [info](RtcpHeader *chead) {
+    switch (chead->packettype) {
+      case RTCP_Receiver_PT:
+        {
+          uint16_t incoming_seq_num = chead->getHighestSeqnum();
+          SequenceNumber input_seq_num = info.translator.reverse(incoming_seq_num);
+          if (input_seq_num.type != SequenceNumberType::Valid) {
+            break;
           }
-          chead->setHighestSeqnum(chead->getHighestSeqnum() + offset);
+          if (RtpUtils::sequenceNumberLessThan(input_seq_num.input, incoming_seq_num)) {
+            chead->setSeqnumCycles(chead->getSeqnumCycles() - 1);
+          }
 
+          chead->setHighestSeqnum(input_seq_num.input);
           break;
-        case RTCP_RTP_Feedback_PT:
-          chead->setNackPid(chead->getNackPid() + offset);
+        }
+      case RTCP_RTP_Feedback_PT:
+        {
+          SequenceNumber input_seq_num = info.translator.reverse(chead->getNackPid());
+          if (input_seq_num.type == SequenceNumberType::Valid) {
+            chead->setNackPid(input_seq_num.input);
+          }
           break;
-        default:
-          break;
-      }
-    } while (total_length < packet->length);
-  }
+        }
+      default:
+        break;
+    }
+  });
 }
 
 void RtpTrackMuteHandler::write(Context *ctx, std::shared_ptr<DataPacket> packet) {
@@ -83,37 +83,49 @@ void RtpTrackMuteHandler::write(Context *ctx, std::shared_ptr<DataPacket> packet
 
 void RtpTrackMuteHandler::handlePacket(Context *ctx, TrackMuteInfo *info, std::shared_ptr<DataPacket> packet) {
   RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
-  info->last_original_seq_num = rtp_header->getSeqNumber();
-  if (info->last_sent_seq_num == -1) {
-    info->last_sent_seq_num = info->last_original_seq_num;
-  }
+  time_point now = clock_->now();
+  bool should_skip_packet = false;
   if (info->mute_is_active) {
-    if (packet->is_keyframe) {
-      if (info->unmute_requested) {
+    if (info->label == "video") {
+      if (packet->is_keyframe && info->unmute_requested) {
         ELOG_DEBUG("%s message: Keyframe arrived - unmuting video", stream_->toLog());
         info->mute_is_active = false;
         info->unmute_requested = false;
-      } else {
-        ELOG_DEBUG("%s message: video muted - maybe transforming into black keyframe", stream_->toLog());
+        last_keyframe_sent_time_ = now;
+      } else if (packet->is_keyframe ||
+          (now - last_keyframe_sent_time_) > kMuteVideoKeyframeTimeout) {
+        ELOG_DEBUG("Will create Keyframe last_keyframe time: %u is_keyframe: %u", now - last_keyframe_sent_time_,
+            packet->is_keyframe);
         if (packet->codec == "VP8") {
           packet = transformIntoBlackKeyframePacket(packet);
+          last_keyframe_sent_time_ = now;
         } else {
-          ELOG_WARN("%s cannot generate keyframe packet is not available for codec %s",
+          ELOG_INFO("%s cannot generate keyframe packet is not available for codec %s",
               stream_->toLog(), packet->codec);
-          return;
+          should_skip_packet = true;
         }
+      } else {
+        should_skip_packet = true;;
       }
-      updateOffset(info);
     } else {
-      return;
+      should_skip_packet = true;
     }
   }
-  uint16_t offset = info->seq_num_offset;
-  info->last_sent_seq_num = info->last_original_seq_num - offset;
-  if (offset > 0) {
-    setPacketSeqNumber(packet, info->last_sent_seq_num);
+  RtpHeader *head = reinterpret_cast<RtpHeader*> (packet->data);
+  uint16_t packet_seq_num = rtp_header->getSeqNumber();
+  maybeUpdateHighestSeqNum(info, packet_seq_num);
+  SequenceNumber sequence_number_info = info->translator.get(packet_seq_num, should_skip_packet);
+  if (!should_skip_packet) {
+    setPacketSeqNumber(packet, sequence_number_info.output);
+    ctx->fireWrite(std::move(packet));
   }
-  ctx->fireWrite(std::move(packet));
+}
+
+void RtpTrackMuteHandler::maybeUpdateHighestSeqNum(TrackMuteInfo *info, uint16_t seq_num) {
+  if (RtpUtils::sequenceNumberLessThan(info->highest_seq_num, seq_num) || !info->highest_seq_num_initialized) {
+    info->highest_seq_num = seq_num;
+    info->highest_seq_num_initialized = true;
+  }
 }
 
 void RtpTrackMuteHandler::muteAudio(bool active) {
@@ -133,11 +145,10 @@ void RtpTrackMuteHandler::muteTrack(TrackMuteInfo *info, bool active) {
     if (info->label == "video") {
       info->unmute_requested = true;
       getContext()->fireRead(RtpUtils::createPLI(stream_->getVideoSinkSSRC(), stream_->getVideoSourceSSRC()));
-      ELOG_DEBUG("%s message: Unmute requested for video, original_seq_num: %u, last_sent_seq_num: %u, offset: %u",
-          stream_->toLog(), info->last_original_seq_num, info->last_sent_seq_num, info->seq_num_offset);
+      ELOG_DEBUG("%s message: Unmute requested for video",
+          stream_->toLog());
     } else {
       info->mute_is_active = active;
-      updateOffset(info);
     }
   } else {
     info->mute_is_active = active;
@@ -151,10 +162,6 @@ inline void RtpTrackMuteHandler::setPacketSeqNumber(std::shared_ptr<DataPacket> 
     return;
   }
   head->setSeqNumber(seq_number);
-}
-
-void RtpTrackMuteHandler::updateOffset(TrackMuteInfo *info) {
-  info->seq_num_offset = info->last_original_seq_num - info->last_sent_seq_num;
 }
 
 

--- a/erizo/src/erizo/rtp/RtpTrackMuteHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpTrackMuteHandler.cpp
@@ -94,18 +94,18 @@ void RtpTrackMuteHandler::handlePacket(Context *ctx, TrackMuteInfo *info, std::s
         last_keyframe_sent_time_ = now;
       } else if (packet->is_keyframe ||
           (now - last_keyframe_sent_time_) > kMuteVideoKeyframeTimeout) {
-        ELOG_DEBUG("Will create Keyframe last_keyframe time: %u is_keyframe: %u", now - last_keyframe_sent_time_,
-            packet->is_keyframe);
+        ELOG_DEBUG("message: Will create Keyframe last_keyframe, time: %u, is_keyframe: %u",
+            now - last_keyframe_sent_time_, packet->is_keyframe);
         if (packet->codec == "VP8") {
           packet = transformIntoBlackKeyframePacket(packet);
           last_keyframe_sent_time_ = now;
         } else {
-          ELOG_INFO("%s cannot generate keyframe packet is not available for codec %s",
+          ELOG_INFO("%s message: cannot generate keyframe packet is not available for codec %s",
               stream_->toLog(), packet->codec);
           should_skip_packet = true;
         }
       } else {
-        should_skip_packet = true;;
+        should_skip_packet = true;
       }
     } else {
       should_skip_packet = true;

--- a/erizo/src/erizo/rtp/RtpTrackMuteHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpTrackMuteHandler.cpp
@@ -111,7 +111,6 @@ void RtpTrackMuteHandler::handlePacket(Context *ctx, TrackMuteInfo *info, std::s
       should_skip_packet = true;
     }
   }
-  RtpHeader *head = reinterpret_cast<RtpHeader*> (packet->data);
   uint16_t packet_seq_num = rtp_header->getSeqNumber();
   maybeUpdateHighestSeqNum(info, packet_seq_num);
   SequenceNumber sequence_number_info = info->translator.get(packet_seq_num, should_skip_packet);

--- a/erizo/src/erizo/rtp/RtpTrackMuteHandler.h
+++ b/erizo/src/erizo/rtp/RtpTrackMuteHandler.h
@@ -3,8 +3,11 @@
 
 #include "./logger.h"
 #include "pipeline/Handler.h"
+#include "rtp/SequenceNumberTranslator.h"
 
 #include <mutex>  // NOLINT
+
+static constexpr erizo::duration kMuteVideoKeyframeTimeout = std::chrono::seconds(5);
 
 namespace erizo {
 
@@ -13,12 +16,12 @@ class MediaStream;
 class TrackMuteInfo {
  public:
   explicit TrackMuteInfo(std::string label_)
-    : label{label_}, last_original_seq_num{-1}, seq_num_offset{0},
-      last_sent_seq_num{-1}, mute_is_active{false}, unmute_requested{false} {}
+    : label{label_}, highest_seq_num{0}, highest_seq_num_initialized{false},
+    mute_is_active{false}, unmute_requested{false} {}
   std::string label;
-  int32_t last_original_seq_num;
-  uint16_t seq_num_offset;
-  int32_t last_sent_seq_num;
+  SequenceNumberTranslator translator;
+  uint16_t highest_seq_num;
+  uint16_t highest_seq_num_initialized;
   bool mute_is_active;
   bool unmute_requested;
 };
@@ -27,7 +30,7 @@ class RtpTrackMuteHandler: public Handler {
   DECLARE_LOGGER();
 
  public:
-  RtpTrackMuteHandler();
+  explicit RtpTrackMuteHandler(std::shared_ptr<erizo::Clock> the_clock = std::make_shared<SteadyClock>());
   void muteAudio(bool active);
   void muteVideo(bool active);
 
@@ -46,6 +49,7 @@ class RtpTrackMuteHandler: public Handler {
   void muteTrack(TrackMuteInfo *info, bool active);
   void handleFeedback(const TrackMuteInfo &info, const std::shared_ptr<DataPacket> &packet);
   void handlePacket(Context *ctx, TrackMuteInfo *info, std::shared_ptr<DataPacket> packet);
+  void maybeUpdateHighestSeqNum(TrackMuteInfo *info, uint16_t seq_num);
   inline void setPacketSeqNumber(std::shared_ptr<DataPacket> packet, uint16_t seq_number);
   std::shared_ptr<DataPacket> transformIntoBlackKeyframePacket(std::shared_ptr<DataPacket> packet);
   void updateOffset(TrackMuteInfo *info);
@@ -53,6 +57,8 @@ class RtpTrackMuteHandler: public Handler {
  private:
   TrackMuteInfo audio_info_;
   TrackMuteInfo video_info_;
+  time_point last_keyframe_sent_time_;
+  std::shared_ptr<erizo::Clock> clock_;
 
   MediaStream* stream_;
 };

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -379,17 +379,17 @@ const Stream = (altConnectionHelpers, specInput) => {
       callback('error');
       return;
     }
-    if (that.stream) {
-      for (let index = 0; index < that.stream.getVideoTracks().length; index += 1) {
-        const track = that.stream.getVideoTracks()[index];
-        track.enabled = !that.videoMuted;
-      }
+    if (!that.stream || !that.pc) {
+      Logger.warning('muteAudio/muteVideo cannot be called until a stream is published or subscribed');
+      callback('error');
+    }
+    for (let index = 0; index < that.stream.getVideoTracks().length; index += 1) {
+      const track = that.stream.getVideoTracks()[index];
+      track.enabled = !that.videoMuted;
     }
     const config = { muteStream: { audio: that.audioMuted, video: that.videoMuted } };
     that.checkOptions(config, true);
-    if (that.pc) {
-      that.pc.updateSpec(config, that.getID(), callback);
-    }
+    that.pc.updateSpec(config, that.getID(), callback);
   };
 
   that.muteAudio = (isMuted, callback = () => {}) => {


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
This PR addresses issues in TrackMuteHandler - particularly video issues:
1. Now we will only be able to mute video or audio tracks once the stream is published or subscribed. We allowed mutes before the pc was present, generating weird cases.
2. Once the video is muted we let a frame through periodically - transforming it into a black keyframe
3. Better manage sequence number by using translators instead of an offset.

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.