### PR TITLE
Fix client to susbcribe to local streams

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -327,7 +327,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       return;
     }
     const stream = Stream(that.Connection, { streamID: arg.id,
-      local: localStreams.has(arg.id),
+      local: false,
       audio: arg.audio,
       video: arg.video,
       data: arg.data,


### PR DESCRIPTION
**Description**

We were not able to susbcribe to the remote version of local streams because we were marking them as remote. Not sure about the implications of this change yet so I need to investigate further to check if it could affect other features.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.