### PR TITLE
[WIP] Add support to ICE TCP candidates

### DIFF
--- a/erizo/src/erizo/NicerConnection.cpp
+++ b/erizo/src/erizo/NicerConnection.cpp
@@ -251,6 +251,7 @@ void NicerConnection::startSync() {
     ELOG_DEBUG("%s message: setting remote credentials in constructor, ufrag:%s, pass:%s",
                toLog(), ice_config_.username.c_str(), ice_config_.password.c_str());
     setRemoteCredentialsSync(ice_config_.username, ice_config_.password);
+    peer_->controlling = 0;
   } else {
     peer_->controlling = 1;
   }
@@ -431,7 +432,19 @@ void NicerConnection::onCandidate(nr_ice_media_stream *stream, int component_id,
     default:
       break;
   }
-  cand_info.netProtocol = "udp";
+  cand_info.netProtocol = cand->addr.protocol == IPPROTO_UDP ? "udp" : "tcp";
+  if (cand->addr.protocol == IPPROTO_TCP) {
+    switch (cand->tcp_type) {
+      case nr_socket_tcp_type::TCP_TYPE_ACTIVE:
+        cand_info.tcpType = TCP_ACTIVE;
+        break;
+      case nr_socket_tcp_type::TCP_TYPE_PASSIVE:
+        cand_info.tcpType = TCP_PASSIVE;
+        break;
+      default:
+        cand_info.tcpType = TCP_SO;
+    }
+  }
   cand_info.transProtocol = ice_config_.transport_name;
   cand_info.username = ufrag_;
   cand_info.password = upass_;
@@ -602,6 +615,7 @@ void NicerConnection::initializeGlobals() {
     NR_reg_set_uchar(const_cast<char *>(NR_ICE_REG_PREF_TYPE_SRV_RFLX), 100);
     NR_reg_set_uchar(const_cast<char *>(NR_ICE_REG_PREF_TYPE_PEER_RFLX), 110);
     NR_reg_set_uchar(const_cast<char *>(NR_ICE_REG_PREF_TYPE_HOST), 126);
+    NR_reg_set_uchar(const_cast<char *>(NR_ICE_REG_PREF_TYPE_HOST_TCP), 125);
     NR_reg_set_uchar(const_cast<char *>(NR_ICE_REG_PREF_TYPE_RELAYED), 5);
     NR_reg_set_uchar(const_cast<char *>(NR_ICE_REG_PREF_TYPE_RELAYED_TCP), 0);
 
@@ -634,7 +648,7 @@ void NicerConnection::initializeGlobals() {
     NR_reg_set_uint4(const_cast<char *>("stun.client.maximum_transmits"), 7);
     NR_reg_set_uint4(const_cast<char *>(NR_ICE_REG_TRICKLE_GRACE_PERIOD), 5000);
 
-    NR_reg_set_char(const_cast<char *>(NR_ICE_REG_ICE_TCP_DISABLE), true);
+    NR_reg_set_char(const_cast<char *>(NR_ICE_REG_ICE_TCP_DISABLE), false);
     NR_reg_set_char(const_cast<char *>(NR_STUN_REG_PREF_ALLOW_LINK_LOCAL_ADDRS), 1);
   }
 }

--- a/erizo/src/erizo/SdpInfo.h
+++ b/erizo/src/erizo/SdpInfo.h
@@ -21,6 +21,9 @@ namespace erizo {
 enum HostType {
     HOST, SRFLX, PRFLX, RELAY
 };
+enum TcpType {
+  TCP_ACTIVE, TCP_PASSIVE, TCP_SO
+};
 /**
  * Channel types
  */
@@ -92,11 +95,24 @@ class CandidateInfo {
         default: return "host";
       }
     }
