### PR TITLE
Fix wrong parameter when stopping recorder

### DIFF
--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -735,7 +735,7 @@ class Client extends events.EventEmitter {
     this.room.streamManager.forEachPublishedStream((stream) => {
       if (stream.hasExternalOutputSubscriber(url)) {
         stream.removeExternalOutputSubscriber(url);
-        this.room.controller.removeExternalOutput(options.id, url, callback);
+        this.room.controller.removeExternalOutput(stream.id, url, callback);
         removed = true;
       }
     });


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

When stopping a recording, the ExternalOutput must be removed from the RoomController using the method `removeExternalOutput`. The first parameter must be an existing publisherId.
In the current source, the value used as first parameter is the recordingId that isn't a publisherId, so the RoomController won't find the publisher and the recording won't stop.
The recording will only stop when the publisher leaves the room.

This PR changes the parameter to the publisherId so that the ExternalOutput can be correctly removed.

<!--
Add a short description here, please.
If the contribution needs and includes Unit Tests check the box below.
-->

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.