### PR TITLE
Update x509 cert version to 3

### DIFF
--- a/erizo/src/erizo/dtls/DtlsClient.cpp
+++ b/erizo/src/erizo/dtls/DtlsClient.cpp
@@ -210,7 +210,7 @@ int createCert(const std::string& pAor, int expireDays, int keyLen, X509*& outCe
   X509_EXTENSION* ext = X509_EXTENSION_new();
 
   // set version to X509v3 (starts from 0)
-  // X509_set_version(cert, 0L);
+  X509_set_version(cert, 2L);
   std::string thread_id = boost::lexical_cast<std::string>(boost::this_thread::get_id());
   unsigned int thread_number = 0;
   sscanf(thread_id.c_str(), "%x", &thread_number);


### PR DESCRIPTION
**Description**

This should fix issues with latest versions of Chrome (v86+), like the one mention in #1609 .

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.