### PR TITLE
Send SDP Offers from Erizo by default

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -656,6 +656,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     options.audio = (options.audio === undefined) ? true : options.audio;
     options.video = (options.video === undefined) ? true : options.video;
     options.data = (options.data === undefined) ? true : options.data;
+    options.offerFromErizo = (options.offerFromErizo === undefined) ? true : options.offerFromErizo;
     stream.checkOptions(options);
     const constraint = { streamId: stream.getID(),
       audio: options.audio && stream.hasAudio(),


### PR DESCRIPTION
**Description**

Send SDP offers from Erizo by default. The other options will eventually be removed once this is used in production.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.