### PR TITLE
Use log modules in Erizo Client

### DIFF
--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -20,10 +20,12 @@ const QUALITY_LEVELS = [
   QUALITY_LEVEL_GOOD,
 ];
 
+const log = Logger.module('ErizoConnection');
+
 class ErizoConnection extends EventEmitterConst {
   constructor(specInput, erizoId = undefined) {
     super();
-    Logger.debug('Building a new Connection');
+    log.debug('Building a new Connection');
     this.stack = {};
 
     this.erizoId = erizoId;
@@ -48,30 +50,30 @@ class ErizoConnection extends EventEmitterConst {
     // Check which WebRTC Stack is installed.
     this.browser = ConnectionHelpers.getBrowser();
     if (this.browser === 'fake') {
-      Logger.warning('Publish/subscribe video/audio streams not supported in erizofc yet');
+      log.warning('Publish/subscribe video/audio streams not supported in erizofc yet');
       this.stack = FcStack(spec);
     } else if (this.browser === 'mozilla') {
-      Logger.debug('Firefox Stack');
+      log.debug('Firefox Stack');
       this.stack = FirefoxStack(spec);
     } else if (this.browser === 'safari') {
-      Logger.debug('Safari using Chrome Stable Stack');
+      log.debug('Safari using Chrome Stable Stack');
       this.stack = ChromeStableStack(spec);
     } else if (this.browser === 'chrome-stable' || this.browser === 'electron') {
-      Logger.debug('Chrome Stable Stack');
+      log.debug('Chrome Stable Stack');
       this.stack = ChromeStableStack(spec);
     } else {
-      Logger.error('No stack available for this browser');
+      log.error('No stack available for this browser');
       throw new Error('WebRTC stack not available');
     }
     if (!this.stack.updateSpec) {
       this.stack.updateSpec = (newSpec, callback = () => {}) => {
-        Logger.error('Update Configuration not implemented in this browser');
+        log.error('Update Configuration not implemented in this browser');
         callback('unimplemented');
       };
     }
     if (!this.stack.setSignallingCallback) {
       this.stack.setSignallingCallback = () => {
-        Logger.error('setSignallingCallback is not implemented in this stack');
+        log.error('setSignallingCallback is not implemented in this stack');
       };
     }
 
@@ -95,7 +97,7 @@ class ErizoConnection extends EventEmitterConst {
   }
 
   close() {
-    Logger.debug('Closing ErizoConnection');
+    log.debug('Closing ErizoConnection');
     this.streamsMap.clear();
     this.stack.close();
   }
@@ -109,7 +111,7 @@ class ErizoConnection extends EventEmitterConst {
   }
 
   addStream(stream) {
-    Logger.debug(`message: Adding stream to Connection, streamId: ${stream.getID()}`);
+    log.debug(`message: Adding stream to Connection, streamId: ${stream.getID()}`);
     this.streamsMap.add(stream.getID(), stream);
     if (stream.local) {
       this.stack.addStream(stream.stream);
@@ -119,7 +121,7 @@ class ErizoConnection extends EventEmitterConst {
   removeStream(stream) {
     const streamId = stream.getID();
     if (!this.streamsMap.has(streamId)) {
-      Logger.debug(`message: Cannot remove stream not in map, streamId: ${streamId}`);
+      log.debug(`message: Cannot remove stream not in map, streamId: ${streamId}`);
       return;
     }
     this.streamsMap.remove(streamId);
@@ -185,7 +187,7 @@ class ErizoConnectionManager {
   }
 
   getOrBuildErizoConnection(specInput, erizoId = undefined, singlePC = false) {
-    Logger.debug(`message: getOrBuildErizoConnection, erizoId: ${erizoId}`);
+    log.debug(`message: getOrBuildErizoConnection, erizoId: ${erizoId}`);
     let connection = {};
 
     if (erizoId === undefined) {
@@ -228,12 +230,12 @@ class ErizoConnectionManager {
   }
 
   maybeCloseConnection(connection, force = false) {
-    Logger.debug(`Trying to remove connection ${connection.sessionId}
+    log.debug(`Trying to remove connection ${connection.sessionId}
        with erizoId ${connection.erizoId}`);
     if (connection.streamsMap.size() === 0 || force) {
-      Logger.debug(`No streams in connection ${connection.sessionId}, erizoId: ${connection.erizoId}`);
+      log.debug(`No streams in connection ${connection.sessionId}, erizoId: ${connection.erizoId}`);
       if (this.ErizoConnectionsMap.get(connection.erizoId) !== undefined && this.ErizoConnectionsMap.get(connection.erizoId)['single-pc'] && !force) {
-        Logger.debug(`Will not remove empty connection ${connection.erizoId} - it is singlePC`);
+        log.debug(`Will not remove empty connection ${connection.erizoId} - it is singlePC`);
         return;
       }
       connection.close();

--- a/erizo_controller/erizoClient/src/Events.js
+++ b/erizo_controller/erizoClient/src/Events.js
@@ -1,6 +1,7 @@
 /* global */
 import Logger from './utils/Logger';
 
+const log = Logger.module('EventDispatcher');
 /*
  * Class EventDispatcher provides event handling to sub-classes.
  * It is inherited from Publisher, Room, etc.
@@ -50,7 +51,7 @@ const EventDispatcher = () => {
       try {
         listeners[i](event);
       } catch (e) {
-        Logger.info(`Error triggering event: ${event.type}, error: ${e}`);
+        log.info(`Error triggering event: ${event.type}, error: ${e}`);
       }
     }
   };

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -7,6 +7,7 @@ import ErizoMap from './utils/ErizoMap';
 import Base64 from './utils/Base64';
 import Logger from './utils/Logger';
 
+const log = Logger.module('Room');
 /*
  * Class Room represents a Licode Room. It will handle the connection, local stream publication and
  * remote stream subscription.
@@ -52,7 +53,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       stream.pc.removeStream(stream);
     }
 
-    Logger.debug('Removed stream');
+    log.debug('Removed stream');
     if (stream.stream) {
       // Remove HTML element
       stream.hide();
@@ -79,7 +80,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   const dispatchStreamSubscribed = (streamInput, evt) => {
     const stream = streamInput;
     // Draw on html
-    Logger.info('Stream subscribed');
+    log.info('Stream subscribed');
     stream.stream = evt.stream;
     if (!that.p2p) {
       stream.pc.addStream(stream);
@@ -91,10 +92,10 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
 
   const maybeDispatchStreamUnsubscribed = (streamInput) => {
     const stream = streamInput;
-    Logger.debug(`maybeDispatchStreamUnsubscribed - unsubscribe id ${stream.getID()}`, stream.unsubscribing);
+    log.debug(`maybeDispatchStreamUnsubscribed - unsubscribe id ${stream.getID()}`, stream.unsubscribing);
     if (stream && stream.unsubscribing.callbackReceived &&
       (stream.unsubscribing.pcEventReceived || stream.failed)) {
-      Logger.info(`Dispatching Stream unsubscribed ${stream.getID()}`);
+      log.info(`Dispatching Stream unsubscribed ${stream.getID()}`);
       stream.unsubscribing.callbackReceived = false;
       stream.unsubscribing.pcEventReceived = false;
       removeStream(stream);
@@ -103,7 +104,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       const evt2 = StreamEvent({ type: 'stream-unsubscribed', stream });
       that.dispatchEvent(evt2);
     } else {
-      Logger.debug(`Not dispatching stream unsubscribed yet ${stream.getID()}`);
+      log.debug(`Not dispatching stream unsubscribed yet ${stream.getID()}`);
     }
   };
 
@@ -166,14 +167,14 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   const createRemoteStreamP2PConnection = (streamInput, peerSocket) => {
     const stream = streamInput;
     const connection = that.erizoConnectionManager.getOrBuildErizoConnection(
-        getP2PConnectionOptions(stream, peerSocket));
+      getP2PConnectionOptions(stream, peerSocket));
     stream.addPC(connection);
     connection.on('connection-failed', () => {
       onConnectionFailed(connection);
     });
     stream.on('added', dispatchStreamSubscribed.bind(null, stream));
     stream.on('icestatechanged', (evt) => {
-      Logger.info(`${stream.getID()} - iceConnectionState: ${evt.msg.state}`);
+      log.info(`${stream.getID()} - iceConnectionState: ${evt.msg.state}`);
       if (evt.msg.state === 'failed') {
         const message = 'ICE Connection Failed';
         onStreamFailed(stream, message, 'ice-client');
@@ -192,7 +193,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     });
 
     stream.on('icestatechanged', (evt) => {
-      Logger.info(`${stream.getID()} - iceConnectionState: ${evt.msg.state}`);
+      log.info(`${stream.getID()} - iceConnectionState: ${evt.msg.state}`);
       if (evt.msg.state === 'failed') {
         stream.pc.get(peerSocket).close();
         stream.pc.remove(peerSocket);
@@ -224,7 +225,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   const getErizoConnectionOptions = (stream, connectionId, erizoId, options, isRemote) => {
     const connectionOpts = {
       callback(message, streamId = stream.getID()) {
-        Logger.info('Sending message', message, stream.getID(), streamId);
+        log.info('Sending message', message, stream.getID(), streamId);
         if (message && message.type && message.type === 'updatestream') {
           socket.sendSDP('streamMessage', {
             streamId,
@@ -265,14 +266,14 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     const stream = streamInput;
     const connectionOpts = getErizoConnectionOptions(stream, connectionId, erizoId, options, true);
     const connection = that.erizoConnectionManager
-        .getOrBuildErizoConnection(connectionOpts, erizoId, spec.singlePC);
+      .getOrBuildErizoConnection(connectionOpts, erizoId, spec.singlePC);
     stream.addPC(connection);
     connection.on('connection-failed', () => {
       onConnectionFailed(connection);
     });
     stream.on('added', dispatchStreamSubscribed.bind(null, stream));
     stream.on('icestatechanged', (evt) => {
-      Logger.info(`${stream.getID()} - iceConnectionState: ${evt.msg.state}`);
+      log.info(`${stream.getID()} - iceConnectionState: ${evt.msg.state}`);
       if (evt.msg.state === 'failed') {
         const message = 'ICE Connection Failed';
         onStreamFailed(stream, message, 'ice-client');
@@ -293,7 +294,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       onConnectionFailed(connection);
     });
     stream.on('icestatechanged', (evt) => {
-      Logger.info(`${stream.getID()} - iceConnectionState: ${evt.msg.state}`);
+      log.info(`${stream.getID()} - iceConnectionState: ${evt.msg.state}`);
       if (evt.msg.state === 'failed') {
         const message = 'ICE Connection Failed';
         onStreamFailed(stream, message, 'ice-client');
@@ -365,7 +366,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     } else if (arg.context === 'auto-streams-unsubscription') {
       onAutomaticStreamsUnsubscription(arg.mess);
     } else {
-      Logger.debug('Failed applying a stream message from erizo', arg);
+      log.debug('Failed applying a stream message from erizo', arg);
     }
   };
 
@@ -412,7 +413,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     if (connection) {
       connection.processSignalingMessage(arg.evt);
     } else {
-      Logger.warning('Received signaling message to unknown connectionId', arg.connectionId);
+      log.warning('Received signaling message to unknown connectionId', arg.connectionId);
     }
   };
 
@@ -445,7 +446,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   };
 
   const socketOnBandwidthAlert = (arg) => {
-    Logger.info('Bandwidth Alert on', arg.streamID, 'message',
+    log.info('Bandwidth Alert on', arg.streamID, 'message',
       arg.message, 'BW:', arg.bandwidth);
     if (arg.streamID) {
       const stream = remoteStreams.get(arg.streamID);
@@ -494,9 +495,9 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
 
   // The socket has disconnected
   const socketOnDisconnect = () => {
-    Logger.info('Socket disconnected, lost connection to ErizoController');
+    log.info('Socket disconnected, lost connection to ErizoController');
     if (that.state !== DISCONNECTED) {
-      Logger.error('Unexpected disconnection from ErizoController');
+      log.error('Unexpected disconnection from ErizoController');
       const disconnectEvt = RoomEvent({ type: 'room-disconnected',
         message: 'unexpected-disconnection' });
       that.dispatchEvent(disconnectEvt);
@@ -504,14 +505,14 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   };
 
   const socketOnReconnecting = () => {
-    Logger.info('Socket reconnecting, lost connection to ErizoController');
+    log.info('Socket reconnecting, lost connection to ErizoController');
     const reconnectingEvt = RoomEvent({ type: 'room-reconnecting',
       message: 'reconnecting' });
     that.dispatchEvent(reconnectingEvt);
   };
 
   const socketOnReconnected = () => {
-    Logger.info('Socket reconnected, restablished connection to ErizoController');
+    log.info('Socket reconnected, restablished connection to ErizoController');
     const reconnectedEvt = RoomEvent({ type: 'room-reconnected',
       message: 'reconnected' });
     that.dispatchEvent(reconnectedEvt);
@@ -523,7 +524,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       return;
     }
     const message = `ICE Connection Failed on ${arg.type} ${arg.streamId} ${that.state}`;
-    Logger.error(message);
+    log.error(message);
     if (arg.type === 'publish') {
       stream = localStreams.get(arg.streamId);
     } else {
@@ -533,7 +534,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   };
 
   const socketOnError = (e) => {
-    Logger.error('Cannot connect to erizo Controller');
+    log.error('Cannot connect to erizo Controller');
     const connectEvt = RoomEvent({ type: 'room-error', message: e });
     that.dispatchEvent(connectEvt);
   };
@@ -544,7 +545,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     if (stream.local) {
       socket.sendMessage('sendDataStream', { id: stream.getID(), msg });
     } else {
-      Logger.error('You can not send data through a remote stream');
+      log.error('You can not send data through a remote stream');
     }
   };
 
@@ -555,7 +556,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       stream.updateLocalAttributes(attrs);
       socket.sendMessage('updateStreamAttributes', { id: stream.getID(), attrs });
     } else {
-      Logger.error('You can not update attributes in a remote stream');
+      log.error('You can not update attributes in a remote stream');
     }
   };
 
@@ -583,13 +584,13 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   const populateStreamFunctions = (id, streamInput, error, callback = () => {}) => {
     const stream = streamInput;
     if (id === null) {
-      Logger.error('Error when publishing the stream', error);
+      log.error('Error when publishing the stream', error);
       // Unauth -1052488119
       // Network -5
       callback(undefined, error);
       return;
     }
-    Logger.info('Stream published');
+    log.info('Stream published');
     stream.getID = () => id;
     stream.on('internal-send-data', sendDataSocketFromStreamEvent);
     stream.on('internal-set-attributes', updateAttributesFromStreamEvent);
@@ -609,7 +610,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       type = 'recording';
       arg = stream.recording;
     }
-    Logger.info('Checking publish options for', stream.getID());
+    log.info('Checking publish options for', stream.getID());
     stream.checkOptions(options);
     socket.sendSDP('publish', createSdpConstraints(type, stream, options), arg,
       (id, error) => {
@@ -636,7 +637,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
 
   const publishErizo = (streamInput, options, callback = () => {}) => {
     const stream = streamInput;
-    Logger.info('Publishing to Erizo Normally, is createOffer', options.createOffer);
+    log.info('Publishing to Erizo Normally, is createOffer', options.createOffer);
     const constraints = createSdpConstraints('erizo', stream, options);
     constraints.minVideoBW = options.minVideoBW;
     constraints.maxVideoBW = options.maxVideoBW;
@@ -644,7 +645,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
 
     socket.sendSDP('publish', constraints, undefined, (id, erizoId, connectionId, error) => {
       if (id === null) {
-        Logger.error('Error publishing stream', error);
+        log.error('Error publishing stream', error);
         callback(undefined, error);
         return;
       }
@@ -690,13 +691,13 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       slideShowMode: options.slideShowMode };
     socket.sendSDP('subscribe', constraint, undefined, (result, erizoId, connectionId, error) => {
       if (result === null) {
-        Logger.error(`Error subscribing to stream, streamId: ${stream.getID()}, error:`, error);
+        log.error(`Error subscribing to stream, streamId: ${stream.getID()}, error:`, error);
         stream.state = 'unsubscribed';
         callback(undefined, error);
         return;
       }
 
-      Logger.info('Subscriber added', erizoId, connectionId);
+      log.info('Subscriber added', erizoId, connectionId);
       createRemoteStreamErizoConnection(stream, connectionId, erizoId, options);
       if (!options.offerFromErizo) {
         stream.pc.sendOffer();
@@ -713,12 +714,12 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
         metadata: options.metadata },
       undefined, (result, error) => {
         if (result === null) {
-          Logger.error(`Error subscribing to stream, streamId: ${stream.getID()}, error:`, error);
+          log.error(`Error subscribing to stream, streamId: ${stream.getID()}, error:`, error);
           stream.state = 'unsubscribed';
           callback(undefined, error);
           return;
         }
-        Logger.info('Stream subscribed');
+        log.info('Stream subscribed');
         const evt = StreamEvent({ type: 'stream-subscribed', stream });
         that.dispatchEvent(evt);
         callback(true);
@@ -751,7 +752,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     try {
       socket.disconnect();
     } catch (error) {
-      Logger.debug('Socket already disconnected');
+      log.debug('Socket already disconnected');
     }
     socket = undefined;
   };
@@ -764,7 +765,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     const token = Base64.decodeBase64(spec.token);
 
     if (that.state !== DISCONNECTED) {
-      Logger.warning(`Room already connected, roomId: ${that.roomID}`);
+      log.warning(`Room already connected, roomId: ${that.roomID}`);
     }
 
     // 1- Connect to Erizo-Controller
@@ -803,12 +804,12 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       // 3 - Update RoomID
       that.roomID = roomId;
 
-      Logger.info(`Connected to room, roomId ${that.roomID}`);
+      log.info(`Connected to room, roomId ${that.roomID}`);
 
       const connectEvt = RoomEvent({ type: 'room-connected', streams: streamList });
       that.dispatchEvent(connectEvt);
     }, (error) => {
-      Logger.error(`Error connecting to room, roomId: ${that.roomID}, Error:`, error);
+      log.error(`Error connecting to room, roomId: ${that.roomID}, Error:`, error);
       const connectEvt = RoomEvent({ type: 'room-error', message: error });
       that.dispatchEvent(connectEvt);
     });
@@ -816,7 +817,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
 
   // It disconnects from the room, dispatching a new RoomEvent("room-disconnected")
   that.disconnect = () => {
-    Logger.debug('Disconnection requested');
+    log.debug('Disconnection requested');
     // 1- Disconnect from room
     const disconnectEvt = RoomEvent({ type: 'room-disconnected',
       message: 'expected-disconnection' });
@@ -866,7 +867,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
         publishData(stream, options, callback);
       }
     } else {
-      Logger.error('Trying to publish invalid stream, stream:', stream);
+      log.error('Trying to publish invalid stream, stream:', stream);
       callback(undefined, 'Invalid Stream');
     }
   };
@@ -874,19 +875,19 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   // Returns callback(id, error)
   that.startRecording = (stream, callback = () => {}) => {
     if (stream === undefined) {
-      Logger.error('Trying to start recording on an invalid stream, stream:', stream);
+      log.error('Trying to start recording on an invalid stream, stream:', stream);
       callback(undefined, 'Invalid Stream');
       return;
     }
-    Logger.debug(`Start Recording stream, streamId: ${stream.getID()}`);
+    log.debug(`Start Recording stream, streamId: ${stream.getID()}`);
     socket.sendMessage('startRecorder', { to: stream.getID() }, (id, error) => {
       if (id === null) {
-        Logger.error(`Error on start recording, streamId: ${stream.getID()}, error:`, error);
+        log.error(`Error on start recording, streamId: ${stream.getID()}, error:`, error);
         callback(undefined, error);
         return;
       }
 
-      Logger.info('Start recording', id);
+      log.info('Start recording', id);
       callback(id);
     });
   };
@@ -895,11 +896,11 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   that.stopRecording = (recordingId, callback = () => {}) => {
     socket.sendMessage('stopRecorder', { id: recordingId }, (result, error) => {
       if (result === null) {
-        Logger.error(`Error on stop recording, recordingId: ${recordingId}, error:`, error);
+        log.error(`Error on stop recording, recordingId: ${recordingId}, error:`, error);
         callback(undefined, error);
         return;
       }
-      Logger.info('Stop recording', recordingId);
+      log.info('Stop recording', recordingId);
       callback(true);
     });
   };
@@ -912,7 +913,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       // Media stream
       socket.sendMessage('unpublish', stream.getID(), (result, error) => {
         if (result === null) {
-          Logger.error(`Error unpublishing stream, streamId: ${stream.getID()}, error:`, error);
+          log.error(`Error unpublishing stream, streamId: ${stream.getID()}, error:`, error);
           callback(undefined, error);
           return;
         }
@@ -921,7 +922,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
         callback(true);
       });
 
-      Logger.info(`Stream unpublished, streamId: ${stream.getID()}`);
+      log.info(`Stream unpublished, streamId: ${stream.getID()}`);
       stream.room = undefined;
       if (stream.hasMedia() && !stream.isExternal()) {
         const localStream = localStreams.has(stream.getID()) ?
@@ -935,7 +936,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       stream.off('internal-set-attributes', updateAttributesFromStreamEvent);
     } else {
       const error = 'Cannot unpublish, stream does not exist or is not local';
-      Logger.error(error);
+      log.error(error);
       callback(undefined, error);
     }
   };
@@ -954,7 +955,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
 
     if (stream && !stream.local && !stream.failed) {
       if (stream.state !== 'unsubscribed') {
-        Logger.warning(`Cannot subscribe to a subscribed stream, streamId: ${stream.getID()}`);
+        log.warning(`Cannot subscribe to a subscribed stream, streamId: ${stream.getID()}`);
         callback(undefined, 'Stream already subscribed');
         return;
       }
@@ -987,25 +988,25 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       } else if (stream.hasData() && options.data !== false) {
         subscribeData(stream, options, callback);
       } else {
-        Logger.warning(`There is nothing to subscribe to in stream, streamId: ${stream.getID()}`);
+        log.warning(`There is nothing to subscribe to in stream, streamId: ${stream.getID()}`);
         stream.state = 'unsubscribed';
         callback(undefined, 'Nothing to subscribe to');
         return;
       }
       // Subscribe to stream stream
-      Logger.info(`Subscribing to: ${stream.getID()}`);
+      log.info(`Subscribing to: ${stream.getID()}`);
     } else {
       let error = 'Error on subscribe';
       stream.state = 'unsubscribed';
       if (!stream) {
-        Logger.warning(`Cannot subscribe to invalid stream, streamId: ${stream.getID()}`);
+        log.warning(`Cannot subscribe to invalid stream, streamId: ${stream.getID()}`);
         error = 'Invalid or undefined stream';
       } else if (stream.local) {
-        Logger.warning('Cannot subscribe to local stream, you should ' +
+        log.warning('Cannot subscribe to local stream, you should ' +
                          'subscribe to the remote version of your local stream');
         error = 'Local copy of stream';
       } else if (stream.failed) {
-        Logger.warning(`Cannot subscribe to failed stream, streamId: ${stream.getID()}, unsubscribing:`,
+        log.warning(`Cannot subscribe to failed stream, streamId: ${stream.getID()}, unsubscribing:`,
           stream.unsubscribing, ' failed: ', stream.failed);
         error = 'Failed stream';
       }
@@ -1020,7 +1021,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     if (socket !== undefined) {
       if (stream && !stream.local) {
         if (stream.state !== 'subscribed') {
-          Logger.warning(`Cannot unsubscribe to a stream that is not subscribed, streamId: ${stream.getID()}`);
+          log.warning(`Cannot unsubscribe to a stream that is not subscribed, streamId: ${stream.getID()}`);
           callback(undefined, 'Stream not subscribed');
           return;
         }
@@ -1036,7 +1037,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
           maybeDispatchStreamUnsubscribed(stream);
         }, () => {
           stream.state = 'subscribed';
-          Logger.error(`Error calling unsubscribe, streamId: ${stream.getID()}`);
+          log.error(`Error calling unsubscribe, streamId: ${stream.getID()}`);
         });
       } else {
         stream.state = 'unsubscribed';

--- a/erizo_controller/erizoClient/src/Socket.js
+++ b/erizo_controller/erizoClient/src/Socket.js
@@ -5,6 +5,8 @@ import Logger from './utils/Logger';
 
 import { EventDispatcher, LicodeEvent } from './Events';
 
+const log = Logger.module('Socket');
+
 const SocketEvent = (type, specInput) => {
   const that = LicodeEvent({ type });
   that.args = specInput.args;
@@ -64,7 +66,7 @@ const Socket = (newIo) => {
     let closeCode = WEBSOCKET_NORMAL_CLOSURE;
     const socketOnCloseFunction = socket.io.engine.transport.ws.onclose;
     socket.io.engine.transport.ws.onclose = (closeEvent) => {
-      Logger.warning('WebSocket closed, code:', closeEvent.code);
+      log.warning('WebSocket closed, code:', closeEvent.code);
       closeCode = closeEvent.code;
       socketOnCloseFunction(closeEvent);
     };
@@ -91,7 +93,7 @@ const Socket = (newIo) => {
 
     // The socket has disconnected
     socket.on('disconnect', (reason) => {
-      Logger.debug('disconnect', that.id, reason);
+      log.debug('disconnect', that.id, reason);
       if (closeCode !== WEBSOCKET_NORMAL_CLOSURE) {
         emit('reconnecting', reason);
         that.state = that.RECONNECTING;
@@ -102,27 +104,27 @@ const Socket = (newIo) => {
     });
 
     socket.on('connection_failed', (evt) => {
-      Logger.error('connection failed, id:', that.id);
+      log.error('connection failed, id:', that.id);
       emit('connection_failed', evt);
     });
     socket.on('error', (err) => {
-      Logger.warning('socket error, id:', that.id, ', error:', err.message);
+      log.warning('socket error, id:', that.id, ', error:', err.message);
       emit('error');
     });
     socket.on('connect_error', (err) => {
-      Logger.warning('connect error, id:', that.id, ', error:', err.message);
+      log.warning('connect error, id:', that.id, ', error:', err.message);
     });
 
     socket.on('connect_timeout', (err) => {
-      Logger.warning('connect timeout, id:', that.id, ', error:', err.message);
+      log.warning('connect timeout, id:', that.id, ', error:', err.message);
     });
 
     socket.on('reconnecting', (attemptNumber) => {
-      Logger.debug('reconnecting, id:', that.id, ', attempet:', attemptNumber);
+      log.debug('reconnecting, id:', that.id, ', attempet:', attemptNumber);
     });
 
     socket.on('reconnect', (attemptNumber) => {
-      Logger.debug('reconnected, id:', that.id, ', attempet:', attemptNumber);
+      log.debug('reconnected, id:', that.id, ', attempet:', attemptNumber);
       that.state = that.CONNECTED;
       socket.emit('reconnected', that.id);
       emit('reconnected', that.id);
@@ -130,15 +132,15 @@ const Socket = (newIo) => {
     });
 
     socket.on('reconnect_attempt', (attemptNumber) => {
-      Logger.debug('reconnect attempt, id:', that.id, ', attempet:', attemptNumber);
+      log.debug('reconnect attempt, id:', that.id, ', attempet:', attemptNumber);
     });
 
     socket.on('reconnect_error', (err) => {
-      Logger.debug('error reconnecting, id:', that.id, ', error:', err.message);
+      log.debug('error reconnecting, id:', that.id, ', error:', err.message);
     });
 
     socket.on('reconnect_failed', () => {
-      Logger.warning('reconnect failed, id:', that.id);
+      log.warning('reconnect failed, id:', that.id);
       that.state = that.DISCONNECTED;
       emit('disconnect', 'reconnect failed');
     });
@@ -161,7 +163,7 @@ const Socket = (newIo) => {
   // Function to send a message to the server using socket.io
   that.sendMessage = (type, msg, callback = defaultCallback, error = defaultCallback) => {
     if (that.state === that.DISCONNECTED && type !== 'token') {
-      Logger.error('Trying to send a message over a disconnected Socket');
+      log.error('Trying to send a message over a disconnected Socket');
       return;
     }
     if (that.state === that.RECONNECTING) {
@@ -182,7 +184,7 @@ const Socket = (newIo) => {
   // It sends a SDP message to the server using socket.io
   that.sendSDP = (type, options, sdp, callback = defaultCallback) => {
     if (that.state === that.DISCONNECTED) {
-      Logger.error('Trying to send a message over a disconnected Socket');
+      log.error('Trying to send a message over a disconnected Socket');
       return;
     }
     socket.emit(type, options, sdp, (...args) => {

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -8,6 +8,8 @@ import VideoPlayer from './views/VideoPlayer';
 import AudioPlayer from './views/AudioPlayer';
 import Logger from './utils/Logger';
 
+const log = Logger.module('Stream');
+
 /*
  * Class Stream represents a local or a remote Stream in the Room. It will handle the WebRTC
  * stream and identify the stream and where it should be drawn.
@@ -94,7 +96,7 @@ const Stream = (altConnectionHelpers, specInput) => {
       that.emit(StreamEvent({ type: 'internal-set-attributes', stream: that, attrs }));
       return;
     }
-    Logger.error('Failed to set attributes data. This Stream object has not been published.');
+    log.error('Failed to set attributes data. This Stream object has not been published.');
   };
 
   that.updateLocalAttributes = (attrs) => {
@@ -144,7 +146,7 @@ const Stream = (altConnectionHelpers, specInput) => {
       that.emit(StreamEvent({ type: 'internal-send-data', stream: that, msg }));
       return;
     }
-    Logger.error('Failed to send data. This Stream object has not been published.');
+    log.error('Failed to send data. This Stream object has not been published.');
   };
 
   // Initializes the stream and tries to retrieve a stream from local video and audio
@@ -152,7 +154,7 @@ const Stream = (altConnectionHelpers, specInput) => {
   that.init = () => {
     try {
       if ((spec.audio || spec.video || spec.screen) && spec.url === undefined) {
-        Logger.info('Requested access to local media');
+        log.info('Requested access to local media');
         let videoOpt = spec.video;
         if (videoOpt === true || spec.screen === true) {
           videoOpt = videoOpt === true || videoOpt === null ? {} : videoOpt;
@@ -185,13 +187,13 @@ const Stream = (altConnectionHelpers, specInput) => {
           desktopStreamId: that.desktopStreamId };
 
         that.ConnectionHelpers.GetUserMedia(opt, (stream) => {
-          Logger.info('User has granted access to local media.');
+          log.info('User has granted access to local media.');
           that.stream = stream;
 
           that.dispatchEvent(StreamEvent({ type: 'access-accepted' }));
 
           that.stream.getTracks().forEach((trackInput) => {
-            Logger.info('getTracks', trackInput);
+            log.info('getTracks', trackInput);
             const track = trackInput;
             track.onended = () => {
               that.stream.getTracks().forEach((secondTrackInput) => {
@@ -205,7 +207,7 @@ const Stream = (altConnectionHelpers, specInput) => {
             };
           });
         }, (error) => {
-          Logger.error('Failed to get access to local media. Error was ' +
+          log.error('Failed to get access to local media. Error was ' +
             `${error.name} with message ${error.message}.`);
           const streamEvent = StreamEvent({ type: 'access-denied', msg: error });
           that.dispatchEvent(streamEvent);
@@ -215,7 +217,7 @@ const Stream = (altConnectionHelpers, specInput) => {
         that.dispatchEvent(streamEvent);
       }
     } catch (e) {
-      Logger.error(`Failed to get access to local media. Error was ${e}.`);
+      log.error(`Failed to get access to local media. Error was ${e}.`);
       const streamEvent = StreamEvent({ type: 'access-denied', msg: e });
       that.dispatchEvent(streamEvent);
     }
@@ -348,25 +350,25 @@ const Stream = (altConnectionHelpers, specInput) => {
     // TODO: Check for any incompatible options
     if (isUpdate === true) { // We are updating the stream
       if (config.audio || config.screen) {
-        Logger.warning('Cannot update type of subscription');
+        log.warning('Cannot update type of subscription');
         config.audio = undefined;
         config.screen = undefined;
       }
     } else if (that.local === false) { // check what we can subscribe to
       if (config.video === true && that.hasVideo() === false) {
-        Logger.warning('Trying to subscribe to video when there is no ' +
+        log.warning('Trying to subscribe to video when there is no ' +
                                    'video, won\'t subscribe to video');
         config.video = false;
       }
       if (config.audio === true && that.hasAudio() === false) {
-        Logger.warning('Trying to subscribe to audio when there is no ' +
+        log.warning('Trying to subscribe to audio when there is no ' +
                                    'audio, won\'t subscribe to audio');
         config.audio = false;
       }
     }
     if (that.local === false) {
       if (!that.hasVideo() && (config.slideShowMode === true)) {
-        Logger.warning('Cannot enable slideShowMode if it is not a video ' +
+        log.warning('Cannot enable slideShowMode if it is not a video ' +
                                  'subscription, please check your parameters');
         config.slideShowMode = false;
       }
@@ -375,12 +377,12 @@ const Stream = (altConnectionHelpers, specInput) => {
 
   const muteStream = (callback = () => {}) => {
     if (that.room && that.room.p2p) {
-      Logger.warning('muteAudio/muteVideo are not implemented in p2p streams');
+      log.warning('muteAudio/muteVideo are not implemented in p2p streams');
       callback('error');
       return;
     }
     if (!that.stream || !that.pc) {
-      Logger.warning('muteAudio/muteVideo cannot be called until a stream is published or subscribed');
+      log.warning('muteAudio/muteVideo cannot be called until a stream is published or subscribed');
       callback('error');
     }
     for (let index = 0; index < that.stream.getVideoTracks().length; index += 1) {
@@ -405,7 +407,7 @@ const Stream = (altConnectionHelpers, specInput) => {
   // eslint-disable-next-line no-underscore-dangle
   that._setStaticQualityLayer = (spatialLayer, temporalLayer, callback = () => {}) => {
     if (that.room && that.room.p2p) {
-      Logger.warning('setStaticQualityLayer is not implemented in p2p streams');
+      log.warning('setStaticQualityLayer is not implemented in p2p streams');
       callback('error');
       return;
     }
@@ -417,7 +419,7 @@ const Stream = (altConnectionHelpers, specInput) => {
   // eslint-disable-next-line no-underscore-dangle
   that._setDynamicQualityLayer = (callback) => {
     if (that.room && that.room.p2p) {
-      Logger.warning('setDynamicQualityLayer is not implemented in p2p streams');
+      log.warning('setDynamicQualityLayer is not implemented in p2p streams');
       callback('error');
       return;
     }
@@ -429,13 +431,13 @@ const Stream = (altConnectionHelpers, specInput) => {
   // eslint-disable-next-line no-underscore-dangle
   that._enableSlideShowBelowSpatialLayer = (enabled, spatialLayer = 0, callback = () => {}) => {
     if (that.room && that.room.p2p) {
-      Logger.warning('enableSlideShowBelowSpatialLayer is not implemented in p2p streams');
+      log.warning('enableSlideShowBelowSpatialLayer is not implemented in p2p streams');
       callback('error');
       return;
     }
     const config = { slideShowBelowLayer: { enabled, spatialLayer } };
     that.checkOptions(config, true);
-    Logger.debug('Calling updateSpec with config', config);
+    log.debug('Calling updateSpec with config', config);
     that.pc.updateSpec(config, that.getID(), callback);
   };
 

--- a/erizo_controller/erizoClient/src/utils/ConnectionHelpers.js
+++ b/erizo_controller/erizoClient/src/utils/ConnectionHelpers.js
@@ -1,6 +1,8 @@
 /* global navigator, window, chrome */
 import Logger from './Logger';
 
+const log = Logger.module('ConnectionHelpers');
+
 const getBrowser = () => {
   let browser = 'none';
 
@@ -36,7 +38,7 @@ const GetUserMedia = (config, callback = () => {}, error = () => {}) => {
   const configureScreensharing = () => {
     switch (getBrowser()) {
       case 'electron' :
-        Logger.debug('Screen sharing in Electron');
+        log.debug('Screen sharing in Electron');
         screenConfig = {};
         screenConfig.video = config.video || {};
         screenConfig.video.mandatory = config.video.mandatory || {};
@@ -45,7 +47,7 @@ const GetUserMedia = (config, callback = () => {}, error = () => {}) => {
         getUserMedia(screenConfig, callback, error);
         break;
       case 'mozilla':
-        Logger.debug('Screen sharing in Firefox');
+        log.debug('Screen sharing in Firefox');
         screenConfig = {};
         if (config.video !== undefined) {
           screenConfig.video = config.video;
@@ -62,7 +64,7 @@ const GetUserMedia = (config, callback = () => {}, error = () => {}) => {
         break;
 
       case 'chrome-stable':
-        Logger.debug('Screen sharing in Chrome');
+        log.debug('Screen sharing in Chrome');
         screenConfig = {};
         if (config.desktopStreamId) {
           screenConfig.video = config.video || { mandatory: {} };
@@ -76,15 +78,15 @@ const GetUserMedia = (config, callback = () => {}, error = () => {}) => {
           // erizo_controller/erizoClient/extras/chrome-extension
           let extensionId = 'okeephmleflklcdebijnponpabbmmgeo';
           if (config.extensionId) {
-            Logger.debug(`extensionId supplied, using ${config.extensionId}`);
+            log.debug(`extensionId supplied, using ${config.extensionId}`);
             extensionId = config.extensionId;
           }
-          Logger.debug('Screen access on chrome stable, looking for extension');
+          log.debug('Screen access on chrome stable, looking for extension');
           try {
             chrome.runtime.sendMessage(extensionId, { getStream: true },
               (response) => {
                 if (response === undefined) {
-                  Logger.error('Access to screen denied');
+                  log.error('Access to screen denied');
                   const theError = { code: 'Access to screen denied' };
                   error(theError);
                   return;
@@ -101,29 +103,29 @@ const GetUserMedia = (config, callback = () => {}, error = () => {}) => {
                 getUserMedia(screenConfig, callback, error);
               });
           } catch (e) {
-            Logger.debug('Screensharing plugin is not accessible ');
+            log.debug('Screensharing plugin is not accessible ');
             const theError = { code: 'no_plugin_present' };
             error(theError);
           }
         }
         break;
       default:
-        Logger.error('This browser does not support ScreenSharing');
+        log.error('This browser does not support ScreenSharing');
     }
   };
 
   if (config.screen) {
     if (config.desktopStreamId || config.extensionId) {
-      Logger.debug('Screen access requested using GetUserMedia');
+      log.debug('Screen access requested using GetUserMedia');
       configureScreensharing();
     } else {
-      Logger.debug('Screen access requested using GetDisplayMedia');
+      log.debug('Screen access requested using GetDisplayMedia');
       getDisplayMedia(config, callback, error);
     }
   } else if (typeof module !== 'undefined' && module.exports) {
-    Logger.error('Video/audio streams not supported in erizofc yet');
+    log.error('Video/audio streams not supported in erizofc yet');
   } else {
-    Logger.debug('Calling getUserMedia with config', config);
+    log.debug('Calling getUserMedia with config', config);
     getUserMedia(config, callback, error);
   }
 };

--- a/erizo_controller/erizoClient/src/utils/Logger.js
+++ b/erizo_controller/erizoClient/src/utils/Logger.js
@@ -41,9 +41,6 @@ const Logger = (() => {
     //  Logger.[DEBUG, TRACE, INFO, WARNING, ERROR]
   const log = (level, ...args) => {
     let out = logPrefix;
-    if (level < Logger.logLevel) {
-      return;
-    }
     if (level === Logger.DEBUG) {
       out = `${out}DEBUG`;
     } else if (level === Logger.TRACE) {
@@ -68,27 +65,41 @@ const Logger = (() => {
     }
   };
 
-  const debug = (...args) => {
-    Logger.log(Logger.DEBUG, ...args);
+  const logFromModule = (moduleName, moduleMinLevel, logLevel, ...args) => {
+    if (moduleMinLevel === undefined && logLevel >= Logger.logLevel) {
+      log(logLevel, `(${moduleName})`, ...args);
+    } else if (logLevel >= moduleMinLevel) {
+      log(logLevel, `(${moduleName})`, ...args);
+    }
   };
 
-  const trace = (...args) => {
-    Logger.log(Logger.TRACE, ...args);
-  };
+  class ModuleLogger {
+    constructor(name) {
+      this.name = name;
+    }
 
-  const info = (...args) => {
-    Logger.log(Logger.INFO, ...args);
-  };
+    setLogLevel(level) { this.level = level; }
 
-  const warning = (...args) => {
-    Logger.log(Logger.WARNING, ...args);
-  };
+    debug(...args) { logFromModule(this.name, this.level, Logger.DEBUG, ...args); }
+    trace(...args) { logFromModule(this.name, this.level, Logger.TRACE, ...args); }
+    info(...args) { logFromModule(this.name, this.level, Logger.INFO, ...args); }
+    warning(...args) { logFromModule(this.name, this.level, Logger.WARNING, ...args); }
+    error(...args) { logFromModule(this.name, this.level, Logger.ERROR, ...args); }
+  }
 
-  const error = (...args) => {
-    Logger.log(Logger.ERROR, ...args);
+  const modules = new Map();
+
+  const module = (moduleName) => {
+    if (modules.has(moduleName)) {
+      return modules.get(moduleName);
+    }
+    const newModule = new ModuleLogger(moduleName);
+    modules.set(moduleName, newModule);
+    return newModule;
   };
 
   return {
+    logLevel: DEBUG,
     DEBUG,
     TRACE,
     INFO,
@@ -98,12 +109,7 @@ const Logger = (() => {
     setLogLevel,
     setOutputFunction,
     setLogPrefix,
-    log,
-    debug,
-    trace,
-    info,
-    warning,
-    error,
+    module,
   };
 })();
 

--- a/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
@@ -2,8 +2,10 @@ import BaseStack from './BaseStack';
 import SdpHelpers from './../utils/SdpHelpers';
 import Logger from '../utils/Logger';
 
+const log = Logger.module('ChromeStableStack');
+
 const ChromeStableStack = (specInput) => {
-  Logger.info('Starting Chrome stable stack', specInput);
+  log.info('Starting Chrome stable stack', specInput);
   const spec = specInput;
   const that = BaseStack(specInput);
   const defaultSimulcastSpatialLayers = 2;
@@ -72,29 +74,29 @@ const ChromeStableStack = (specInput) => {
 
   const setBitrateForVideoLayers = (sender) => {
     if (typeof sender.getParameters !== 'function' || typeof sender.setParameters !== 'function') {
-      Logger.warning('Cannot set simulcast layers bitrate: getParameters or setParameters is not available');
+      log.warning('Cannot set simulcast layers bitrate: getParameters or setParameters is not available');
       return;
     }
     const parameters = sender.getParameters();
     Object.keys(that.simulcast.spatialLayerBitrates).forEach((key) => {
       if (parameters.encodings[key] !== undefined) {
-        Logger.debug(`Setting bitrate for layer ${key}, bps: ${that.simulcast.spatialLayerBitrates[key]}`);
+        log.debug(`Setting bitrate for layer ${key}, bps: ${that.simulcast.spatialLayerBitrates[key]}`);
         parameters.encodings[key].maxBitrate = that.simulcast.spatialLayerBitrates[key];
       }
     });
     sender.setParameters(parameters)
       .then((result) => {
-        Logger.debug('Success setting simulcast layer bitrates', result);
+        log.debug('Success setting simulcast layer bitrates', result);
       })
       .catch((e) => {
-        Logger.warning('Error setting simulcast layer bitrates', e);
+        log.warning('Error setting simulcast layer bitrates', e);
       });
   };
 
   that.prepareCreateOffer = () => Promise.resolve();
 
   that.setSimulcastLayersBitrate = () => {
-    Logger.debug('Maybe set simulcast Layers bitrate', that.simulcast);
+    log.debug('Maybe set simulcast Layers bitrate', that.simulcast);
     if (that.simulcast && that.simulcast.spatialLayerBitrates) {
       that.peerConnection.getSenders().forEach((sender) => {
         if (sender.track.kind === 'video') {
@@ -106,14 +108,14 @@ const ChromeStableStack = (specInput) => {
 
   that.setStartVideoBW = (sdpInfo) => {
     if (that.video && spec.startVideoBW) {
-      Logger.debug(`startVideoBW requested: ${spec.startVideoBW}`);
+      log.debug(`startVideoBW requested: ${spec.startVideoBW}`);
       SdpHelpers.setParamForCodecs(sdpInfo, 'video', 'x-google-start-bitrate', spec.startVideoBW);
     }
   };
 
   that.setHardMinVideoBW = (sdpInfo) => {
     if (that.video && spec.hardMinVideoBW) {
-      Logger.debug(`hardMinVideoBW requested: ${spec.hardMinVideoBW}`);
+      log.debug(`hardMinVideoBW requested: ${spec.hardMinVideoBW}`);
       SdpHelpers.setParamForCodecs(sdpInfo, 'video', 'x-google-min-bitrate', spec.hardMinVideoBW);
     }
   };

--- a/erizo_controller/erizoClient/src/webrtc-stacks/FcStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/FcStack.js
@@ -1,5 +1,6 @@
 import Logger from '../utils/Logger';
 
+const log = Logger.module('FcStack');
 const FcStack = (spec) => {
   /*
   spec.callback({
@@ -16,29 +17,29 @@ const FcStack = (spec) => {
   that.signalCallback = undefined;
 
   that.close = () => {
-    Logger.info('Close FcStack');
+    log.info('Close FcStack');
   };
 
   that.createOffer = () => {
-    Logger.debug('FCSTACK: CreateOffer');
+    log.debug('FCSTACK: CreateOffer');
   };
 
   that.addStream = (stream) => {
-    Logger.debug('FCSTACK: addStream', stream);
+    log.debug('FCSTACK: addStream', stream);
   };
 
   that.processSignalingMessage = (msg) => {
-    Logger.debug('FCSTACK: processSignaling', msg);
+    log.debug('FCSTACK: processSignaling', msg);
     if (that.signalCallback !== undefined) { that.signalCallback(msg); }
   };
 
   that.sendSignalingMessage = (msg) => {
-    Logger.debug('FCSTACK: Sending signaling Message', msg);
+    log.debug('FCSTACK: Sending signaling Message', msg);
     spec.callback(msg);
   };
 
   that.setSignalingCallback = (callback = () => {}) => {
-    Logger.debug('FCSTACK: Setting signalling callback');
+    log.debug('FCSTACK: Setting signalling callback');
     that.signalCallback = callback;
   };
   return that;

--- a/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
@@ -1,8 +1,9 @@
 import Logger from '../utils/Logger';
 import BaseStack from './BaseStack';
 
+const log = Logger.module('FirefoxStack');
 const FirefoxStack = (specInput) => {
-  Logger.info('Starting Firefox stack');
+  log.info('Starting Firefox stack');
   const that = BaseStack(specInput);
   const defaultSimulcastSpatialLayers = 2;
 

--- a/erizo_controller/erizoClient/src/webrtc-stacks/PeerConnectionFsm.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/PeerConnectionFsm.js
@@ -3,6 +3,7 @@
 import StateMachine from '../../lib/state-machine';
 import Logger from '../utils/Logger';
 
+const log = Logger.module('PeerConnectionFsm');
 const activeStates = ['initial', 'failed', 'stable'];
 const HISTORY_SIZE_LIMIT = 200;
 // FSM
@@ -30,58 +31,58 @@ const PeerConnectionFsm = StateMachine.factory({
     },
 
     onBeforeClose: function onBeforeClose(lifecycle) {
-      Logger.info(`FSM onBeforeClose from: ${lifecycle.from}, to: ${lifecycle.to}`);
+      log.info(`FSM onBeforeClose from: ${lifecycle.from}, to: ${lifecycle.to}`);
       return this.baseStackCalls.protectedClose();
     },
 
     onBeforeAddIceCandidate: function onBeforeAddIceCandidate(lifecycle, candidate) {
-      Logger.info(`FSM onBeforeAddIceCandidate, from ${lifecycle.from}, to: ${lifecycle.to}`);
+      log.info(`FSM onBeforeAddIceCandidate, from ${lifecycle.from}, to: ${lifecycle.to}`);
       return this.baseStackCalls.protectedAddIceCandidate(candidate);
     },
 
     onBeforeAddStream: function onBeforeAddStream(lifecycle, stream) {
-      Logger.info(`FSM onBeforeAddStream, from ${lifecycle.from}, to: ${lifecycle.to}`);
+      log.info(`FSM onBeforeAddStream, from ${lifecycle.from}, to: ${lifecycle.to}`);
       return this.baseStackCalls.protectedAddStream(stream);
     },
 
     onBeforeRemoveStream: function onBeforeRemoveStream(lifecycle, stream) {
-      Logger.info(`FSM onBeforeRemoveStream, from ${lifecycle.from}, to: ${lifecycle.to}`);
+      log.info(`FSM onBeforeRemoveStream, from ${lifecycle.from}, to: ${lifecycle.to}`);
       return this.baseStackCalls.protectedRemoveStream(stream);
     },
 
     onBeforeCreateOffer: function onBeforeCreateOffer(lifecycle, isSubscribe) {
-      Logger.info(`FSM onBeforeCreateOffer, from ${lifecycle.from}, to: ${lifecycle.to}`);
+      log.info(`FSM onBeforeCreateOffer, from ${lifecycle.from}, to: ${lifecycle.to}`);
       return this.baseStackCalls.protectedCreateOffer(isSubscribe);
     },
 
     onBeforeProcessOffer:
     function onBeforeProcessOffer(lifecycle, message) {
-      Logger.info(`FSM onBeforeProcessOffer, from ${lifecycle.from}, to: ${lifecycle.to}`);
+      log.info(`FSM onBeforeProcessOffer, from ${lifecycle.from}, to: ${lifecycle.to}`);
       return this.baseStackCalls.protectedProcessOffer(message);
     },
 
     onBeforeProcessAnswer:
     function onBeforeProcessAnswer(lifecycle, message) {
-      Logger.info(`FSM onBeforeProcessAnswer from: ${lifecycle.from}, to: ${lifecycle.to}`);
+      log.info(`FSM onBeforeProcessAnswer from: ${lifecycle.from}, to: ${lifecycle.to}`);
       return this.baseStackCalls.protectedProcessAnswer(message);
     },
 
     onBeforeNegotiateMaxBW:
     function onBeforeNegotiateMaxBW(lifecycle, configInput, callback) {
-      Logger.info(`FSM onBeforeNegotiateMaxBW from: ${lifecycle.from}, to: ${lifecycle.to}`);
+      log.info(`FSM onBeforeNegotiateMaxBW from: ${lifecycle.from}, to: ${lifecycle.to}`);
       return this.baseStackCalls.protectedNegotiateMaxBW(configInput, callback);
     },
 
     onStable: function onStable(lifecycle) {
-      Logger.info(`FSM reached STABLE, from ${lifecycle.from}, to: ${lifecycle.to}`);
+      log.info(`FSM reached STABLE, from ${lifecycle.from}, to: ${lifecycle.to}`);
     },
 
     onClosed: function onClosed(lifecycle) {
-      Logger.info(`FSM reached close, from ${lifecycle.from}, to: ${lifecycle.to}`);
+      log.info(`FSM reached close, from ${lifecycle.from}, to: ${lifecycle.to}`);
     },
 
     onTransition: function saveToHistory(lifecycle) {
-      Logger.debug(`FSM onTransition, transition: ${lifecycle.transition}, from ${lifecycle.from}, to: ${lifecycle.to}`);
+      log.debug(`FSM onTransition, transition: ${lifecycle.transition}, from ${lifecycle.from}, to: ${lifecycle.to}`);
       this.history.push(
         { from: lifecycle.from, to: lifecycle.to, transition: lifecycle.transition });
       if (this.history.length > HISTORY_SIZE_LIMIT) {
@@ -90,22 +91,22 @@ const PeerConnectionFsm = StateMachine.factory({
     },
 
     onError: function onError(lifecycle, message) {
-      Logger.warning(`FSM Error Transition Failed, message: ${message}, from: ${lifecycle.from}, to: ${lifecycle.to}, printing history:`);
+      log.warning(`FSM Error Transition Failed, message: ${message}, from: ${lifecycle.from}, to: ${lifecycle.to}, printing history:`);
       this.history.forEach((item) => {
-        Logger.warning(item);
+        log.warning(item);
       });
     },
 
     onInvalidTransition: function onInvalidTransition(transition, from, to) {
       if (from === 'closed') {
-        Logger.info(`Trying to transition a closed FSM, transition: ${transition}, from: ${from}, to: ${to}`);
+        log.info(`Trying to transition a closed FSM, transition: ${transition}, from: ${from}, to: ${to}`);
         return;
       }
-      Logger.warning(`FSM Error Invalid transition: ${transition}, from: ${from}, to: ${to}`);
+      log.warning(`FSM Error Invalid transition: ${transition}, from: ${from}, to: ${to}`);
     },
 
     onPendingTransition: function onPendingTransition(transition, from, to) {
-      Logger.warning(`FSM Error Pending transition: ${transition}, from: ${from}, to: ${to}`);
+      log.warning(`FSM Error Pending transition: ${transition}, from: ${from}, to: ${to}`);
     },
   },
 });


### PR DESCRIPTION
**Description**

This PR adds Log scopes to make it easier to filter log lines in Erizo Client. We will now do it by module, and we are currently having one module per file (this could change in the future).

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

We don't change any public API, although people could set up different log levels for each module now.

For instance, we could do things like:

```js
Erizo.Logger.setLogLevel(Erizo.Logger.NONE);
Erizo.Logger.module('Stream').level = Erizo.Logger.DEBUG;
```

[] It includes documentation for these changes in `/doc`.