### PR TITLE
User WeakPtr instead of raw pointers in MediaDef

### DIFF
--- a/erizo/src/erizo/MediaDefinitions.h
+++ b/erizo/src/erizo/MediaDefinitions.h
@@ -102,7 +102,7 @@ class FeedbackSink {
  public:
     virtual ~FeedbackSink() {}
     int deliverFeedback(std::shared_ptr<DataPacket> data_packet) {
-        return this->deliverFeedback_(data_packet);
+        return deliverFeedback_(data_packet);
     }
  private:
     virtual int deliverFeedback_(std::shared_ptr<DataPacket> data_packet) = 0;
@@ -110,11 +110,11 @@ class FeedbackSink {
 
 class FeedbackSource {
  protected:
-    FeedbackSink* fb_sink_;
+   std::weak_ptr<FeedbackSink> fb_sink_;
  public:
-    FeedbackSource(): fb_sink_{nullptr} {}
+    FeedbackSource() : fb_sink_{} {}
     virtual ~FeedbackSource() {}
-    void setFeedbackSink(FeedbackSink* sink) {
+    void setFeedbackSink(std::weak_ptr<FeedbackSink> sink) {
         fb_sink_ = sink;
     }
 };
@@ -128,14 +128,14 @@ class MediaSink: public virtual Monitor {
     uint32_t audio_sink_ssrc_;
     uint32_t video_sink_ssrc_;
     // Is it able to provide Feedback
-    FeedbackSource* sink_fb_source_;
+    std::weak_ptr<FeedbackSource> sink_fb_source_;
 
  public:
     int deliverAudioData(std::shared_ptr<DataPacket> data_packet) {
-        return this->deliverAudioData_(data_packet);
+        return deliverAudioData_(data_packet);
     }
     int deliverVideoData(std::shared_ptr<DataPacket> data_packet) {
-        return this->deliverVideoData_(data_packet);
+        return deliverVideoData_(data_packet);
     }
     uint32_t getVideoSinkSSRC() {
         boost::mutex::scoped_lock lock(monitor_mutex_);
@@ -159,14 +159,14 @@ class MediaSink: public virtual Monitor {
     bool isAudioSinkSSRC(uint32_t ssrc) {
       return ssrc == audio_sink_ssrc_;
     }
-    FeedbackSource* getFeedbackSource() {
+    std::weak_ptr<FeedbackSource> getFeedbackSource() {
         boost::mutex::scoped_lock lock(monitor_mutex_);
         return sink_fb_source_;
     }
     int deliverEvent(MediaEventPtr event) {
-      return this->deliverEvent_(event);
+      return deliverEvent_(event);
     }
-    MediaSink() : audio_sink_ssrc_{0}, video_sink_ssrc_{0}, sink_fb_source_{nullptr} {}
+    MediaSink() : audio_sink_ssrc_{0}, video_sink_ssrc_{0}, sink_fb_source_{} {}
     virtual ~MediaSink() {}
 
     virtual boost::future<void> close() = 0;
@@ -185,29 +185,29 @@ class MediaSource: public virtual Monitor {
     // SSRCs coming from the source
     uint32_t audio_source_ssrc_;
     std::vector<uint32_t> video_source_ssrc_list_;
-    MediaSink* video_sink_;
-    MediaSink* audio_sink_;
-    MediaSink* event_sink_;
+    std::weak_ptr<MediaSink> video_sink_;
+    std::weak_ptr<MediaSink> audio_sink_;
+    std::weak_ptr<MediaSink> event_sink_;
     // can it accept feedback
-    FeedbackSink* source_fb_sink_;
+    std::weak_ptr<FeedbackSink> source_fb_sink_;
 
  public:
-    void setAudioSink(MediaSink* audio_sink) {
-        boost::mutex::scoped_lock lock(monitor_mutex_);
-        this->audio_sink_ = audio_sink;
-    }
-    void setVideoSink(MediaSink* video_sink) {
-        boost::mutex::scoped_lock lock(monitor_mutex_);
-        this->video_sink_ = video_sink;
-    }
-    void setEventSink(MediaSink* event_sink) {
+    void setAudioSink(std::weak_ptr<MediaSink> audio_sink) {
       boost::mutex::scoped_lock lock(monitor_mutex_);
-      this->event_sink_ = event_sink;
+      audio_sink_ = audio_sink;
+    }
+    void setVideoSink(std::weak_ptr<MediaSink> video_sink) {
+      boost::mutex::scoped_lock lock(monitor_mutex_);
+      video_sink_ = video_sink;
+    }
+    void setEventSink(std::weak_ptr<MediaSink> event_sink) {
+      boost::mutex::scoped_lock lock(monitor_mutex_);
+      event_sink_ = event_sink;
     }
 
-    FeedbackSink* getFeedbackSink() {
-        boost::mutex::scoped_lock lock(monitor_mutex_);
-        return source_fb_sink_;
+    std::weak_ptr<FeedbackSink> getFeedbackSink() {
+      boost::mutex::scoped_lock lock(monitor_mutex_);
+      return source_fb_sink_;
     }
     virtual int sendPLI() = 0;
     uint32_t getVideoSourceSSRC() {
@@ -255,7 +255,7 @@ class MediaSource: public virtual Monitor {
     }
 
     MediaSource() : audio_source_ssrc_{0}, video_source_ssrc_list_{std::vector<uint32_t>(1, 0)},
-      video_sink_{nullptr}, audio_sink_{nullptr}, event_sink_{nullptr}, source_fb_sink_{nullptr} {}
+      video_sink_{}, audio_sink_{}, event_sink_{}, source_fb_sink_{} {}
     virtual ~MediaSource() {}
 
     virtual boost::future<void> close() = 0;

--- a/erizo/src/erizo/MediaDefinitions.h
+++ b/erizo/src/erizo/MediaDefinitions.h
@@ -110,13 +110,13 @@ class FeedbackSink {
 
 class FeedbackSource {
  protected:
-   std::weak_ptr<FeedbackSink> fb_sink_;
+  std::weak_ptr<FeedbackSink> fb_sink_;
  public:
-    FeedbackSource() : fb_sink_{} {}
-    virtual ~FeedbackSource() {}
-    void setFeedbackSink(std::weak_ptr<FeedbackSink> sink) {
-        fb_sink_ = sink;
-    }
+  FeedbackSource() : fb_sink_{} {}
+  virtual ~FeedbackSource() {}
+  void setFeedbackSink(std::weak_ptr<FeedbackSink> sink) {
+    fb_sink_ = sink;
+  }
 };
 
 /*

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -82,8 +82,6 @@ MediaStream::MediaStream(std::shared_ptr<Worker> worker,
   }
   ELOG_INFO("%s message: constructor, id: %s",
       toLog(), media_stream_id.c_str());
-  source_fb_sink_ = this;
-  sink_fb_source_ = this;
   stats_ = std::make_shared<Stats>();
   log_stats_ = std::make_shared<Stats>();
   quality_manager_ = std::make_shared<QualityManager>();
@@ -134,9 +132,9 @@ void MediaStream::syncClose() {
   }
   sending_ = false;
   ready_ = false;
-  video_sink_ = nullptr;
-  audio_sink_ = nullptr;
-  fb_sink_ = nullptr;
+  video_sink_.reset();
+  audio_sink_.reset();
+  fb_sink_.reset();
   pipeline_initialized_ = false;
   pipeline_->close();
   pipeline_.reset();
@@ -150,6 +148,16 @@ boost::future<void> MediaStream::close() {
   return asyncTask([shared_this] (std::shared_ptr<MediaStream> stream) {
     shared_this->syncClose();
   });
+}
+
+void MediaStream::configure() {
+  ELOG_WARN("%s conifgure WeakPtr %d %d", toLog(), source_fb_sink_.expired(), sink_fb_source_.expired())
+  if (source_fb_sink_.expired()) {
+    source_fb_sink_ = std::dynamic_pointer_cast<FeedbackSink>(shared_from_this());
+  }
+  if (sink_fb_source_.expired()) {
+    sink_fb_source_ = std::dynamic_pointer_cast<FeedbackSource>(shared_from_this());
+  }
 }
 
 bool MediaStream::init(bool doNotWaitForRemoteSdp) {
@@ -210,7 +218,6 @@ bool MediaStream::setRemoteSdp(std::shared_ptr<SdpInfo> sdp, int session_version
     pipeline_->notifyUpdate();
     return true;
   }
-
   bundle_ = remote_sdp_->isBundle;
   if (video_ssrc_list_it != remote_sdp_->video_ssrc_map.end()) {
     setVideoSourceSSRCList(video_ssrc_list_it->second);
@@ -493,7 +500,7 @@ int MediaStream::deliverEvent_(MediaEventPtr event) {
 }
 
 void MediaStream::onTransportData(std::shared_ptr<DataPacket> incoming_packet, Transport *transport) {
-  if ((audio_sink_ == nullptr && video_sink_ == nullptr && fb_sink_ == nullptr)) {
+  if (audio_sink_.expired() && video_sink_.expired() && fb_sink_.expired()) {
     return;
   }
 
@@ -537,6 +544,8 @@ void MediaStream::read(std::shared_ptr<DataPacket> packet) {
   RtpHeader *head = reinterpret_cast<RtpHeader*> (buf);
   RtcpHeader *chead = reinterpret_cast<RtcpHeader*> (buf);
   uint32_t recvSSRC = 0;
+  auto video_sink = video_sink_.lock();
+  auto audio_sink = audio_sink_.lock();
   if (!chead->isRtcp()) {
     recvSSRC = head->getSSRC();
   } else if (chead->packettype == RTCP_Sender_PT || chead->packettype == RTCP_SDES_PT) {  // Sender Report
@@ -544,46 +553,47 @@ void MediaStream::read(std::shared_ptr<DataPacket> packet) {
   }
   // DELIVER FEEDBACK (RR, FEEDBACK PACKETS)
   if (chead->isFeedback()) {
-    if (fb_sink_ != nullptr && should_send_feedback_) {
-      fb_sink_->deliverFeedback(std::move(packet));
+    auto fb_sink = fb_sink_.lock();
+    if (should_send_feedback_ && fb_sink) {
+      fb_sink->deliverFeedback(std::move(packet));
     }
   } else {
     // RTP or RTCP Sender Report
     if (bundle_) {
       // Check incoming SSRC
       // Deliver data
-      if (isVideoSourceSSRC(recvSSRC) && video_sink_) {
+      if (isVideoSourceSSRC(recvSSRC) && video_sink) {
         parseIncomingPayloadType(buf, len, VIDEO_PACKET);
         parseIncomingExtensionId(buf, len, VIDEO_PACKET);
-        video_sink_->deliverVideoData(std::move(packet));
-      } else if (isAudioSourceSSRC(recvSSRC) && audio_sink_) {
+        video_sink->deliverVideoData(std::move(packet));
+      } else if (isAudioSourceSSRC(recvSSRC) && audio_sink) {
         parseIncomingPayloadType(buf, len, AUDIO_PACKET);
         parseIncomingExtensionId(buf, len, AUDIO_PACKET);
-        audio_sink_->deliverAudioData(std::move(packet));
+        audio_sink->deliverAudioData(std::move(packet));
       } else {
         ELOG_DEBUG("%s read video unknownSSRC: %u, localVideoSSRC: %u, localAudioSSRC: %u",
                     toLog(), recvSSRC, this->getVideoSourceSSRC(), this->getAudioSourceSSRC());
       }
     } else {
-      if (packet->type == AUDIO_PACKET && audio_sink_) {
+      if (packet->type == AUDIO_PACKET && audio_sink) {
         parseIncomingPayloadType(buf, len, AUDIO_PACKET);
         parseIncomingExtensionId(buf, len, AUDIO_PACKET);
         // Firefox does not send SSRC in SDP
         if (getAudioSourceSSRC() == 0) {
           ELOG_DEBUG("%s discoveredAudioSourceSSRC:%u", toLog(), recvSSRC);
-          this->setAudioSourceSSRC(recvSSRC);
+          setAudioSourceSSRC(recvSSRC);
         }
-        audio_sink_->deliverAudioData(std::move(packet));
-      } else if (packet->type == VIDEO_PACKET && video_sink_) {
+        audio_sink->deliverAudioData(std::move(packet));
+      } else if (packet->type == VIDEO_PACKET && video_sink) {
         parseIncomingPayloadType(buf, len, VIDEO_PACKET);
         parseIncomingExtensionId(buf, len, VIDEO_PACKET);
         // Firefox does not send SSRC in SDP
         if (getVideoSourceSSRC() == 0) {
           ELOG_DEBUG("%s discoveredVideoSourceSSRC:%u", toLog(), recvSSRC);
-          this->setVideoSourceSSRC(recvSSRC);
+          setVideoSourceSSRC(recvSSRC);
         }
         // change ssrc for RTP packets, don't touch here if RTCP
-        video_sink_->deliverVideoData(std::move(packet));
+        video_sink->deliverVideoData(std::move(packet));
       }
     }  // if not bundle
   }  // if not Feedback
@@ -602,7 +612,9 @@ void MediaStream::notifyMediaStreamEvent(const std::string& type, const std::str
 }
 
 void MediaStream::notifyToEventSink(MediaEventPtr event) {
-  event_sink_->deliverEvent(std::move(event));
+  if (auto event_sink = event_sink_.lock()) {
+    event_sink->deliverEvent(std::move(event));
+  }
 }
 
 int MediaStream::sendPLI() {
@@ -619,9 +631,8 @@ int MediaStream::sendPLI() {
 }
 
 void MediaStream::sendPLIToFeedback() {
-  if (fb_sink_) {
-    fb_sink_->deliverFeedback(RtpUtils::createPLI(this->getVideoSinkSSRC(),
-      this->getVideoSourceSSRC()));
+  if (auto fb_sink = fb_sink_.lock()) {
+    fb_sink->deliverFeedback(RtpUtils::createPLI(getVideoSinkSSRC(), getVideoSourceSSRC()));
   }
 }
 

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -150,8 +150,7 @@ boost::future<void> MediaStream::close() {
   });
 }
 
-void MediaStream::configure() {
-  ELOG_WARN("%s conifgure WeakPtr %d %d", toLog(), source_fb_sink_.expired(), sink_fb_source_.expired())
+void MediaStream::init() {
   if (source_fb_sink_.expired()) {
     source_fb_sink_ = std::dynamic_pointer_cast<FeedbackSink>(shared_from_this());
   }
@@ -160,7 +159,7 @@ void MediaStream::configure() {
   }
 }
 
-bool MediaStream::init(bool doNotWaitForRemoteSdp) {
+bool MediaStream::configure(bool doNotWaitForRemoteSdp) {
   if (doNotWaitForRemoteSdp) {
     ready_ = true;
   }

--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -69,6 +69,7 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
    * Destructor.
    */
   virtual ~MediaStream();
+  void configure();
   bool init(bool doNotWaitForRemoteSdp);
   boost::future<void> close() override;
   virtual uint32_t getMaxVideoBW();

--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -69,8 +69,8 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
    * Destructor.
    */
   virtual ~MediaStream();
-  void configure();
-  bool init(bool doNotWaitForRemoteSdp);
+  void init();
+  bool configure(bool doNotWaitForRemoteSdp);
   boost::future<void> close() override;
   virtual uint32_t getMaxVideoBW();
   virtual uint32_t getBitrateFromMaxQualityLayer() { return bitrate_from_max_quality_layer_; }

--- a/erizo/src/erizo/OneToManyProcessor.h
+++ b/erizo/src/erizo/OneToManyProcessor.h
@@ -21,7 +21,7 @@ class MediaStream;
 * Represents a One to Many connection.
 * Receives media from one publisher and retransmits it to every subscriber.
 */
-class OneToManyProcessor : public MediaSink, public FeedbackSink {
+class OneToManyProcessor : public MediaSink, public FeedbackSink, public std::enable_shared_from_this<OneToManyProcessor> {
   DECLARE_LOGGER();
 
  public:
@@ -61,7 +61,7 @@ class OneToManyProcessor : public MediaSink, public FeedbackSink {
   uint32_t translateAndMaybeAdaptForSimulcast(uint32_t orig_ssrc);
 
  private:
-  FeedbackSink* feedback_sink_;
+  std::weak_ptr<FeedbackSink> feedback_sink_;
   std::map<std::string, std::shared_ptr<MediaSink>> subscribers_;
   std::shared_ptr<MediaSource> publisher_;
   std::string publisher_id_;

--- a/erizo/src/erizo/OneToManyProcessor.h
+++ b/erizo/src/erizo/OneToManyProcessor.h
@@ -21,7 +21,8 @@ class MediaStream;
 * Represents a One to Many connection.
 * Receives media from one publisher and retransmits it to every subscriber.
 */
-class OneToManyProcessor : public MediaSink, public FeedbackSink, public std::enable_shared_from_this<OneToManyProcessor> {
+class OneToManyProcessor
+    : public MediaSink, public FeedbackSink, public std::enable_shared_from_this<OneToManyProcessor> {
   DECLARE_LOGGER();
 
  public:

--- a/erizo/src/erizo/media/SyntheticInput.cpp
+++ b/erizo/src/erizo/media/SyntheticInput.cpp
@@ -135,8 +135,8 @@ void SyntheticInput::sendVideoframe(bool is_keyframe, bool is_marker, uint32_t s
     last_video_keyframe_time_ = clock_->now();
     keyframe_requested_ = false;
   }
-  if (video_sink_) {
-    video_sink_->deliverVideoData(std::make_shared<DataPacket>(0, packet_buffer, size, VIDEO_PACKET));
+  if (auto video_sink = video_sink_.lock()) {
+    video_sink->deliverVideoData(std::make_shared<DataPacket>(0, packet_buffer, size, VIDEO_PACKET));
   }
   delete header;
 }
@@ -151,8 +151,8 @@ void SyntheticInput::sendAudioFrame(uint32_t size) {
   char packet_buffer[kMaxPacketSize];
   memset(packet_buffer, 0, size);
   memcpy(packet_buffer, reinterpret_cast<char*>(header), header->getHeaderLength());
-  if (audio_sink_) {
-    audio_sink_->deliverAudioData(std::make_shared<DataPacket>(0, packet_buffer, size, AUDIO_PACKET));
+  if (auto audio_sink = audio_sink_.lock()) {
+    audio_sink->deliverAudioData(std::make_shared<DataPacket>(0, packet_buffer, size, AUDIO_PACKET));
   }
   delete header;
 }

--- a/erizo/src/erizo/rtp/RtpSink.cpp
+++ b/erizo/src/erizo/rtp/RtpSink.cpp
@@ -88,8 +88,9 @@ namespace erizo {
   }
 
   void RtpSink::handleReceive(const::boost::system::error_code& error, size_t bytes_recvd) {  // NOLINT
-    if (bytes_recvd > 0 && fb_sink_) {
-      fb_sink_->deliverFeedback(std::make_shared<DataPacket>(0, reinterpret_cast<char*>(buffer_),
+    auto fb_sink = fb_sink_.lock();
+    if (bytes_recvd > 0 && fb_sink) {
+      fb_sink->deliverFeedback(std::make_shared<DataPacket>(0, reinterpret_cast<char*>(buffer_),
             static_cast<int>(bytes_recvd), OTHER_PACKET));
     }
   }

--- a/erizo/src/erizo/rtp/RtpSource.cpp
+++ b/erizo/src/erizo/rtp/RtpSource.cpp
@@ -39,8 +39,9 @@ int RtpSource::deliverFeedback_(std::shared_ptr<DataPacket> fb_packet) {
 }
 
 void RtpSource::handleReceive(const::boost::system::error_code& error, size_t bytes_recvd) { // NOLINT
-  if (bytes_recvd > 0 && this->video_sink_) {
-    this->video_sink_->deliverVideoData(std::make_shared<DataPacket>(0, reinterpret_cast<char*>(buffer_),
+  auto video_sink = video_sink_.lock();
+  if (bytes_recvd > 0 && video_sink) {
+    video_sink->deliverVideoData(std::make_shared<DataPacket>(0, reinterpret_cast<char*>(buffer_),
           static_cast<int>(bytes_recvd), OTHER_PACKET));
   }
 }

--- a/erizo/src/test/OneToManyProcessorTest.cpp
+++ b/erizo/src/test/OneToManyProcessorTest.cpp
@@ -14,12 +14,11 @@ using erizo::MediaEventPtr;
 
 static const char kArbitraryPeerId[] = "111";
 
-class MockPublisher: public erizo::MediaSource, public erizo::FeedbackSink {
+class MockPublisher: public erizo::MediaSource, public erizo::FeedbackSink, public std::enable_shared_from_this<MockPublisher> {
  public:
   MockPublisher() {
     video_source_ssrc_list_[0] = 1;
     audio_source_ssrc_ = 2;
-    source_fb_sink_ = this;
   }
   ~MockPublisher() {}
   boost::future<void> close() override {
@@ -27,6 +26,12 @@ class MockPublisher: public erizo::MediaSource, public erizo::FeedbackSink {
     p->set_value();
     return p->get_future();
   }
+
+  void setAsSelfFeedbackSink() {
+    auto fb_sink = std::dynamic_pointer_cast<erizo::FeedbackSink>(shared_from_this());
+    source_fb_sink_ = fb_sink;
+  }
+
   int sendPLI() override { return 0; }
   int deliverFeedback_(std::shared_ptr<DataPacket> packet) override {
     return internalDeliverFeedback_(packet);
@@ -37,7 +42,6 @@ class MockPublisher: public erizo::MediaSource, public erizo::FeedbackSink {
 class MockSubscriber: public erizo::MediaSink, public erizo::FeedbackSource {
  public:
   MockSubscriber() {
-    sink_fb_source_ = this;
   }
   ~MockSubscriber() {}
   boost::future<void> close() override {
@@ -64,6 +68,7 @@ class OneToManyProcessorTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
     publisher = std::make_shared<MockPublisher>();
+    publisher->setAsSelfFeedbackSink();
     subscriber = std::make_shared<MockSubscriber>();
     otm.setPublisher(publisher, "1");
     otm.addSubscriber(subscriber, kArbitraryPeerId);

--- a/erizo/src/test/OneToManyProcessorTest.cpp
+++ b/erizo/src/test/OneToManyProcessorTest.cpp
@@ -14,7 +14,8 @@ using erizo::MediaEventPtr;
 
 static const char kArbitraryPeerId[] = "111";
 
-class MockPublisher: public erizo::MediaSource, public erizo::FeedbackSink, public std::enable_shared_from_this<MockPublisher> {
+class MockPublisher
+  : public erizo::MediaSource, public erizo::FeedbackSink, public std::enable_shared_from_this<MockPublisher> {
  public:
   MockPublisher() {
     video_source_ssrc_list_[0] = 1;

--- a/erizoAPI/ExternalInput.cc
+++ b/erizoAPI/ExternalInput.cc
@@ -97,10 +97,9 @@ NAN_METHOD(ExternalInput::setAudioReceiver) {
   std::shared_ptr<erizo::ExternalInput> me = obj->me;
 
   MediaSink* param = ObjectWrap::Unwrap<MediaSink>(Nan::To<v8::Object>(info[0]).ToLocalChecked());
-  erizo::MediaSink *mr = param->msink;
 
-  me->setAudioSink(mr);
-  me->setEventSink(mr);
+  me->setAudioSink(param->msink);
+  me->setEventSink(param->msink);
 }
 
 NAN_METHOD(ExternalInput::setVideoReceiver) {
@@ -108,10 +107,9 @@ NAN_METHOD(ExternalInput::setVideoReceiver) {
   std::shared_ptr<erizo::ExternalInput> me = obj->me;
 
   MediaSink* param = ObjectWrap::Unwrap<MediaSink>(Nan::To<v8::Object>(info[0]).ToLocalChecked());
-  erizo::MediaSink *mr = param->msink;
 
-  me->setVideoSink(mr);
-  me->setEventSink(mr);
+  me->setVideoSink(param->msink);
+  me->setEventSink(param->msink);
 }
 
 NAN_METHOD(ExternalInput::generatePLIPacket) {

--- a/erizoAPI/MediaDefinitions.h
+++ b/erizoAPI/MediaDefinitions.h
@@ -10,7 +10,7 @@
  */
 class MediaSink : public Nan::ObjectWrap {
  public:
-    erizo::MediaSink* msink;
+  std::weak_ptr<erizo::MediaSink> msink;
 };
 
 
@@ -19,7 +19,7 @@ class MediaSink : public Nan::ObjectWrap {
  */
 class MediaSource : public Nan::ObjectWrap {
  public:
-    erizo::MediaSource* msource;
+  std::weak_ptr<erizo::MediaSource> msource;
 };
 
 #endif  // ERIZOAPI_MEDIADEFINITIONS_H_

--- a/erizoAPI/MediaStream.cc
+++ b/erizoAPI/MediaStream.cc
@@ -125,7 +125,6 @@ NAN_MODULE_INIT(MediaStream::Init) {
 
   // Prototype
   Nan::SetPrototypeMethod(tpl, "close", close);
-  Nan::SetPrototypeMethod(tpl, "init", init);
   Nan::SetPrototypeMethod(tpl, "configure", configure);
   Nan::SetPrototypeMethod(tpl, "setAudioReceiver", setAudioReceiver);
   Nan::SetPrototypeMethod(tpl, "setVideoReceiver", setVideoReceiver);
@@ -178,6 +177,7 @@ NAN_METHOD(MediaStream::New) {
 
     MediaStream* obj = new MediaStream();
     obj->me = std::make_shared<erizo::MediaStream>(worker, wrtc, wrtc_id, stream_label, is_publisher, session_version);
+    obj->me->init();
     obj->msink = obj->me;
     obj->id_ = wrtc_id;
     obj->label_ = stream_label;
@@ -208,18 +208,8 @@ NAN_METHOD(MediaStream::configure) {
   if (!me || obj->closed_) {
     return;
   }
-  me->configure();
-}
-
-
-NAN_METHOD(MediaStream::init) {
-  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
-  std::shared_ptr<erizo::MediaStream> me = obj->me;
-  if (!me || obj->closed_) {
-    return;
-  }
   bool force =  info.Length() > 0 ? Nan::To<bool>(info[0]).FromJust() : false;
-  bool r = me->init(force);
+  bool r = me->configure(force);
 
   info.GetReturnValue().Set(Nan::New(r));
 }

--- a/erizoAPI/MediaStream.cc
+++ b/erizoAPI/MediaStream.cc
@@ -126,6 +126,7 @@ NAN_MODULE_INIT(MediaStream::Init) {
   // Prototype
   Nan::SetPrototypeMethod(tpl, "close", close);
   Nan::SetPrototypeMethod(tpl, "init", init);
+  Nan::SetPrototypeMethod(tpl, "configure", configure);
   Nan::SetPrototypeMethod(tpl, "setAudioReceiver", setAudioReceiver);
   Nan::SetPrototypeMethod(tpl, "setVideoReceiver", setVideoReceiver);
   Nan::SetPrototypeMethod(tpl, "getCurrentState", getCurrentState);
@@ -177,7 +178,7 @@ NAN_METHOD(MediaStream::New) {
 
     MediaStream* obj = new MediaStream();
     obj->me = std::make_shared<erizo::MediaStream>(worker, wrtc, wrtc_id, stream_label, is_publisher, session_version);
-    obj->msink = obj->me.get();
+    obj->msink = obj->me;
     obj->id_ = wrtc_id;
     obj->label_ = stream_label;
     ELOG_DEBUG("%s, message: Created", obj->toLog());
@@ -200,6 +201,16 @@ NAN_METHOD(MediaStream::close) {
       });
   info.GetReturnValue().Set(resolver->GetPromise());
 }
+
+NAN_METHOD(MediaStream::configure) {
+  MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
+  std::shared_ptr<erizo::MediaStream> me = obj->me;
+  if (!me || obj->closed_) {
+    return;
+  }
+  me->configure();
+}
+
 
 NAN_METHOD(MediaStream::init) {
   MediaStream* obj = Nan::ObjectWrap::Unwrap<MediaStream>(info.Holder());
@@ -309,10 +320,9 @@ NAN_METHOD(MediaStream::setAudioReceiver) {
   }
 
   MediaSink* param = Nan::ObjectWrap::Unwrap<MediaSink>(Nan::To<v8::Object>(info[0]).ToLocalChecked());
-  erizo::MediaSink *mr = param->msink;
 
-  me->setAudioSink(mr);
-  me->setEventSink(mr);
+  me->setAudioSink(param->msink);
+  me->setEventSink(param->msink);
 }
 
 NAN_METHOD(MediaStream::setVideoReceiver) {
@@ -323,10 +333,9 @@ NAN_METHOD(MediaStream::setVideoReceiver) {
   }
 
   MediaSink* param = Nan::ObjectWrap::Unwrap<MediaSink>(Nan::To<v8::Object>(info[0]).ToLocalChecked());
-  erizo::MediaSink *mr = param->msink;
 
-  me->setVideoSink(mr);
-  me->setEventSink(mr);
+  me->setVideoSink(param->msink);
+  me->setEventSink(param->msink);
 }
 
 

--- a/erizoAPI/MediaStream.h
+++ b/erizoAPI/MediaStream.h
@@ -81,6 +81,10 @@ class MediaStream : public MediaSink, public erizo::MediaStreamStatsListener, pu
      */
     static NAN_METHOD(init);
     /*
+     * Configures the MediaStream.
+     */
+    static NAN_METHOD(configure);
+    /*
      * Sets a MediaReceiver that is going to receive Audio Data
      * Param: the MediaReceiver to send audio to.
      */

--- a/erizoAPI/MediaStream.h
+++ b/erizoAPI/MediaStream.h
@@ -76,11 +76,6 @@ class MediaStream : public MediaSink, public erizo::MediaStreamStatsListener, pu
      */
     static NAN_METHOD(close);
     /*
-     * Inits the MediaStream and passes the callback to get Events.
-     * Returns true if the candidates are gathered.
-     */
-    static NAN_METHOD(init);
-    /*
      * Configures the MediaStream.
      */
     static NAN_METHOD(configure);

--- a/erizoAPI/OneToManyProcessor.cc
+++ b/erizoAPI/OneToManyProcessor.cc
@@ -87,7 +87,7 @@ NAN_MODULE_INIT(OneToManyProcessor::Init) {
 NAN_METHOD(OneToManyProcessor::New) {
   OneToManyProcessor* obj = new OneToManyProcessor();
   obj->me = std::make_shared<erizo::OneToManyProcessor>();
-  obj->msink = obj->me.get();
+  obj->msink = obj->me;
 
   obj->Wrap(info.This());
   info.GetReturnValue().Set(info.This());

--- a/erizoAPI/SyntheticInput.cc
+++ b/erizoAPI/SyntheticInput.cc
@@ -106,10 +106,9 @@ NAN_METHOD(SyntheticInput::setAudioReceiver) {
   std::shared_ptr<erizo::SyntheticInput> me = obj->me;
 
   MediaSink* param = ObjectWrap::Unwrap<MediaSink>(Nan::To<v8::Object>(info[0]).ToLocalChecked());
-  erizo::MediaSink *mr = param->msink;
 
-  me->setAudioSink(mr);
-  me->setEventSink(mr);
+  me->setAudioSink(param->msink);
+  me->setEventSink(param->msink);
 }
 
 NAN_METHOD(SyntheticInput::setVideoReceiver) {
@@ -117,10 +116,9 @@ NAN_METHOD(SyntheticInput::setVideoReceiver) {
   std::shared_ptr<erizo::SyntheticInput> me = obj->me;
 
   MediaSink* param = ObjectWrap::Unwrap<MediaSink>(Nan::To<v8::Object>(info[0]).ToLocalChecked());
-  erizo::MediaSink *mr = param->msink;
 
-  me->setVideoSink(mr);
-  me->setEventSink(mr);
+  me->setVideoSink(param->msink);
+  me->setEventSink(param->msink);
 }
 
 NAN_METHOD(SyntheticInput::setFeedbackSource) {
@@ -128,9 +126,9 @@ NAN_METHOD(SyntheticInput::setFeedbackSource) {
   std::shared_ptr<erizo::SyntheticInput> me = obj->me;
 
   MediaStream* param = ObjectWrap::Unwrap<MediaStream>(Nan::To<v8::Object>(info[0]).ToLocalChecked());
-  erizo::FeedbackSource* fb_source = param->me->getFeedbackSource();
+  std::shared_ptr<erizo::FeedbackSource> fb_source = param->me->getFeedbackSource().lock();
 
-  if (fb_source != nullptr) {
-    fb_source->setFeedbackSink(me.get());
+  if (fb_source) {
+    fb_source->setFeedbackSink(me);
   }
 }

--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -114,7 +114,6 @@ class Connection extends events.EventEmitter {
       Connection._getMediaConfiguration(this.mediaConfiguration),
       isPublisher,
       sessionVersion);
-    mediaStream.configure();
     mediaStream.id = id;
     mediaStream.label = options.label;
     if (options.metadata) {

--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -114,6 +114,7 @@ class Connection extends events.EventEmitter {
       Connection._getMediaConfiguration(this.mediaConfiguration),
       isPublisher,
       sessionVersion);
+    mediaStream.configure();
     mediaStream.id = id;
     mediaStream.label = options.label;
     if (options.metadata) {

--- a/erizo_controller/erizoJS/models/Node.js
+++ b/erizo_controller/erizoJS/models/Node.js
@@ -54,7 +54,7 @@ class Node extends EventEmitter {
       return;
     }
     const mediaStream = this.mediaStream;
-    mediaStream.init(force);
+    mediaStream.configure(force);
     if (mediaStream.minVideoBW) {
       let monitorMinVideoBw = {};
       if (mediaStream.scheme) {

--- a/erizo_controller/test/utils.js
+++ b/erizo_controller/test/utils.js
@@ -175,7 +175,6 @@ module.exports.reset = () => {
     periodicPlis: '',
     close: sinon.stub(),
     configure: sinon.stub(),
-    init: sinon.stub(),
     setAudioReceiver: sinon.stub(),
     setVideoReceiver: sinon.stub(),
     setMaxVideoBW: sinon.stub(),

--- a/erizo_controller/test/utils.js
+++ b/erizo_controller/test/utils.js
@@ -174,6 +174,7 @@ module.exports.reset = () => {
     scheme: '',
     periodicPlis: '',
     close: sinon.stub(),
+    configure: sinon.stub(),
     init: sinon.stub(),
     setAudioReceiver: sinon.stub(),
     setVideoReceiver: sinon.stub(),


### PR DESCRIPTION
**Description**

Introduce Weak pointers to Media Definitions to avoid having wrong access to memory from OneToManyProcessor.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.