### PR TITLE
Centralize the way we get configuration flags in BasicExample

### DIFF
--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -53,11 +53,13 @@ function startRecording() {
       room.startRecording(localStream, (id) => {
         recording = true;
         recordingId = id;
+        window.recordingId = recordingId;
       });
     } else {
       room.stopRecording(recordingId);
       recording = false;
     }
+    window.recording = recording;
   }
 }
 

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -5,11 +5,11 @@
 /* eslint-disable no-param-reassign, no-console */
 
 const serverUrl = '/';
-window.localStream = undefined;
-window.room = undefined;
-window.recording = false;
-window.recordingId = '';
-window.configFlags = {
+let localStream;
+let room;
+let recording = false;
+let recordingId = '';
+const configFlags = {
   noStart: false, // disable start button when only subscribe
   forceStart: false, // force start button in all cases
   screen: false, // screensharinug
@@ -33,11 +33,11 @@ const getParameterByName = (name) => {
   return results == null ? false : decodeURIComponent(results[1].replace(/\+/g, ' '));
 };
 
-const getConfigFlagsFromParameters = () => {
-  Object.keys(window.configFlags).forEach((key) => {
-    window.configFlags[key] = getParameterByName(key);
+const fillInConfigFlagsFromParameters = (config) => {
+  Object.keys(config).forEach((key) => {
+    config[key] = getParameterByName(key);
   });
-  console.log('Flags parsed, configuration is ', window.configFlags);
+  console.log('Flags parsed, configuration is ', config);
 };
 
 // eslint-disable-next-line no-unused-vars
@@ -48,15 +48,15 @@ const testConnection = () => {
 
 // eslint-disable-next-line no-unused-vars
 function startRecording() {
-  if (window.room !== undefined) {
-    if (!window.recording) {
-      window.room.startRecording(window.localStream, (id) => {
-        window.recording = true;
-        window.recordingId = id;
+  if (room !== undefined) {
+    if (!recording) {
+      room.startRecording(localStream, (id) => {
+        recording = true;
+        recordingId = id;
       });
     } else {
-      window.room.stopRecording(window.recordingId);
-      window.recording = false;
+      room.stopRecording(recordingId);
+      recording = false;
     }
   }
 }
@@ -65,13 +65,13 @@ let slideShowMode = false;
 
 // eslint-disable-next-line no-unused-vars
 function toggleSlideShowMode() {
-  const streams = window.room.remoteStreams;
+  const streams = room.remoteStreams;
   const cb = (evt) => {
     console.log('SlideShowMode changed', evt);
   };
   slideShowMode = !slideShowMode;
   streams.forEach((stream) => {
-    if (window.localStream.getID() !== stream.getID()) {
+    if (localStream.getID() !== stream.getID()) {
       console.log('Updating config');
       stream.updateConfiguration({ slideShowMode }, cb);
     }
@@ -83,21 +83,22 @@ const startBasicExample = () => {
   document.getElementById('slideShowMode').disabled = false;
   document.getElementById('startWarning').hidden = true;
   document.getElementById('startButton').hidden = true;
-  window.recording = false;
-  console.log('Selected Room', window.configFlags.room, 'of type', window.configFlags.type);
+  recording = false;
+  console.log('Selected Room', configFlags.room, 'of type', configFlags.type);
   const config = { audio: true,
-    video: !window.configFlags.onlyAudio,
+    video: !configFlags.onlyAudio,
     data: true,
-    screen: window.configFlags.screen,
+    screen: configFlags.screen,
     attributes: {} };
   // If we want screen sharing we have to put our Chrome extension id.
   // The default one only works in our Lynckia test servers.
   // If we are not using chrome, the creation of the stream will fail regardless.
-  if (window.configFlags.screen) {
+  if (configFlags.screen) {
     config.extensionId = 'okeephmleflklcdebijnponpabbmmgeo';
   }
   Erizo.Logger.setLogLevel(Erizo.Logger.INFO);
-  window.localStream = Erizo.Stream(config);
+  localStream = Erizo.Stream(config);
+  window.localStream = localStream;
   const createToken = (roomData, callback) => {
     const req = new XMLHttpRequest();
     const url = `${serverUrl}createToken/`;
@@ -115,20 +116,21 @@ const startBasicExample = () => {
 
   const roomData = { username: `user ${parseInt(Math.random() * 100, 10)}`,
     role: 'presenter',
-    room: window.configFlags.room,
-    type: window.configFlags.type,
-    mediaConfiguration: window.configFlags.mediaConfiguration };
+    room: configFlags.room,
+    type: configFlags.type,
+    mediaConfiguration: configFlags.mediaConfiguration };
 
   createToken(roomData, (response) => {
     const token = response;
     console.log(token);
-    window.room = Erizo.Room({ token });
+    room = Erizo.Room({ token });
+    window.room = room;
 
     const subscribeToStreams = (streams) => {
-      if (window.configFlags.autoSubscribe) {
+      if (configFlags.autoSubscribe) {
         return;
       }
-      if (window.configFlags.onlyPublish) {
+      if (configFlags.onlyPublish) {
         return;
       }
       const cb = (evt) => {
@@ -136,30 +138,30 @@ const startBasicExample = () => {
       };
 
       streams.forEach((stream) => {
-        if (window.localStream.getID() !== stream.getID()) {
-          window.room.subscribe(stream, { slideShowMode, metadata: { type: 'subscriber' }, offerFromErizo: window.configFlags.offerFromErizo });
+        if (localStream.getID() !== stream.getID()) {
+          room.subscribe(stream, { slideShowMode, metadata: { type: 'subscriber' }, offerFromErizo: configFlags.offerFromErizo });
           stream.addEventListener('bandwidth-alert', cb);
         }
       });
     };
 
-    window.room.addEventListener('room-connected', (roomEvent) => {
+    room.addEventListener('room-connected', (roomEvent) => {
       const options = { metadata: { type: 'publisher' } };
-      if (window.configFlags.simulcast) options.simulcast = { numSpatialLayers: 2 };
+      if (configFlags.simulcast) options.simulcast = { numSpatialLayers: 2 };
       subscribeToStreams(roomEvent.streams);
 
-      if (!window.configFlags.onlySubscribe) {
-        window.room.publish(window.localStream, options);
+      if (!configFlags.onlySubscribe) {
+        room.publish(localStream, options);
       }
-      window.room.addEventListener('quality-level', (qualityEvt) => {
+      room.addEventListener('quality-level', (qualityEvt) => {
         console.log(`New Quality Event, connection quality: ${qualityEvt.message}`);
       });
-      if (window.configFlags.autoSubscribe) {
-        window.room.autoSubscribe({ '/attributes/type': 'publisher' }, {}, { audio: true, video: true, data: false }, () => {});
+      if (configFlags.autoSubscribe) {
+        room.autoSubscribe({ '/attributes/type': 'publisher' }, {}, { audio: true, video: true, data: false }, () => {});
       }
     });
 
-    window.room.addEventListener('stream-subscribed', (streamEvent) => {
+    room.addEventListener('stream-subscribed', (streamEvent) => {
       const stream = streamEvent.stream;
       const div = document.createElement('div');
       div.setAttribute('style', 'width: 320px; height: 240px;float:left;');
@@ -169,17 +171,17 @@ const startBasicExample = () => {
       stream.show(`test${stream.getID()}`);
     });
 
-    window.room.addEventListener('stream-added', (streamEvent) => {
+    room.addEventListener('stream-added', (streamEvent) => {
       const streams = [];
       streams.push(streamEvent.stream);
-      if (window.localStream) {
-        window.localStream.setAttributes({ type: 'publisher' });
+      if (localStream) {
+        localStream.setAttributes({ type: 'publisher' });
       }
       subscribeToStreams(streams);
       document.getElementById('recordButton').disabled = false;
     });
 
-    window.room.addEventListener('stream-removed', (streamEvent) => {
+    room.addEventListener('stream-removed', (streamEvent) => {
       // Remove stream from DOM
       const stream = streamEvent.stream;
       if (stream.elementID !== undefined) {
@@ -188,33 +190,34 @@ const startBasicExample = () => {
       }
     });
 
-    window.room.addEventListener('stream-failed', () => {
+    room.addEventListener('stream-failed', () => {
       console.log('Stream Failed, act accordingly');
     });
 
-    if (window.configFlags.onlySubscribe) {
-      window.room.connect({ singlePC: window.configFlags.singlePC });
+    if (configFlags.onlySubscribe) {
+      room.connect({ singlePC: configFlags.singlePC });
     } else {
       const div = document.createElement('div');
       div.setAttribute('style', 'width: 320px; height: 240px; float:left');
       div.setAttribute('id', 'myVideo');
       document.getElementById('videoContainer').appendChild(div);
 
-      window.localStream.addEventListener('access-accepted', () => {
-        window.room.connect({ singlePC: window.configFlags.singlePC });
-        window.localStream.show('myVideo');
+      localStream.addEventListener('access-accepted', () => {
+        room.connect({ singlePC: configFlags.singlePC });
+        localStream.show('myVideo');
       });
-      window.localStream.init();
+      localStream.init();
     }
   });
 };
 
 window.onload = () => {
-  getConfigFlagsFromParameters();
+  fillInConfigFlagsFromParameters(configFlags);
+  window.configFlags = configFlags;
 
   const shouldSkipButton =
-    !window.configFlags.forceStart &&
-    (!window.configFlags.onlySubscribe || window.configFlags.noStart);
+    !configFlags.forceStart &&
+    (!configFlags.onlySubscribe || configFlags.noStart);
 
   if (shouldSkipButton) {
     startBasicExample();


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR cleans up the way we get configuration flags in the BasicExample by creating a new global structure to hold them and parsing all of them when the window is loaded.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.