### PR TITLE
Update conan version to 1.21

### DIFF
--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -88,7 +88,7 @@ install_apt_deps(){
 }
 
 install_conan(){
-  pip3 install conan==1.18.5
+  pip3 install conan==1.21
 }
 
 download_openssl() {


### PR DESCRIPTION
**Description**

Update conan to version 1.21. Previous version started to fail.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.