### PR TITLE
Fix stream used for check - should use the one for the stream in erizo

### DIFF
--- a/erizo_controller/erizoJS/models/Subscriber.js
+++ b/erizo_controller/erizoJS/models/Subscriber.js
@@ -38,7 +38,7 @@ class Subscriber extends NodeClass {
   }
 
   _onMediaStreamEvent(mediaStreamEvent) {
-    if (mediaStreamEvent.mediaStreamId !== this.streamId) {
+    if (mediaStreamEvent.mediaStreamId !== this.erizoStreamId) {
       return;
     }
     if (mediaStreamEvent.type === 'slideshow_fallback_update') {


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
`Subscriber` was always ignoring `MediaStreamEvents` because it was checking the wrong id. It should be checking the streamId in erizo

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.