### PR TITLE
Add SR info to algorithm in ConnectionQualityCheck

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -494,6 +494,17 @@ int MediaStream::deliverEvent_(MediaEventPtr event) {
     if (stream_ptr->pipeline_) {
       stream_ptr->pipeline_->notifyEvent(event);
     }
+
+    if (event->getType() == "PublisherRtpInfoEvent") {
+      if (!stream_ptr->is_publisher_) {
+        auto publisher_info_event = std::static_pointer_cast<PublisherRtpInfoEvent>(event);
+        if (publisher_info_event->kind_ == "audio") {
+          stream_ptr->publisher_info_.audio_fraction_lost = publisher_info_event->fraction_lost_;
+        } else {
+          stream_ptr->publisher_info_.video_fraction_lost = publisher_info_event->fraction_lost_;
+        }
+      }
+    }
   });
   return 1;
 }

--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -44,6 +44,16 @@ class MediaStreamEventListener {
     }
     virtual void notifyMediaStreamEvent(const std::string& type, const std::string& message) = 0;
 };
+
+class PublisherInfo {
+ public:
+  PublisherInfo() : audio_fraction_lost{0}, video_fraction_lost{0} {}
+  PublisherInfo(uint8_t audio_fl, uint8_t video_fl)
+    : audio_fraction_lost{audio_fl}, video_fraction_lost{video_fl} {}
+  uint8_t audio_fraction_lost;
+  uint8_t video_fraction_lost;
+};
+
 /**
  * A MediaStream. This class represents a Media Stream that can be established with other peers via a SDP negotiation
  */
@@ -161,9 +171,7 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   void parseIncomingPayloadType(char *buf, int len, packetType type);
   void parseIncomingExtensionId(char *buf, int len, packetType type);
   virtual void setTargetPaddingBitrate(uint64_t bitrate);
-  virtual uint64_t getTargetPaddingBitrate() {
-    return target_padding_bitrate_;
-  }
+  virtual uint64_t getTargetPaddingBitrate() { return target_padding_bitrate_; }
 
   virtual uint32_t getTargetVideoBitrate();
 
@@ -177,6 +185,8 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   inline std::string toLog() {
     return "id: " + stream_id_ + ", role:" + (is_publisher_ ? "publisher" : "subscriber") + ", " + printLogContext();
   }
+
+  virtual PublisherInfo getPublisherInfo() { return publisher_info_; }
 
  private:
   void sendPacket(std::shared_ptr<DataPacket> packet);
@@ -238,6 +248,7 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   bool periodic_keyframes_requested_;
   uint32_t periodic_keyframe_interval_;
   int session_version_;
+  PublisherInfo publisher_info_;
 
  protected:
   std::shared_ptr<SdpInfo> remote_sdp_;

--- a/erizo/src/erizo/bandwidth/ConnectionQualityCheck.cpp
+++ b/erizo/src/erizo/bandwidth/ConnectionQualityCheck.cpp
@@ -47,10 +47,19 @@ void ConnectionQualityCheck::onFeedback(std::shared_ptr<DataPacket> packet,
         [ssrc, fraction_lost, this] (const std::shared_ptr<MediaStream> &media_stream) {
       bool is_audio = media_stream->isAudioSourceSSRC(ssrc) || media_stream->isAudioSinkSSRC(ssrc);
       bool is_video = media_stream->isVideoSourceSSRC(ssrc) || media_stream->isVideoSinkSSRC(ssrc);
+      uint8_t subscriber_fraction_lost = fraction_lost;
+      uint8_t publisher_fraction_lost = is_audio ?
+        media_stream->getPublisherInfo().audio_fraction_lost : media_stream->getPublisherInfo().video_fraction_lost;
+      if (fraction_lost < publisher_fraction_lost) {
+        subscriber_fraction_lost = 0;
+      } else {
+        subscriber_fraction_lost = fraction_lost - publisher_fraction_lost;
+      }
+
       if (is_audio) {
-        audio_buffer_.push_back(fraction_lost);
+        audio_buffer_.push_back(subscriber_fraction_lost);
       } else if (is_video) {
-        video_buffer_.push_back(fraction_lost);
+        video_buffer_.push_back(subscriber_fraction_lost);
       }
     });
   });

--- a/erizo/src/erizo/rtp/RtcpFeedbackGenerationHandler.h
+++ b/erizo/src/erizo/rtp/RtcpFeedbackGenerationHandler.h
@@ -10,12 +10,26 @@
 #include "rtp/RtcpRrGenerator.h"
 #include "rtp/RtcpNackGenerator.h"
 #include "lib/ClockUtils.h"
+#include "./MediaDefinitions.h"
 
 #define MAX_DELAY 450000
 
 namespace erizo {
 
 class MediaStream;
+
+class PublisherRtpInfoEvent : public MediaEvent {
+ public:
+  explicit PublisherRtpInfoEvent(std::string kind, uint8_t fraction_lost)
+    : kind_{kind}, fraction_lost_{fraction_lost} {}
+
+  std::string getType() const override {
+    return "PublisherRtpInfoEvent";
+  }
+
+  std::string kind_;
+  uint8_t fraction_lost_;
+};
 
 class RtcpGeneratorPair {
  public:
@@ -43,6 +57,9 @@ class RtcpFeedbackGenerationHandler: public Handler {
   void read(Context *ctx, std::shared_ptr<DataPacket> packet) override;
   void write(Context *ctx, std::shared_ptr<DataPacket> packet) override;
   void notifyUpdate() override;
+
+ private:
+  void notifyReceiverReportInfo(const std::shared_ptr<DataPacket> &packet, bool is_audio);
 
  private:
   MediaStream *stream_;

--- a/erizo/src/test/utils/Mocks.h
+++ b/erizo/src/test/utils/Mocks.h
@@ -119,6 +119,7 @@ class MockMediaStream: public MediaStream {
   MOCK_METHOD0(getTargetPaddingBitrate, uint64_t());
   MOCK_METHOD1(setTargetPaddingBitrate, void(uint64_t));
   MOCK_METHOD0(getTargetVideoBitrate, uint32_t());
+  MOCK_METHOD0(getPublisherInfo, erizo::PublisherInfo());
 
   int deliverEvent_(MediaEventPtr event) override {
     deliverEventInternal(event);


### PR DESCRIPTION
**Description**

We now only measure the fraction lost in the subscriber's path, by subtracting the fraction lost measured in the publisher's side when calculating it in ConnectionQualityCheck.

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.