### PR TITLE
Fix crash while updating quality stats

### DIFF
--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -59,6 +59,9 @@ void QualityManager::onConnectionQualityUpdate(ConnectionQualityLevel level) {
     selectLayer(false);
   }
   last_connection_quality_level_received_ = level;
+  if (!initialized_) {
+    return;
+  }
   stats_->getNode()["qualityLayers"].insertStat("currentQualityLevel",
                                                 CumulativeStat{level});
 }


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR adds a check to make sure that the `QualityManager` is initialized before inserting stats
[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.