### PR TITLE
Print nicer logs

### DIFF
--- a/erizo/src/erizo/NicerConnection.cpp
+++ b/erizo/src/erizo/NicerConnection.cpp
@@ -180,8 +180,8 @@ void NicerConnection::startSync() {
     start_promise_.set_value();
     return;
   }
-
-  int r = nicer_->IceContextCreate(const_cast<char *>(name_.c_str()), flags, &ctx_);
+  std::string ice_ctx_id = toLog() + "transportName: " + name_;
+  int r = nicer_->IceContextCreate(const_cast<char *>(ice_ctx_id.c_str()), flags, &ctx_);
   if (r) {
     ELOG_WARN("%s message: Couldn't create ICE ctx", toLog());
     start_promise_.set_value();
@@ -219,7 +219,7 @@ void NicerConnection::startSync() {
     return;
   }
 
-  std::string stream_name(name_ + " - " + ufrag_.c_str() + ":" + upass_.c_str());
+  std::string stream_name(name_ + " - " + ufrag_ + ":" + upass_);
   r = nicer_->IceAddMediaStream(ctx_, stream_name.c_str(), ufrag_.c_str(),
                                 upass_.c_str(), ice_config_.ice_components, &stream_);
   if (r) {
@@ -251,6 +251,7 @@ void NicerConnection::startSync() {
     ELOG_DEBUG("%s message: setting remote credentials in constructor, ufrag:%s, pass:%s",
                toLog(), ice_config_.username.c_str(), ice_config_.password.c_str());
     setRemoteCredentialsSync(ice_config_.username, ice_config_.password);
+    peer_->controlling = 0;
   } else {
     peer_->controlling = 1;
   }

--- a/erizo_controller/erizoAgent/erizoAgent.js
+++ b/erizo_controller/erizoAgent/erizoAgent.js
@@ -23,6 +23,7 @@ global.config.erizoAgent.useIndividualLogFiles =
   global.config.erizoAgent.useIndividualLogFiles || false;
 
 global.config.erizoAgent.launchDebugErizoJS = global.config.erizoAgent.launchDebugErizoJS || false;
+global.config.erizoAgent.enableNicerLogs = global.config.erizoAgent.enableNicerLogs || true;
 
 const BINDED_INTERFACE_NAME = global.config.erizoAgent.networkInterface;
 const LAUNCH_SCRIPT = './launch.sh';
@@ -138,14 +139,21 @@ const launchErizoJS = (erizo) => {
     erizoLaunchOptions.push('-d');
   }
 
+  const erizoLaunchEnv = Object.assign({}, process.env);
+  if (global.config.erizoAgent.enableNicerLogs) {
+    erizoLaunchEnv.R_LOG_VERBOSE = 1;
+    erizoLaunchEnv.R_LOG_DESTINATION = 'stderr';
+    erizoLaunchEnv.R_LOG_LEVEL = 3;
+  }
+
   if (global.config.erizoAgent.useIndividualLogFiles) {
     out = fs.openSync(`${global.config.erizoAgent.instanceLogDir}/erizo-${id}.log`, 'a');
     err = fs.openSync(`${global.config.erizoAgent.instanceLogDir}/erizo-${id}.log`, 'a');
     erizoProcess = spawn(LAUNCH_SCRIPT, erizoLaunchOptions,
-      { detached: true, stdio: ['ignore', out, err] });
+      { detached: true, stdio: ['ignore', out, err], env: erizoLaunchEnv });
   } else {
     erizoProcess = spawn(LAUNCH_SCRIPT, erizoLaunchOptions,
-      { detached: true, stdio: ['ignore', 'pipe', 'pipe'] });
+      { detached: true, stdio: ['ignore', 'pipe', 'pipe'], env: erizoLaunchEnv });
     erizoProcess.stdout.setEncoding('utf8');
     erizoProcess.stdout.on('data', (message) => {
       printErizoLogMessage(`[erizo-${id}]`, message.replace(/\n$/, ''));

--- a/erizo_controller/test/erizoAgent/erizoAgent.js
+++ b/erizo_controller/test/erizoAgent/erizoAgent.js
@@ -20,9 +20,13 @@ describe('Erizo Agent', () => {
   let erizoAgent;
   let licodeConfigMock;
   let processArgsBackup;
+  const defaultEnv = Object.assign({}, process.env);
+  defaultEnv.R_LOG_VERBOSE = 1;
+  defaultEnv.R_LOG_DESTINATION = 'stderr';
+  defaultEnv.R_LOG_LEVEL = 3;
 
   const kDefaultOpts = {
-    detached: true, stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true, stdio: ['ignore', 'pipe', 'pipe'], env: defaultEnv,
   };
 
   // Allows passing arguments to mocha

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -140,6 +140,9 @@ config.erizoAgent.useIndividualLogFiles = false;
 // If true this Agent will launch Debug versions of ErizoJS
 config.erizoAgent.launchDebugErizoJS = false;
 
+// If true this Agent will log also nICEr logs
+config.erizoAgent.enableNicerLogs = true; // default value: true
+
 // Custom log directory for agent instance log files.
 // If useIndividualLogFiles is enabled, files will go here
 // Default is [licode_path]/erizo_controller/erizoAgent


### PR DESCRIPTION
**Description**

This adds nICEr logs to the rest of ErizoJS logs to have more data in case of issues.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.