### PR TITLE
Avoid using publisher from OTM

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -128,7 +128,7 @@ void MediaStream::setMaxVideoBW(uint32_t max_video_bw) {
 }
 
 void MediaStream::syncClose() {
-  ELOG_DEBUG("%s message:Close called", toLog());
+  ELOG_INFO("%s message:Close called", toLog());
   if (!sending_) {
     return;
   }

--- a/erizo/src/erizo/OneToManyProcessor.cpp
+++ b/erizo/src/erizo/OneToManyProcessor.cpp
@@ -25,8 +25,9 @@ namespace erizo {
       return 0;
 
     boost::unique_lock<boost::mutex> lock(monitor_mutex_);
-    if (subscribers.empty())
+    if (subscribers.empty() || !publisher) {
       return 0;
+    }
 
     std::map<std::string, std::shared_ptr<MediaSink>>::iterator it;
     RtpHeader* head = reinterpret_cast<RtpHeader*>(audio_packet->data);
@@ -69,8 +70,9 @@ namespace erizo {
       return 0;
     }
     boost::unique_lock<boost::mutex> lock(monitor_mutex_);
-    if (subscribers.empty())
+    if (subscribers.empty() || !publisher) {
       return 0;
+    }
     std::map<std::string, std::shared_ptr<MediaSink>>::iterator it;
     RtpHeader* rhead = reinterpret_cast<RtpHeader*>(video_packet->data);
     uint32_t ssrc = head->isRtcp() ? head->getSSRC() : rhead->getSSRC();
@@ -125,8 +127,9 @@ namespace erizo {
 
   int OneToManyProcessor::deliverEvent_(MediaEventPtr event) {
     boost::unique_lock<boost::mutex> lock(monitor_mutex_);
-    if (subscribers.empty())
+    if (subscribers.empty() || !publisher) {
       return 0;
+    }
     std::map<std::string, std::shared_ptr<MediaSink>>::iterator it;
     for (it = subscribers.begin(); it != subscribers.end(); ++it) {
       if ((*it).second != nullptr) {

--- a/erizo/src/erizo/OneToManyProcessor.cpp
+++ b/erizo/src/erizo/OneToManyProcessor.cpp
@@ -13,7 +13,7 @@
 
 namespace erizo {
   DEFINE_LOGGER(OneToManyProcessor, "OneToManyProcessor");
-  OneToManyProcessor::OneToManyProcessor() : feedbackSink_{nullptr} {
+  OneToManyProcessor::OneToManyProcessor() : feedback_sink_{nullptr} {
     ELOG_DEBUG("OneToManyProcessor constructor");
   }
 
@@ -25,14 +25,14 @@ namespace erizo {
       return 0;
 
     boost::unique_lock<boost::mutex> lock(monitor_mutex_);
-    if (subscribers.empty() || !publisher) {
+    if (subscribers_.empty() || !publisher_) {
       return 0;
     }
 
     std::map<std::string, std::shared_ptr<MediaSink>>::iterator it;
     RtpHeader* head = reinterpret_cast<RtpHeader*>(audio_packet->data);
     RtcpHeader* chead = reinterpret_cast<RtcpHeader*>(audio_packet->data);
-    for (it = subscribers.begin(); it != subscribers.end(); ++it) {
+    for (it = subscribers_.begin(); it != subscribers_.end(); ++it) {
       if ((*it).second != nullptr) {
         // Hack to avoid audio drift
         if (chead->isRtcp() && chead->isSDES()) {
@@ -50,7 +50,7 @@ namespace erizo {
 
   bool OneToManyProcessor::isSSRCFromAudio(uint32_t ssrc) {
     std::map<std::string, std::shared_ptr<MediaSink>>::iterator it;
-    for (it = subscribers.begin(); it != subscribers.end(); ++it) {
+    for (it = subscribers_.begin(); it != subscribers_.end(); ++it) {
       if ((*it).second != nullptr) {
         if ((*it).second->getAudioSinkSSRC() == ssrc) {
           return true;
@@ -70,14 +70,14 @@ namespace erizo {
       return 0;
     }
     boost::unique_lock<boost::mutex> lock(monitor_mutex_);
-    if (subscribers.empty() || !publisher) {
+    if (subscribers_.empty() || !publisher_) {
       return 0;
     }
     std::map<std::string, std::shared_ptr<MediaSink>>::iterator it;
     RtpHeader* rhead = reinterpret_cast<RtpHeader*>(video_packet->data);
     uint32_t ssrc = head->isRtcp() ? head->getSSRC() : rhead->getSSRC();
     uint32_t ssrc_offset = translateAndMaybeAdaptForSimulcast(ssrc);
-    for (it = subscribers.begin(); it != subscribers.end(); ++it) {
+    for (it = subscribers_.begin(); it != subscribers_.end(); ++it) {
       if ((*it).second != nullptr) {
         uint32_t base_ssrc = (*it).second->getVideoSinkSSRC();
         if (head->isRtcp()) {
@@ -93,45 +93,50 @@ namespace erizo {
   }
 
   uint32_t OneToManyProcessor::translateAndMaybeAdaptForSimulcast(uint32_t orig_ssrc) {
-    return orig_ssrc - publisher->getVideoSourceSSRC();
+    return orig_ssrc - publisher_->getVideoSourceSSRC();
   }
 
-  void OneToManyProcessor::setPublisher(std::shared_ptr<MediaSource> publisher_stream) {
+  void OneToManyProcessor::setPublisher(std::shared_ptr<MediaSource> publisher_stream, std::string publisher_id) {
     boost::mutex::scoped_lock lock(monitor_mutex_);
-    this->publisher = publisher_stream;
-    feedbackSink_ = publisher->getFeedbackSink();
+    publisher_ = publisher_stream;
+    feedback_sink_ = publisher_->getFeedbackSink();
+    publisher_id_ = publisher_id;
+  }
+
+  std::shared_ptr<MediaSource> OneToManyProcessor::getPublisher() {
+    return publisher_;
   }
 
   int OneToManyProcessor::deliverFeedback_(std::shared_ptr<DataPacket> fb_packet) {
-    if (feedbackSink_ != nullptr) {
+    if (feedback_sink_ != nullptr) {
       RtpUtils::forEachRtcpBlock(fb_packet, [this](RtcpHeader *chead) {
         if (chead->isREMB()) {
           for (uint8_t index = 0; index < chead->getREMBNumSSRC(); index++) {
             if (isSSRCFromAudio(chead->getREMBFeedSSRC(index))) {
-              chead->setREMBFeedSSRC(index, publisher->getAudioSourceSSRC());
+              chead->setREMBFeedSSRC(index, publisher_->getAudioSourceSSRC());
             } else {
-              chead->setREMBFeedSSRC(index, publisher->getVideoSourceSSRC());
+              chead->setREMBFeedSSRC(index, publisher_->getVideoSourceSSRC());
             }
           }
         }
         if (isSSRCFromAudio(chead->getSourceSSRC())) {
-          chead->setSourceSSRC(publisher->getAudioSourceSSRC());
+          chead->setSourceSSRC(publisher_->getAudioSourceSSRC());
         } else {
-          chead->setSourceSSRC(publisher->getVideoSourceSSRC());
+          chead->setSourceSSRC(publisher_->getVideoSourceSSRC());
         }
       });
-      feedbackSink_->deliverFeedback(fb_packet);
+      feedback_sink_->deliverFeedback(fb_packet);
     }
     return 0;
   }
 
   int OneToManyProcessor::deliverEvent_(MediaEventPtr event) {
     boost::unique_lock<boost::mutex> lock(monitor_mutex_);
-    if (subscribers.empty() || !publisher) {
+    if (subscribers_.empty() || !publisher_) {
       return 0;
     }
     std::map<std::string, std::shared_ptr<MediaSink>>::iterator it;
-    for (it = subscribers.begin(); it != subscribers.end(); ++it) {
+    for (it = subscribers_.begin(); it != subscribers_.end(); ++it) {
       if ((*it).second != nullptr) {
         (*it).second->deliverEvent(event);
       }
@@ -143,28 +148,36 @@ namespace erizo {
       const std::string& peer_id) {
     ELOG_DEBUG("Adding subscriber");
     boost::mutex::scoped_lock lock(monitor_mutex_);
-    ELOG_DEBUG("From %u, %u ", publisher->getAudioSourceSSRC(), publisher->getVideoSourceSSRC());
+    ELOG_DEBUG("From %u, %u ", publisher_->getAudioSourceSSRC(), publisher_->getVideoSourceSSRC());
     ELOG_DEBUG("Subscribers ssrcs: Audio %u, video, %u from %u, %u ",
                subscriber_stream->getAudioSinkSSRC(), subscriber_stream->getVideoSinkSSRC(),
-               this->publisher->getAudioSourceSSRC() , this->publisher->getVideoSourceSSRC());
+               publisher_->getAudioSourceSSRC() , publisher_->getVideoSourceSSRC());
     FeedbackSource* fbsource = subscriber_stream->getFeedbackSource();
 
     if (fbsource != nullptr) {
       ELOG_DEBUG("adding fbsource");
       fbsource->setFeedbackSink(this);
     }
-    if (this->subscribers.find(peer_id) != subscribers.end()) {
+    if (subscribers_.find(peer_id) != subscribers_.end()) {
         ELOG_WARN("This OTM already has a subscriber with peer_id %s, substituting it", peer_id.c_str());
-        this->subscribers.erase(peer_id);
+        subscribers_.erase(peer_id);
     }
-    this->subscribers[peer_id] = subscriber_stream;
+    subscribers_[peer_id] = subscriber_stream;
+  }
+
+  std::shared_ptr<MediaSink> OneToManyProcessor::getSubscriber(const std::string& peer_id) {
+    auto it = subscribers_.find(peer_id);
+    if (it != subscribers_.end()) {
+      return it->second;
+    }
+    return std::shared_ptr<MediaSink>(nullptr);
   }
 
   void OneToManyProcessor::removeSubscriber(const std::string& peer_id) {
     ELOG_DEBUG("Remove subscriber %s", peer_id.c_str());
     boost::mutex::scoped_lock lock(monitor_mutex_);
-    if (this->subscribers.find(peer_id) != subscribers.end()) {
-      this->subscribers.erase(peer_id);
+    if (subscribers_.find(peer_id) != subscribers_.end()) {
+      subscribers_.erase(peer_id);
     }
   }
 
@@ -176,22 +189,22 @@ namespace erizo {
     ELOG_DEBUG("OneToManyProcessor closeAll");
     std::shared_ptr<boost::promise<void>> p = std::make_shared<boost::promise<void>>();
     boost::future<void> f = p->get_future();
-    feedbackSink_ = nullptr;
-    publisher.reset();
+    feedback_sink_ = nullptr;
+    publisher_.reset();
     boost::unique_lock<boost::mutex> lock(monitor_mutex_);
-    std::map<std::string, std::shared_ptr<MediaSink>>::iterator it = subscribers.begin();
-    while (it != subscribers.end()) {
+    std::map<std::string, std::shared_ptr<MediaSink>>::iterator it = subscribers_.begin();
+    while (it != subscribers_.end()) {
       if ((*it).second != nullptr) {
         FeedbackSource* fbsource = (*it).second->getFeedbackSource();
         if (fbsource != nullptr) {
           fbsource->setFeedbackSink(nullptr);
         }
       }
-      subscribers.erase(it++);
+      subscribers_.erase(it++);
     }
-    subscribers.clear();
+    subscribers_.clear();
     p->set_value();
-    ELOG_DEBUG("ClosedAll media in this OneToMany");
+    ELOG_INFO("OneToManyProcessor closed, publisher_id: %s", publisher_id_);
     return f;
   }
 

--- a/erizo/src/erizo/OneToManyProcessor.h
+++ b/erizo/src/erizo/OneToManyProcessor.h
@@ -25,22 +25,24 @@ class OneToManyProcessor : public MediaSink, public FeedbackSink {
   DECLARE_LOGGER();
 
  public:
-  std::map<std::string, std::shared_ptr<MediaSink>> subscribers;
-  std::shared_ptr<MediaSource> publisher;
-
   OneToManyProcessor();
   virtual ~OneToManyProcessor();
   /**
   * Sets the Publisher
   * @param webRtcConn The MediaStream of the Publisher
   */
-  void setPublisher(std::shared_ptr<MediaSource> publisher_stream);
+  void setPublisher(std::shared_ptr<MediaSource> publisher_stream, std::string publisher_id);
+
+  std::shared_ptr<MediaSource> getPublisher();
   /**
   * Sets the subscriber
   * @param webRtcConn The MediaStream of the subscriber
   * @param peerId An unique Id for the subscriber
   */
   void addSubscriber(std::shared_ptr<MediaSink> subscriber_stream, const std::string& peer_id);
+
+  std::shared_ptr<MediaSink> getSubscriber(const std::string& peer_id);
+
   /**
   * Eliminates the subscriber given its peer id
   * @param peerId the peerId
@@ -50,9 +52,6 @@ class OneToManyProcessor : public MediaSink, public FeedbackSink {
   boost::future<void> close() override;
 
  private:
-  typedef std::shared_ptr<MediaSink> sink_ptr;
-  FeedbackSink* feedbackSink_;
-
   int deliverAudioData_(std::shared_ptr<DataPacket> audio_packet) override;
   int deliverVideoData_(std::shared_ptr<DataPacket> video_packet) override;
   int deliverFeedback_(std::shared_ptr<DataPacket> fb_packet) override;
@@ -60,6 +59,13 @@ class OneToManyProcessor : public MediaSink, public FeedbackSink {
   boost::future<void> closeAll();
   bool isSSRCFromAudio(uint32_t ssrc);
   uint32_t translateAndMaybeAdaptForSimulcast(uint32_t orig_ssrc);
+
+ private:
+  typedef std::shared_ptr<MediaSink> sink_ptr;
+  FeedbackSink* feedback_sink_;
+  std::map<std::string, std::shared_ptr<MediaSink>> subscribers_;
+  std::shared_ptr<MediaSource> publisher_;
+  std::string publisher_id_;
 };
 
 }  // namespace erizo

--- a/erizo/src/erizo/OneToManyProcessor.h
+++ b/erizo/src/erizo/OneToManyProcessor.h
@@ -61,7 +61,6 @@ class OneToManyProcessor : public MediaSink, public FeedbackSink {
   uint32_t translateAndMaybeAdaptForSimulcast(uint32_t orig_ssrc);
 
  private:
-  typedef std::shared_ptr<MediaSink> sink_ptr;
   FeedbackSink* feedback_sink_;
   std::map<std::string, std::shared_ptr<MediaSink>> subscribers_;
   std::shared_ptr<MediaSource> publisher_;

--- a/erizo/src/erizo/media/ExternalInput.h
+++ b/erizo/src/erizo/media/ExternalInput.h
@@ -45,6 +45,8 @@ class ExternalInput : public MediaSource, public FeedbackSink, public RTPDataRec
     return p->get_future();
   }
 
+  std::string getUrl() { return url_; }
+
  private:
   boost::scoped_ptr<OutputProcessor> op_;
   VideoDecoder inCodec_;

--- a/erizo/src/test/OneToManyProcessorTest.cpp
+++ b/erizo/src/test/OneToManyProcessorTest.cpp
@@ -31,7 +31,6 @@ class MockPublisher: public erizo::MediaSource, public erizo::FeedbackSink {
   int deliverFeedback_(std::shared_ptr<DataPacket> packet) override {
     return internalDeliverFeedback_(packet);
   }
-
   MOCK_METHOD1(internalDeliverFeedback_, int(std::shared_ptr<DataPacket>));
 };
 
@@ -66,15 +65,15 @@ class OneToManyProcessorTest : public ::testing::Test {
   virtual void SetUp() {
     publisher = std::make_shared<MockPublisher>();
     subscriber = std::make_shared<MockSubscriber>();
-    otm.setPublisher(publisher);
+    otm.setPublisher(publisher, "1");
     otm.addSubscriber(subscriber, kArbitraryPeerId);
   }
   virtual void TearDown() {}
 
   std::shared_ptr<MockSubscriber> getSubscriber(std::string peer_id) {
-    if (otm.subscribers.find(peer_id) != otm.subscribers.end()) {
-      return std::dynamic_pointer_cast<MockSubscriber>(
-                        otm.subscribers.find(peer_id)->second);
+    std::shared_ptr<erizo::MediaSink> subscriber = otm.getSubscriber(peer_id);
+    if (subscriber) {
+      return std::dynamic_pointer_cast<MockSubscriber>(subscriber);
     }
     return std::shared_ptr<MockSubscriber>();
   }
@@ -84,7 +83,7 @@ class OneToManyProcessorTest : public ::testing::Test {
 };
 
 TEST_F(OneToManyProcessorTest, setPublisher_Success_WhenCalled) {
-  EXPECT_THAT(otm.publisher.get(), Eq(publisher.get()));
+  EXPECT_THAT(otm.getPublisher().get(), Eq(publisher.get()));
 }
 
 TEST_F(OneToManyProcessorTest, addSubscriber_Success_WhenAddingNewSubscribers) {

--- a/erizoAPI/OneToManyProcessor.cc
+++ b/erizoAPI/OneToManyProcessor.cc
@@ -121,7 +121,7 @@ NAN_METHOD(OneToManyProcessor::setPublisher) {
   auto wr = std::shared_ptr<erizo::MediaStream>(param->me);
 
   std::shared_ptr<erizo::MediaSource> ms = std::dynamic_pointer_cast<erizo::MediaSource>(wr);
-  me->setPublisher(ms);
+  me->setPublisher(ms, wr->getId());
 }
 
 NAN_METHOD(OneToManyProcessor::addExternalOutput) {
@@ -155,7 +155,7 @@ NAN_METHOD(OneToManyProcessor::setExternalPublisher) {
   std::shared_ptr<erizo::ExternalInput> wr = param->me;
 
   std::shared_ptr<erizo::MediaSource> ms = std::dynamic_pointer_cast<erizo::MediaSource>(wr);
-  me->setPublisher(ms);
+  me->setPublisher(ms, wr->getUrl());
 }
 
 NAN_METHOD(OneToManyProcessor::getPublisherState) {
@@ -165,7 +165,7 @@ NAN_METHOD(OneToManyProcessor::getPublisherState) {
     return;
   }
 
-  auto wr = std::dynamic_pointer_cast<erizo::MediaStream>(me->publisher);
+  auto wr = std::dynamic_pointer_cast<erizo::MediaStream>(me->getPublisher());
 
   int state = wr->getCurrentState();
   info.GetReturnValue().Set(Nan::New(state));
@@ -180,7 +180,7 @@ NAN_METHOD(OneToManyProcessor::hasPublisher) {
 
   bool p = true;
 
-  if (me->publisher == NULL) {
+  if (!me->getPublisher()) {
     p = false;
   }
 


### PR DESCRIPTION
**Description**

There have been other crashes inside OneToManyProcessor when trying to access publisher's stuff.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.