### PR TITLE
Fix race conditions between publish/unpublish

### DIFF
--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -317,6 +317,7 @@ const listen = () => {
           const timeStamp = new Date();
           amqper.broadcast('event', { room: room.id,
             user: client.id,
+            name: token.userName,
             type: 'user_connection',
             timestamp: timeStamp.getTime() });
         }

--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -439,6 +439,11 @@ class Client extends events.EventEmitter {
       attributes: options.attributes });
     this.room.streamManager.addPublishedStream(id, st);
     this.room.controller.addPublisher(this.id, id, options, (signMess) => {
+      if (!this.room.streamManager.hasPublishedStream(id)) {
+        log.warn(`message: addPublisher of removed publisher, messageType: ${signMess.type},` +
+          `label: ${options.label}, clientId: ${this.id}, streamId: ${id}`);
+        return;
+      }
       if (signMess.type === 'initializing') {
         callback(id, signMess.erizoId, signMess.connectionId);
         st.updateStreamState(StreamStates.PUBLISHER_INITAL);
@@ -589,6 +594,12 @@ class Client extends events.EventEmitter {
         options.singlePC = this.options.singlePC || false;
         stream.addAvSubscriber(this.id);
         this.room.controller.addSubscriber(this.id, options.streamId, options, (signMess) => {
+          if (!this.room.streamManager.hasPublishedStream(options.streamId)
+              || !stream.hasAvSubscriber(this.id)) {
+            log.warn(`message: addSubscriber of removed subscriber, messageType: ${signMess.type},` +
+              `clientId: ${this.id}, streamId: ${options.streamId}`);
+            return;
+          }
           if (signMess.type === 'initializing') {
             log.info('message: addSubscriber, ' +
                              'state: SUBSCRIBER_INITIAL, ' +

--- a/erizo_controller/test/erizoController/Client.js
+++ b/erizo_controller/test/erizoController/Client.js
@@ -153,6 +153,7 @@ describe('Erizo Controller / Client', () => {
         };
       });
       it('should update the stream and callback when stream is initializing', () => {
+        mocks.StreamManager.hasPublishedStream.returns(true);
         roomControllerMock.addPublisher.callsArgWith(3, { type: 'initializing' });
         client.onPublish(options, sdp, callback);
         expect(callback.callCount).to.equal(1);
@@ -163,6 +164,7 @@ describe('Erizo Controller / Client', () => {
         expect(roomMock.sendMessage.callCount).to.equal(0);
       });
       it('should update the stream and send event to clients when stream is ready', () => {
+        mocks.StreamManager.hasPublishedStream.returns(true);
         roomControllerMock.addPublisher.callsArgWith(3, { type: 'ready' });
         client.onPublish(options, sdp, callback);
         expect(callback.callCount).to.equal(0);
@@ -173,6 +175,7 @@ describe('Erizo Controller / Client', () => {
         expect(roomMock.sendMessage.args[0][0]).to.equal('onAddStream');
       });
       it('should delete the stream and notify error if it does not succeed', () => {
+        mocks.StreamManager.hasPublishedStream.returns(true);
         roomControllerMock.addPublisher.callsArgWith(3, { type: 'failed' });
         client.onPublish(options, sdp, callback);
         expect(callback.callCount).to.equal(0);
@@ -324,6 +327,8 @@ describe('Erizo Controller / Client', () => {
         expect(roomMock.sendMessage.callCount).to.equal(0);
       });
       it('should update stream when state is initializing', () => {
+        mocks.PublishedStream.hasAvSubscriber.onCall(1).returns(true);
+        mocks.StreamManager.hasPublishedStream.returns(true);
         roomControllerMock.addSubscriber.callsArgWith(3, { type: 'initializing' });
         client.onSubscribe(options, sdp, callback);
         expect(mocks.PublishedStream.addAvSubscriber.callCount).to.equal(1);
@@ -334,6 +339,8 @@ describe('Erizo Controller / Client', () => {
         expect(callback.callCount).to.equal(1);
       });
       it('should update the stream and not issue callback when stream is ready', () => {
+        mocks.PublishedStream.hasAvSubscriber.onCall(1).returns(true);
+        mocks.StreamManager.hasPublishedStream.returns(true);
         roomControllerMock.addSubscriber.callsArgWith(3, { type: 'ready' });
         client.onSubscribe(options, sdp, callback);
         expect(mocks.PublishedStream.addAvSubscriber.callCount).to.equal(1);
@@ -344,6 +351,8 @@ describe('Erizo Controller / Client', () => {
         expect(callback.callCount).to.equal(0);
       });
       it('should delete the stream and notify error if it fails', () => {
+        mocks.PublishedStream.hasAvSubscriber.onCall(1).returns(true);
+        mocks.StreamManager.hasPublishedStream.returns(true);
         roomControllerMock.addSubscriber.callsArgWith(3, { type: 'failed' });
         client.onSubscribe(options, sdp, callback);
         expect(mocks.PublishedStream.addAvSubscriber.callCount).to.equal(1);
@@ -354,6 +363,8 @@ describe('Erizo Controller / Client', () => {
         expect(callback.callCount).to.equal(0);
       });
       it('should delete the stream and notify via callback if erizo times out', () => {
+        mocks.PublishedStream.hasAvSubscriber.onCall(1).returns(true);
+        mocks.StreamManager.hasPublishedStream.returns(true);
         roomControllerMock.addSubscriber.callsArgWith(3, 'timeout');
         client.onSubscribe(options, sdp, callback);
         expect(mocks.PublishedStream.addAvSubscriber.callCount).to.equal(1);


### PR DESCRIPTION
**Description**

There are race conditions between stream publishing and unpublishing. Similar things could happen for subscribing. It was actually affecting Ackuaria.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.