### PR TITLE
New Client API to update active simulcast layers for publishers

### DIFF
--- a/doc/client_api.md
+++ b/doc/client_api.md
@@ -90,6 +90,7 @@ In the next table we can see the functions of this class:
 | [getVideoFrameURL()](#get-the-url-of-a-frame-from-the-video)                     | It gets the URL of a Bitmap from the video.                             |
 | [updateConfiguration(config, callback)](#update-the-spec-of-a-stream)            | Updates the spec of a stream.                                           |
 | [updateSimulcastLayersBitrate(config)](#update-simulcast-layers-bitrate)         | Updates the bitrates for each simulcast layer.                          |
+| [updateSimulcastActiveLayers(config)](#update-simulcast-active-layers)           | Updates if each simulcast layer is active.                              |
 
 ## Check if the stream has audio, video and/or data active
 
@@ -317,6 +318,15 @@ console.log(result);
 It allows us to change the max bitrate assigned for each spatial layer in Simulcast. It can only be applied to publishers.
 ```
 localStream.updateSimulcastLayersBitrate({0: 80000, 1: 430000});
+```
+
+In this example we are configuring 2 spatial layers bitrates, limiting the lower layer to 80 Kbps and the higher to 430 Kbps.
+
+## Update Simulcast Active Layers
+
+We can decide which Simulcast layers are active. It can only be applied to publishers.
+```
+localStream.updateSimulcastActiveLayers({0: true, 1: false});
 ```
 
 In this example we are configuring 2 spatial layers bitrates, limiting the lower layer to 80 Kbps and the higher to 430 Kbps.

--- a/doc/client_api.md
+++ b/doc/client_api.md
@@ -329,7 +329,7 @@ We can decide which Simulcast layers are active. It can only be applied to publi
 localStream.updateSimulcastActiveLayers({0: true, 1: false});
 ```
 
-In this example we are configuring 2 spatial layers bitrates, limiting the lower layer to 80 Kbps and the higher to 430 Kbps.
+In this example we are disabling layer 1 while the other layer (0) is active.
 
 # Room
 

--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -164,6 +164,10 @@ class ErizoConnection extends EventEmitterConst {
     this.stack.updateSimulcastLayersBitrate(bitrates);
   }
 
+  updateSimulcastActiveLayers(layersInfo) {
+    this.stack.updateSimulcastActiveLayers(layersInfo);
+  }
+
   setQualityLevel(level) {
     this.qualityLevel = QUALITY_LEVELS[level];
   }

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -486,6 +486,12 @@ const Stream = (altConnectionHelpers, specInput) => {
     }
   };
 
+  that.updateSimulcastActiveLayers = (layersInfo) => {
+    if (that.pc && that.local) {
+      that.pc.updateSimulcastActiveLayers(layersInfo);
+    }
+  };
+
   that.updateConfiguration = (config, callback = () => {}) => {
     if (config === undefined) { return; }
     if (that.pc) {

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -152,7 +152,7 @@ const BaseStack = (specInput) => {
     log.debug(`message: Setting local description, localDesc: ${JSON.stringify(localDesc)}`);
     logSDP('processOffer - Local Description', localDesc.type);
     return that.peerConnection.setLocalDescription(localDesc).then(() => {
-      that.setSimulcastLayersBitrate();
+      that.setSimulcastLayersConfig();
     });
   };
 
@@ -410,7 +410,7 @@ const BaseStack = (specInput) => {
       const rejectMessages = [];
       return that.peerConnection.setLocalDescription(localDesc)
         .then(() => {
-          that.setSimulcastLayersBitrate();
+          that.setSimulcastLayersConfig();
           logSDP('processAnswer - Remote Description', msg.type);
           that.peerConnection.setRemoteDescription(new RTCSessionDescription(msg));
         })
@@ -455,7 +455,7 @@ const BaseStack = (specInput) => {
         logSDP('protectedNegotiateBW - Local Description', localDesc.type);
         that.peerConnection.setLocalDescription(localDesc)
           .then(() => {
-            that.setSimulcastLayersBitrate();
+            that.setSimulcastLayersConfig();
             remoteSdp = SemanticSdp.SDPInfo.processString(remoteDesc.sdp);
             SdpHelpers.setMaxBW(remoteSdp, specBase);
             remoteDesc.sdp = remoteSdp.toString();
@@ -559,14 +559,31 @@ const BaseStack = (specInput) => {
     return sdpInput;
   };
 
-  that.updateSimulcastLayersBitrate = (bitrates) => {
+  const setSpatialLayersConfig = (field, values, check = () => true) => {
     if (that.simulcast) {
-      that.simulcast.spatialLayerBitrates = bitrates;
-      that.setSimulcastLayersBitrate();
+      Object.keys(values).forEach((layerId) => {
+        const value = values[layerId];
+        if (!that.simulcast.spatialLayerConfigs[layerId]) {
+          that.simulcast.spaialLayerConfigs[layerId] = {};
+        }
+        if (check(value)) {
+          that.simulcast.spatialLayerConfigs[layerId][field] = value;
+        }
+      });
+      that.setSimulcastLayersConfig();
     }
   };
 
-  that.setSimulcastLayersBitrate = () => {
+  that.updateSimulcastLayersBitrate = (bitrates) => {
+    setSpatialLayersConfig('maxBitrate', bitrates);
+  };
+
+  that.updateSimulcastActiveLayers = (layersInfo) => {
+    const ifIsBoolean = value => value === true || value === false;
+    setSpatialLayersConfig('active', layersInfo, ifIsBoolean);
+  };
+
+  that.setSimulcastLayersConfig = () => {
     log.error('message: Simulcast not implemented');
   };
 

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -563,8 +563,11 @@ const BaseStack = (specInput) => {
     if (that.simulcast) {
       Object.keys(values).forEach((layerId) => {
         const value = values[layerId];
+        if (!that.simulcast.spatialLayerConfigs) {
+          that.simulcast.spatialLayerConfigs = {};
+        }
         if (!that.simulcast.spatialLayerConfigs[layerId]) {
-          that.simulcast.spaialLayerConfigs[layerId] = {};
+          that.simulcast.spatialLayerConfigs[layerId] = {};
         }
         if (check(value)) {
           that.simulcast.spatialLayerConfigs[layerId][field] = value;


### PR DESCRIPTION
**Description**

New Client API to update active simulcast layers for publishers.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

We can now decide which Simulcast layers are active. It can only be applied to publishers.
```
localStream.updateSimulcastActiveLayers({0: true, 1: false});
```

In this example we are configuring 2 spatial layers bitrates, limiting the lower layer to 80 Kbps and the higher to 430 Kbps.

- [x] It includes documentation for these changes in `/doc`.