### PR TITLE
Hacky fix for delay when resolving promise

### DIFF
--- a/erizo_controller/erizoJS/erizoJS.js
+++ b/erizo_controller/erizoJS/erizoJS.js
@@ -123,6 +123,8 @@ ejsController.publicIP = process.argv[4];
 amqper.connect(() => {
   try {
     amqper.setPublicRPC(ejsController);
+    // HACK this seems to reduce the delay of the first promise resolved from ErizoAPI
+    setTimeout(() => {}, 0);
 
     log.info(`message: Started, erizoId: ${rpcID}, isDebugMode: ${isDebugMode}`);
 

--- a/erizo_controller/log4js_configuration.json
+++ b/erizo_controller/log4js_configuration.json
@@ -20,6 +20,7 @@
     "ErizoAgentReporter": "ERROR",
     "EcCloudHandler": "INFO",
     "Publisher": "INFO",
+    "Node": "INFO",
     "Subscriber": "INFO",
     "Room": "INFO",
     "RoomController": "INFO",


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

In my setup this reduces the delay of the first publisher in ErizoJS.
The delay is caused by the resolution of the `addMediaStream` promise returned when creating a Publisher. We wait for that promise to complete in order to start the connection. In my tests that promise resolves in less than 5ms in erizoAPI but the callback from the promise in ErizoJS can often take around 5 seconds. This hacky solution greatly reduces the chances of that happening in my setup.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.