### PR TITLE
Fix default nuveUrl

### DIFF
--- a/extras/basic_example/basicServer.js
+++ b/extras/basic_example/basicServer.js
@@ -15,7 +15,7 @@ const config = require('./../../licode_config');
 
 config.erizoController.ssl_key = config.erizoController.ssl_key || '../../cert/key.pem';
 config.erizoController.ssl_cert = config.erizoController.ssl_cert || '../../cert/cert.pem';
-config.basicExample.nuveUrl = config.basicExample.nuveUrl || 'http://localhost:3000';
+config.basicExample.nuveUrl = config.basicExample.nuveUrl || 'http://localhost:3000/';
 
 const options = {
   key: fs.readFileSync(config.erizoController.ssl_key).toString(),


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

The default value for nuveUrl in `basicServer` is not the same that we have in `licode_default.js`. This one fails when trying to connect to nuve

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.