### PR TITLE
Initialize timer to trigger connection quality level events

### DIFF
--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -61,6 +61,7 @@ class Connection extends events.EventEmitter {
     });
     this.isNegotiationLocked = false;
     this.queue = [];
+    this.lastQualityLevelChanged = new Date() - CONNECTION_QUALITY_LEVEL_INCREASE_UPDATE_INTERVAL;
   }
 
   _logSdp(...message) {
@@ -184,6 +185,7 @@ class Connection extends events.EventEmitter {
       const canIncreaseQualityLevel = newQualityLevel > this.qualityLevel &&
           timeSinceLastQualityLevel > CONNECTION_QUALITY_LEVEL_INCREASE_UPDATE_INTERVAL;
       const canDecreaseQualityLevel = newQualityLevel < this.qualityLevel;
+      log.warn('QualityLevel', newQualityLevel, this.qualityLevel, timeSinceLastQualityLevel, canIncreaseQualityLevel, canDecreaseQualityLevel);
       if (canIncreaseQualityLevel || canDecreaseQualityLevel) {
         this.qualityLevel = newQualityLevel;
         this.lastQualityLevelChanged = new Date();

--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -185,7 +185,6 @@ class Connection extends events.EventEmitter {
       const canIncreaseQualityLevel = newQualityLevel > this.qualityLevel &&
           timeSinceLastQualityLevel > CONNECTION_QUALITY_LEVEL_INCREASE_UPDATE_INTERVAL;
       const canDecreaseQualityLevel = newQualityLevel < this.qualityLevel;
-      log.warn('QualityLevel', newQualityLevel, this.qualityLevel, timeSinceLastQualityLevel, canIncreaseQualityLevel, canDecreaseQualityLevel);
       if (canIncreaseQualityLevel || canDecreaseQualityLevel) {
         this.qualityLevel = newQualityLevel;
         this.lastQualityLevelChanged = new Date();


### PR DESCRIPTION
**Description**

There was an issue by which we were not triggering Connection Quality Levels. We need to initialize a variable.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.