### PR TITLE
Fix Firefox SDP negotiation and Simulcast

### DIFF
--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -301,7 +301,7 @@ const BaseStack = (specInput) => {
       negotiationQueue.startEnqueuing();
       logSDP('Creating offer', that.mediaConstraints);
       const rejectMessages = [];
-      return that.preCreateOffer(isSubscribe)
+      return that.prepareCreateOffer(isSubscribe)
         .then(() => that.peerConnection.createOffer(that.mediaConstraints))
         .then(setLocalDescForOffer.bind(null, isSubscribe))
         .catch((error) => {

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -93,15 +93,15 @@ const BaseStack = (specInput) => {
     const numberOfRemoteMedias = that.remoteSdp.getStreams().size;
     const numberOfLocalMedias = localSdp.getStreams().size;
 
-    let direction = Direction.reverse('sendrecv');
+    let direction = Direction.SENDRECV;
     if (numberOfRemoteMedias > 0 && numberOfLocalMedias > 0) {
-      direction = Direction.reverse('sendrecv');
+      direction = Direction.SENDRECV;
     } else if (numberOfRemoteMedias > 0 && numberOfLocalMedias === 0) {
-      direction = Direction.reverse('recvonly');
+      direction = Direction.RECVONLY;
     } else if (numberOfRemoteMedias === 0 && numberOfLocalMedias > 0) {
-      direction = Direction.reverse('sendonly');
+      direction = Direction.SENDONLY;
     } else {
-      direction = Direction.reverse('inactive');
+      direction = Direction.INACTIVE;
     }
     localSdp.getMedias().forEach((media) => {
       media.setDirection(direction);
@@ -301,7 +301,8 @@ const BaseStack = (specInput) => {
       negotiationQueue.startEnqueuing();
       logSDP('Creating offer', that.mediaConstraints);
       const rejectMessages = [];
-      return that.peerConnection.createOffer(that.mediaConstraints)
+      return that.preCreateOffer(isSubscribe)
+        .then(() => that.peerConnection.createOffer(that.mediaConstraints))
         .then(setLocalDescForOffer.bind(null, isSubscribe))
         .catch((error) => {
           rejectMessages.push(`in protectedCreateOffer-createOffer, error: ${error}`);

--- a/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
@@ -91,6 +91,8 @@ const ChromeStableStack = (specInput) => {
       });
   };
 
+  that.preCreateOffer = () => Promise.resolve();
+
   that.setSimulcastLayersBitrate = () => {
     Logger.debug('Maybe set simulcast Layers bitrate', that.simulcast);
     if (that.simulcast && that.simulcast.spatialLayerBitrates) {

--- a/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
@@ -91,7 +91,7 @@ const ChromeStableStack = (specInput) => {
       });
   };
 
-  that.preCreateOffer = () => Promise.resolve();
+  that.prepareCreateOffer = () => Promise.resolve();
 
   that.setSimulcastLayersBitrate = () => {
     Logger.debug('Maybe set simulcast Layers bitrate', that.simulcast);

--- a/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
@@ -41,16 +41,12 @@ const FirefoxStack = (specInput) => {
 
   that.enableSimulcast = sdp => sdp;
 
-  const baseCreateOffer = that.createOffer;
-
-  that.createOffer = (isSubscribe, forceOfferToReceive = false, streamId = '') => {
+  that.preCreateOffer = (isSubscribe = false) => {
     let promises = [];
     if (isSubscribe !== true) {
       promises = enableSimulcast();
     }
-    Promise.all(promises).then(() => {
-      baseCreateOffer(isSubscribe, forceOfferToReceive, streamId);
-    });
+    return Promise.all(promises);
   };
 
   return that;

--- a/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
@@ -41,7 +41,7 @@ const FirefoxStack = (specInput) => {
 
   that.enableSimulcast = sdp => sdp;
 
-  that.preCreateOffer = (isSubscribe = false) => {
+  that.prepareCreateOffer = (isSubscribe = false) => {
     let promises = [];
     if (isSubscribe !== true) {
       promises = enableSimulcast();

--- a/erizo_controller/erizoJS/models/SessionDescription.js
+++ b/erizo_controller/erizoJS/models/SessionDescription.js
@@ -151,7 +151,7 @@ function getMediaInfoFromDescription(info, sdp, mediaType) {
     });
 
     if (isSimulcast) {
-      simulcast.setSimulcastPlainString(`${ridDirection} rid=${ridsData.join(';')}`);
+      simulcast.setSimulcastPlainString(`${ridDirection} ${ridsData.join(';')}`);
       media.simulcast_03 = simulcast;
     }
     if (info.getXGoogleFlag() && info.getXGoogleFlag() !== '') {

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -77,9 +77,7 @@ const startBasicExample = () => {
     video: !audioOnly,
     data: true,
     screen,
-    attributes: {},
-    videoSize: [640, 480, 640, 480],
-    videoFrameRate: [10, 20] };
+    attributes: {}};
   // If we want screen sharing we have to put our Chrome extension id.
   // The default one only works in our Lynckia test servers.
   // If we are not using chrome, the creation of the stream will fail regardless.

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -77,7 +77,7 @@ const startBasicExample = () => {
     video: !audioOnly,
     data: true,
     screen,
-    attributes: {}};
+    attributes: {} };
   // If we want screen sharing we have to put our Chrome extension id.
   // The default one only works in our Lynckia test servers.
   // If we are not using chrome, the creation of the stream will fail regardless.


### PR DESCRIPTION
**Description**

This PR fixes two issues in Firefox:
- When negotiating SDPs when Erizo sends its Offer first (#1577)
- Simulcast was not working anymore due to an issue in the SDPSemantics.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.