### PR TITLE
Catch the exception if the player dom element fails when being removed

### DIFF
--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -289,7 +289,11 @@ const Stream = (altConnectionHelpers, specInput) => {
   that.stop = () => {
     if (that.showing) {
       if (that.player !== undefined) {
-        that.player.destroy();
+        try {
+          that.player.destroy();
+        } catch (e) {
+          log.warning(`message: Exception when destroying Player, error: ${e.message}, ${that.toLog()}`);
+        }
         that.showing = false;
       }
     }


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
We've seen instances where the `removeChild` call issued when stopping a `VideoPlayer` or `AudioPlayer` throws an exception. This PR catches that exception and logs it, preventing it from altering the rest of the operations. It's pretty safe since that exception should be thrown when the child has already been removed.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.