### PR TITLE
Trigger connection-failed events when negotiation times out

### DIFF
--- a/doc/client_api.md
+++ b/doc/client_api.md
@@ -869,6 +869,30 @@ stream.addEventListener("stream-data", function(evt){
 room.addEventListener("stream-attributes-update", function(evt){...});
 ```
 
+## Connection Event
+
+It represents an event related to an internal connection.
+
+There is currently only one possible event type called `connection-failed` that is triggered when the signaling negotiation inside a connection times out.
+
+They are dispatched by Room objects.
+
+<example>
+A ConnectionEvent can be initialized like this, but it is usually created by Client API.
+</example>
+
+```
+var connectionEvent = Erizo.ConnectionEvent({type:"connection-failed"});
+```
+
+<example>
+`connection-failed` is dispatched by Room objects, so you need to add event listeners to them.
+</example>
+
+```
+room.addEventListener("connection-failed", function(evt) {...});
+```
+
 # Examples
 
 Here we show some examples and code snippets for typical use cases in this API.

--- a/erizo_controller/erizoClient/src/Erizo.js
+++ b/erizo_controller/erizoClient/src/Erizo.js
@@ -1,5 +1,5 @@
 import Room from './Room';
-import { LicodeEvent, RoomEvent, StreamEvent } from './Events';
+import { LicodeEvent, RoomEvent, StreamEvent, ConnectionEvent } from './Events';
 import Stream from './Stream';
 import Logger from './utils/Logger';
 
@@ -11,6 +11,7 @@ const Erizo = {
   LicodeEvent,
   RoomEvent,
   StreamEvent,
+  ConnectionEvent,
   Stream: Stream.bind(null, undefined),
   Logger,
 };

--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -36,6 +36,10 @@ class ErizoConnection extends EventEmitterConst {
     this.connectionId = spec.connectionId;
     this.qualityLevel = QUALITY_LEVEL_GOOD;
 
+    spec.onEnqueueingTimeout = () => {
+      this.emit(ConnectionEvent({ type: 'connection-failed', id: this.connectionId }));
+    };
+
     if (!spec.streamRemovedListener) {
       spec.streamRemovedListener = () => {};
     }

--- a/erizo_controller/erizoClient/src/Events.js
+++ b/erizo_controller/erizoClient/src/Events.js
@@ -114,6 +114,7 @@ const LicodeEvent = (spec) => {
  * 'stream-added' - a stream has been added to the connection.
  * 'stream-removed' - a stream has been removed from the connection.
  * 'ice-state-change' - ICE state changed
+ * 'connection-failed' - Connection Failed
  */
 const ConnectionEvent = (spec) => {
   const that = LicodeEvent(spec);

--- a/erizo_controller/erizoClient/src/utils/FunctionQueue.js
+++ b/erizo_controller/erizoClient/src/utils/FunctionQueue.js
@@ -1,7 +1,9 @@
 class FunctionQueue {
-  constructor() {
+  constructor(maxEnqueueingTime = 30000, onEnqueueingTimeout = () => {}) {
     this._enqueuing = false;
     this._queuedArgs = [];
+    this.maxEnqueueingTime = maxEnqueueingTime;
+    this.onEnqueueingTimeout = onEnqueueingTimeout;
   }
 
   protectFunction(protectedFunction) {
@@ -14,10 +16,16 @@ class FunctionQueue {
 
   startEnqueuing() {
     this._enqueuing = true;
+    this._enqueueingTimeout = setTimeout(() => {
+      if (this.onEnqueueingTimeout) {
+        this.onEnqueueingTimeout();
+      }
+    }, this.maxEnqueueingTime);
   }
 
   stopEnqueuing() {
     this._enqueuing = false;
+    clearTimeout(this._enqueueingTimeout);
   }
 
   nextInQueue() {

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -11,10 +11,12 @@ import SdpHelpers from '../utils/SdpHelpers';
 import Logger from '../utils/Logger';
 import FunctionQueue from '../utils/FunctionQueue';
 
+const NEGOTIATION_TIMEOUT = 30000;
+
 const BaseStack = (specInput) => {
   const that = {};
   const specBase = specInput;
-  const negotiationQueue = new FunctionQueue(30000, () => {
+  const negotiationQueue = new FunctionQueue(NEGOTIATION_TIMEOUT, () => {
     if (specBase.onEnqueueingTimeout) {
       specBase.onEnqueueingTimeout();
     }

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -14,7 +14,11 @@ import FunctionQueue from '../utils/FunctionQueue';
 const BaseStack = (specInput) => {
   const that = {};
   const specBase = specInput;
-  const negotiationQueue = new FunctionQueue();
+  const negotiationQueue = new FunctionQueue(30000, () => {
+    if (specBase.onEnqueueingTimeout) {
+      specBase.onEnqueueingTimeout();
+    }
+  });
   that._queue = negotiationQueue;
   let localDesc;
   let remoteDesc;


### PR DESCRIPTION
**Description**

We have a new timeout for negotiations that get locked and we trigger a `connection-failed` when it happens.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

I updated the client API with the new event.

- [x] It includes documentation for these changes in `/doc`.