### PR TITLE
Emit re/connection events

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -503,6 +503,20 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     }
   };
 
+  const socketOnReconnecting = () => {
+    Logger.info('Socket reconnecting, lost connection to ErizoController');
+    const reconnectingEvt = RoomEvent({ type: 'room-reconnecting',
+      message: 'reconnecting' });
+    that.dispatchEvent(reconnectingEvt);
+  };
+
+  const socketOnReconnected = () => {
+    Logger.info('Socket reconnected, restablished connection to ErizoController');
+    const reconnectedEvt = RoomEvent({ type: 'room-reconnected',
+      message: 'reconnected' });
+    that.dispatchEvent(reconnectedEvt);
+  };
+
   const socketOnICEConnectionFailed = (arg) => {
     let stream;
     if (!arg.streamId) {
@@ -1098,6 +1112,8 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   socket.on('onUpdateAttributeStream', socketEventToArgs.bind(null, socketOnUpdateAttributeStream));
   socket.on('onRemoveStream', socketEventToArgs.bind(null, socketOnRemoveStream));
   socket.on('disconnect', socketEventToArgs.bind(null, socketOnDisconnect));
+  socket.on('reconnecting', socketEventToArgs.bind(null, socketOnReconnecting));
+  socket.on('reconnected', socketEventToArgs.bind(null, socketOnReconnected));
   socket.on('connection_failed', socketEventToArgs.bind(null, socketOnICEConnectionFailed));
   socket.on('error', socketEventToArgs.bind(null, socketOnError));
 

--- a/erizo_controller/erizoClient/src/Socket.js
+++ b/erizo_controller/erizoClient/src/Socket.js
@@ -124,6 +124,7 @@ const Socket = (newIo) => {
     socket.on('reconnect', (attemptNumber) => {
       Logger.debug('reconnected, id:', that.id, ', attempet:', attemptNumber);
       that.state = that.CONNECTED;
+      socket.emit('reconnected', that.id);
       emit('reconnected', that.id);
       flushBuffer();
     });

--- a/erizo_controller/erizoClient/src/Socket.js
+++ b/erizo_controller/erizoClient/src/Socket.js
@@ -93,6 +93,7 @@ const Socket = (newIo) => {
     socket.on('disconnect', (reason) => {
       Logger.debug('disconnect', that.id, reason);
       if (closeCode !== WEBSOCKET_NORMAL_CLOSURE) {
+        emit('reconnecting', reason);
         that.state = that.RECONNECTING;
         return;
       }
@@ -123,7 +124,7 @@ const Socket = (newIo) => {
     socket.on('reconnect', (attemptNumber) => {
       Logger.debug('reconnected, id:', that.id, ', attempet:', attemptNumber);
       that.state = that.CONNECTED;
-      socket.emit('reconnected', that.id);
+      emit('reconnected', that.id);
       flushBuffer();
     });
 


### PR DESCRIPTION
**Description**

This PR adds two events that might be interesting when tracking WebSocket reconnections.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.