### PR TITLE
Fix negotiation when removing streams

### DIFF
--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -276,6 +276,10 @@ const BaseStack = (specInput) => {
     protectedRemoveStream: (stream) => {
       try {
         that.peerConnection.removeStream(stream);
+        setTimeout(() => {
+          negotiationQueue.stopEnqueuing();
+          negotiationQueue.nextInQueue();
+        }, 0);
       } catch (e) {
         setTimeout(() => {
           negotiationQueue.stopEnqueuing();


### PR DESCRIPTION
**Description**

There was an issue when unpublishing streams and then trying to subscribe to new ones beucase the negotiation got blocked. The problem was that we expected that Chrome called onnegotiationneeded after calling remoteStream.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.