+    std::string getTcpTypeName() const {
+      if (netProtocol == "udp") {
+        return "";
+      }
+      switch (tcpType) {
+        case TCP_ACTIVE: return "active";
+        case TCP_PASSIVE: return "passive";
+        case TCP_SO: return "so";
+      }
+    }
     std::string to_string() const {
       std::ostringstream sdp_stream;
       sdp_stream << "a=candidate:" << foundation << " " << componentId << " ";
       sdp_stream << netProtocol << " " << priority << " " << hostAddress << " ";
       sdp_stream << hostPort << " typ " << getTypeName();
+      if (netProtocol == "tcp") {
+        sdp_stream << " tcptype " << getTcpTypeName();
+      }
       if (!rAddress.empty()) {
         sdp_stream << " raddr " << rAddress << " rport " << rPort;
       }
@@ -114,6 +130,7 @@ class CandidateInfo {
     int rPort;
     std::string netProtocol;
     HostType hostType;
+    TcpType tcpType;
     std::string transProtocol;
     std::string username;
     std::string password;

--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -24,6 +24,7 @@ using v8::Value;
 using json = nlohmann::json;
 using erizo::CandidateInfo;
 using erizo::HostType;
+using erizo::TcpType;
 
 Nan::Persistent<Function> WebRtcConnection::constructor;
 
@@ -434,12 +435,23 @@ NAN_METHOD(WebRtcConnection::addRemoteCandidate) {
     cand.hostType = HostType::HOST;
   }
 
-  Nan::Utf8String param5(Nan::To<v8::String>(info[9]).ToLocalChecked());
+  Nan::Utf8String param41(Nan::To<v8::String>(info[9]).ToLocalChecked());
+  std::string tcpType = std::string(*param4);
+
+  if (tcpType == "active") {
+    cand.tcpType = TcpType::TCP_ACTIVE;
+  } else if (tcpType == "passive") {
+    cand.tcpType = TcpType::TCP_PASSIVE;
+  } else if (tcpType == "so") {
+    cand.tcpType = TcpType::TCP_SO;
+  }
+
+  Nan::Utf8String param5(Nan::To<v8::String>(info[10]).ToLocalChecked());
   cand.rAddress = std::string(*param5);
 
-  cand.rPort = Nan::To<int>(info[10]).FromJust();
+  cand.rPort = Nan::To<int>(info[11]).FromJust();
 
-  Nan::Utf8String param6(Nan::To<v8::String>(info[11]).ToLocalChecked());
+  Nan::Utf8String param6(Nan::To<v8::String>(info[12]).ToLocalChecked());
   cand.sdp = std::string(*param6);
 
   me->addRemoteCandidate(mid, sdpMLine, cand);

--- a/erizo_controller/common/semanticSdp/CandidateInfo.js
+++ b/erizo_controller/common/semanticSdp/CandidateInfo.js
@@ -1,6 +1,6 @@
 class CandidateInfo {
   constructor(foundation, componentId, transport, priority, address, port,
-    type, generation, relAddr, relPort) {
+    type, tcpType, generation, relAddr, relPort) {
     this.foundation = foundation;
     this.componentId = componentId;
     this.transport = transport;
@@ -8,6 +8,7 @@ class CandidateInfo {
     this.address = address;
     this.port = port;
     this.type = type;
+    this.tcpType = tcpType;
     this.generation = generation;
     this.relAddr = relAddr;
     this.relPort = relPort;
@@ -15,7 +16,8 @@ class CandidateInfo {
 
   clone() {
     return new CandidateInfo(this.foundation, this.componentId, this.transport, this.priority,
-      this.address, this.port, this.type, this.generation, this.relAddr, this.relPort);
+      this.address, this.port, this.type, this.tcpType,
+      this.generation, this.relAddr, this.relPort);
   }
 
   plain() {
@@ -27,6 +29,7 @@ class CandidateInfo {
       address: this.address,
       port: this.port,
       type: this.type,
+      tcptype: this.tcpType,
       generation: this.generation,
     };
     if (this.relAddr) plain.relAddr = this.relAddr;
@@ -60,6 +63,10 @@ class CandidateInfo {
 
   getType() {
     return this.type;
+  }
+
+  getTcpType() {
+    return this.tcpType;
   }
 
   getGeneration() {

--- a/erizo_controller/common/semanticSdp/SDPInfo.js
+++ b/erizo_controller/common/semanticSdp/SDPInfo.js
@@ -278,6 +278,7 @@ class SDPInfo {
           ip: candidate.getAddress(),
           port: candidate.getPort(),
           type: candidate.getType(),
+          tcptype: candidate.getTcpType(),
           relAddr: candidate.getRelAddr(),
           relPort: candidate.getRelPort(),
           generation: candidate.getGeneration(),
@@ -822,7 +823,7 @@ SDPInfo.process = (sdp) => {
       candidates.forEach((candidate) => {
         mediaInfo.addCandidate(new CandidateInfo(candidate.foundation, candidate.component,
           candidate.transport, candidate.priority, candidate.ip, candidate.port, candidate.type,
-          candidate.generation, candidate.relAddr, candidate.relPort));
+          candidate.tcptype, candidate.generation, candidate.relAddr, candidate.relPort));
       });
     }
 

--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -338,13 +338,10 @@ class Connection extends events.EventEmitter {
       return;
     }
     candidatesInfo.candidates.forEach((candidate) => {
-      if (candidate.transport.toLowerCase() !== 'udp') {
-        return;
-      }
       this.wrtc.addRemoteCandidate(sdpCandidate.sdpMid, sdpCandidate.sdpMLineIndex,
         candidate.foundation, candidate.component, candidate.priority, candidate.transport,
-        candidate.ip, candidate.port, candidate.type, candidate.raddr, candidate.rport,
-        sdpCandidate.candidate);
+        candidate.ip, candidate.port, candidate.type, candidate.tcpType,
+        candidate.raddr, candidate.rport, sdpCandidate.candidate);
     });
   }
 

--- a/erizo_controller/erizoJS/models/SessionDescription.js
+++ b/erizo_controller/erizoJS/models/SessionDescription.js
@@ -68,7 +68,7 @@ function getMediaInfoFromDescription(info, sdp, mediaType) {
     candidates.forEach((candidate) => {
       media.addCandidate(new CandidateInfo(candidate.foundation, candidate.componentId,
         candidate.protocol, candidate.priority, candidate.hostIp, candidate.hostPort,
-        candidate.hostType, 0, candidate.relayIp, candidate.relayPort));
+        candidate.hostType, candidate.tcpType, 0, candidate.relayIp, candidate.relayPort));
     });
   }
 
@@ -163,8 +163,10 @@ function getMediaInfoFromDescription(info, sdp, mediaType) {
 
 function candidateToString(cand) {
   let str = `candidate:${cand.foundation} ${cand.componentId} ${cand.transport}` +
-            ` ${cand.priority} ${cand.address} ${cand.port} typ ${cand.type}`;
-
+            ` ${cand.priority} ${cand.address} ${cand.port} typ ${cand.hostType}`;
+  if (cand.hostType === 'tcp') {
+    str += ` tcptype ${cand.tcpType}`;
+  }
   str += (cand.relAddr != null) ? ` raddr ${cand.relAddr} rport ${cand.relPort}` : '';
 
   str += (cand.tcptype != null) ? ` tcptype ${cand.tcptype}` : '';
@@ -303,8 +305,8 @@ class SessionDescription {
         const candidateString = candidateToString(candidate);
         info.addCandidate(media.getType(), candidate.getFoundation(), candidate.getComponentId(),
           candidate.getTransport(), candidate.getPriority(), candidate.getAddress(),
-          candidate.getPort(), candidate.getType(), candidate.getRelAddr(), candidate.getRelPort(),
-          candidateString);
+          candidate.getPort(), candidate.getType(), candidate.getTcpType(),
+          candidate.getRelAddr(), candidate.getRelPort(), candidateString);
       });
 
       const ice = media.getICE();


### PR DESCRIPTION
**Description**

It enables TCP in nICEr to use ICE TCP candidates for connectivity checks. It also fixes some issues when handling this kind of candidates in Erizo.

Note: It is still a WIP as I have not been able to make it fully work when blocking UDP candidates.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.