### PR TITLE
Check for null pointers in OTM

### DIFF
--- a/erizo/src/erizo/OneToManyProcessor.cpp
+++ b/erizo/src/erizo/OneToManyProcessor.cpp
@@ -50,8 +50,10 @@ namespace erizo {
   bool OneToManyProcessor::isSSRCFromAudio(uint32_t ssrc) {
     std::map<std::string, std::shared_ptr<MediaSink>>::iterator it;
     for (it = subscribers.begin(); it != subscribers.end(); ++it) {
-      if ((*it).second->getAudioSinkSSRC() == ssrc) {
-        return true;
+      if ((*it).second != nullptr) {
+        if ((*it).second->getAudioSinkSSRC() == ssrc) {
+          return true;
+        }
       }
     }
     return false;


### PR DESCRIPTION
**Description**

I have seen a couple of crashes because of this bug. We are already checking for null pointers in other parts of this file.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.