### PR TITLE
Improve the way we look for Erizo Client Connections internally

### DIFF
--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -168,6 +168,18 @@ class ErizoConnectionManager {
     this.ErizoConnectionsMap = new Map(); // key: erizoId, value: {connectionId: connection}
   }
 
+  getErizoConnection(erizoConnectionId) {
+    let connection;
+    this.ErizoConnectionsMap.forEach((entry) => {
+      Object.keys(entry).forEach((entryKey) => {
+        if (entry[entryKey].connectionId === erizoConnectionId) {
+          connection = entry[entryKey];
+        }
+      });
+    });
+    return connection;
+  }
+
   getOrBuildErizoConnection(specInput, erizoId = undefined, singlePC = false) {
     Logger.debug(`message: getOrBuildErizoConnection, erizoId: ${erizoId}`);
     let connection = {};

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -386,27 +386,14 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   };
 
   const socketOnConnectionMessageFromErizo = (arg) => {
-    let done = false;
     if (arg.evt.type === 'quality_level') {
       socketOnConnectionQualityLevel(arg);
       return;
     }
-    localStreams.forEach((stream) => {
-      if (!done && !stream.failed && stream.pc && stream.pc.connectionId === arg.connectionId) {
-        stream.pc.processSignalingMessage(arg.evt);
-        done = true;
-      }
-    });
-    if (done) {
-      return;
-    }
-    remoteStreams.forEach((stream) => {
-      if (!done && !stream.failed && stream.pc && stream.pc.connectionId === arg.connectionId) {
-        stream.pc.processSignalingMessage(arg.evt);
-        done = true;
-      }
-    });
-    if (!done) {
+    const connection = that.erizoConnectionManager.getErizoConnection(arg.connectionId);
+    if (connection) {
+      connection.processSignalingMessage(arg.evt);
+    } else {
       Logger.warning('Received signaling message to unknown connectionId', arg.connectionId);
     }
   };


### PR DESCRIPTION
**Description**

This is specially useful when unsubscribing or unpublishing streams in Single Peer Connection. We could not find existing connections because they were not attached to any stream in some cases.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.