### PR TITLE
Put back audio delay hack and add stats

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -365,7 +365,7 @@ void MediaStream::printStats() {
     transferMediaStats("videoPL",      video_ssrc, "packetsLost");
     transferMediaStats("videoFL",      video_ssrc, "fractionLost");
     transferMediaStats("videoJitter",  video_ssrc, "jitter");
-    transferMediaStats("videoMuted",   video_ssrc, "erizoVideoMute");
+    transferMediaStats("videoMuted",   audio_ssrc, "erizoVideoMute");
     transferMediaStats("slideshow",    video_ssrc, "erizoSlideShow");
     transferMediaStats("videoNack",    video_ssrc, "NACK");
     transferMediaStats("videoPli",     video_ssrc, "PLI");

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -257,6 +257,8 @@ void MediaStream::initializeStats() {
   log_stats_->getNode().insertStat("audioMuted", CumulativeStat{0});
   log_stats_->getNode().insertStat("audioNack", CumulativeStat{0});
   log_stats_->getNode().insertStat("audioRemb", CumulativeStat{0});
+  log_stats_->getNode().insertStat("audioSrTimestamp", CumulativeStat{0});
+  log_stats_->getNode().insertStat("audioSrNtp", CumulativeStat{0});
 
   log_stats_->getNode().insertStat("videoBitrate", CumulativeStat{0});
   log_stats_->getNode().insertStat("videoFL", CumulativeStat{0});
@@ -270,6 +272,8 @@ void MediaStream::initializeStats() {
   log_stats_->getNode().insertStat("videoRemb", CumulativeStat{0});
   log_stats_->getNode().insertStat("videoErizoRemb", CumulativeStat{0});
   log_stats_->getNode().insertStat("videoKeyFrames", CumulativeStat{0});
+  log_stats_->getNode().insertStat("videoSrTimestamp", CumulativeStat{0});
+  log_stats_->getNode().insertStat("videoSrNtp", CumulativeStat{0});
 
   log_stats_->getNode().insertStat("SL0TL0", CumulativeStat{0});
   log_stats_->getNode().insertStat("SL0TL1", CumulativeStat{0});
@@ -352,6 +356,8 @@ void MediaStream::printStats() {
     transferMediaStats("audioMuted",   audio_ssrc, "erizoAudioMute");
     transferMediaStats("audioNack",    audio_ssrc, "NACK");
     transferMediaStats("audioRemb",    audio_ssrc, "bandwidth");
+    transferMediaStats("audioSrTimestamp", audio_ssrc, "srTimestamp");
+    transferMediaStats("audioSrNtp", audio_ssrc, "srNtp");
   }
   if (video_enabled_) {
     video_ssrc = std::to_string(is_publisher_ ? getVideoSourceSSRC() : getVideoSinkSSRC());
@@ -359,7 +365,7 @@ void MediaStream::printStats() {
     transferMediaStats("videoPL",      video_ssrc, "packetsLost");
     transferMediaStats("videoFL",      video_ssrc, "fractionLost");
     transferMediaStats("videoJitter",  video_ssrc, "jitter");
-    transferMediaStats("videoMuted",   audio_ssrc, "erizoVideoMute");
+    transferMediaStats("videoMuted",   video_ssrc, "erizoVideoMute");
     transferMediaStats("slideshow",    video_ssrc, "erizoSlideShow");
     transferMediaStats("videoNack",    video_ssrc, "NACK");
     transferMediaStats("videoPli",     video_ssrc, "PLI");
@@ -367,6 +373,8 @@ void MediaStream::printStats() {
     transferMediaStats("videoRemb",    video_ssrc, "bandwidth");
     transferMediaStats("videoErizoRemb", video_ssrc, "erizoBandwidth");
     transferMediaStats("videoKeyFrames", video_ssrc, "keyFrames");
+    transferMediaStats("videoSrTimestamp", video_ssrc, "srTimestamp");
+    transferMediaStats("videoSrNtp", video_ssrc, "srNtp");
   }
 
   for (uint32_t spatial = 0; spatial <= 3; spatial++) {

--- a/erizo/src/erizo/OneToManyProcessor.cpp
+++ b/erizo/src/erizo/OneToManyProcessor.cpp
@@ -33,7 +33,8 @@ namespace erizo {
     RtcpHeader* chead = reinterpret_cast<RtcpHeader*>(audio_packet->data);
     for (it = subscribers.begin(); it != subscribers.end(); ++it) {
       if ((*it).second != nullptr) {
-        if (chead->isRtcp()) {
+        // Hack to avoid audio drift
+        if (chead->isRtcp() && chead->isSDES()) {
           chead->setSSRC((*it).second->getAudioSinkSSRC());
         } else {
           head->setSSRC((*it).second->getAudioSinkSSRC());

--- a/erizo/src/erizo/rtp/QualityFilterHandler.cpp
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.cpp
@@ -220,12 +220,16 @@ void QualityFilterHandler::write(Context *ctx, std::shared_ptr<DataPacket> packe
       tl0_pic_idx_sent : last_tl0_pic_idx_sent_;
     updateTL0PicIdx(packet, tl0_pic_idx_sent);
     // removeVP8OptionalPayload(packet);  // TODO(javier): uncomment this line in case of issues with pictureId
+
+  /*  TODO(pedro): Disabled as part of the hack to reduce audio drift 
+   *  We will have to go back here and fix timestamp updates
   } else if (is_scalable_ && enabled_ && chead->isRtcp() && chead->isSenderReport()) {
     uint32_t ssrc = chead->getSSRC();
     if (video_sink_ssrc_ == ssrc) {
       uint32_t sr_timestamp = chead->getTimestamp();
       chead->setTimestamp(sr_timestamp + timestamp_offset_);
     }
+    */
   }
 
   ctx->fireWrite(packet);

--- a/erizo/src/erizo/rtp/StatsHandler.cpp
+++ b/erizo/src/erizo/rtp/StatsHandler.cpp
@@ -128,6 +128,8 @@ void StatsCalculator::processRtcpPacket(std::shared_ptr<DataPacket> packet) {
         ELOG_DEBUG("RTP SR: Packets Sent %u, Octets Sent %u", chead->getPacketsSent(), chead->getOctetsSent());
         getStatsInfo()[ssrc].insertStat("packetsSent", CumulativeStat{chead->getPacketsSent()});
         getStatsInfo()[ssrc].insertStat("bytesSent", CumulativeStat{chead->getOctetsSent()});
+        getStatsInfo()[ssrc].insertStat("srTimestamp", CumulativeStat{chead->getTimestamp()});
+        getStatsInfo()[ssrc].insertStat("srNtp", CumulativeStat{chead->getNtpTimestamp()});
         break;
       case RTCP_RTP_Feedback_PT:
         ELOG_DEBUG("RTP FB: Usually NACKs: %u", chead->getBlockCount());


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

We have been seeing more reports of a/v desynchronization. This PR disables the mechanism we have been using to update timestamps in SRs and disables sending SRs from audio, relying on the client's best effort.
To track the problem this PR also adds stats for SRs timestamps and NTP.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.