### PR TITLE
Add more info with connection-failed events

### DIFF
--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -38,8 +38,9 @@ class ErizoConnection extends EventEmitterConst {
     this.qualityLevel = QUALITY_LEVEL_GOOD;
 
     log.debug(`message: Building a new Connection, ${this.toLog()}`);
-    spec.onEnqueueingTimeout = () => {
-      this.emit(ConnectionEvent({ type: 'connection-failed', id: this.connectionId }));
+    spec.onEnqueueingTimeout = (step) => {
+      const message = `reason: Timeout in ${step}`;
+      this.emit(ConnectionEvent({ type: 'connection-failed', connection: this, message }));
     };
 
     if (!spec.streamRemovedListener) {

--- a/erizo_controller/erizoClient/src/Events.js
+++ b/erizo_controller/erizoClient/src/Events.js
@@ -121,7 +121,9 @@ const ConnectionEvent = (spec) => {
   const that = LicodeEvent(spec);
 
   that.stream = spec.stream;
+  that.connection = spec.connection;
   that.state = spec.state;
+  that.message = spec.message;
 
   return that;
 };

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -1,6 +1,6 @@
 import ErizoConnectionManager from './ErizoConnectionManager';
 import ConnectionHelpers from './utils/ConnectionHelpers';
-import { EventDispatcher, StreamEvent, RoomEvent, ConnectionEvent } from './Events';
+import { EventDispatcher, StreamEvent, RoomEvent } from './Events';
 import { Socket } from './Socket';
 import Stream from './Stream';
 import ErizoMap from './utils/ErizoMap';
@@ -110,12 +110,6 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     }
   };
 
-  const onConnectionFailed = () => {
-    const connectionFailedEvt = ConnectionEvent(
-      { type: 'connection-failed' });
-    that.dispatchEvent(connectionFailedEvt);
-  };
-
   const onStreamFailed = (streamInput, message, origin = 'unknown') => {
     const stream = streamInput;
     if (that.state !== DISCONNECTED && stream && !stream.failed) {
@@ -171,9 +165,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     const connection = that.erizoConnectionManager.getOrBuildErizoConnection(
       getP2PConnectionOptions(stream, peerSocket));
     stream.addPC(connection);
-    connection.on('connection-failed', () => {
-      onConnectionFailed(connection);
-    });
+    connection.on('connection-failed', that.dispatchEvent.bind(this));
     stream.on('added', dispatchStreamSubscribed.bind(null, stream));
     stream.on('icestatechanged', (evt) => {
       log.debug(`message: icestatechanged, ${stream.toLog()}, iceConnectionState: ${evt.msg.state}, ${toLog()}`);
@@ -190,9 +182,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       getP2PConnectionOptions(stream, peerSocket));
 
     stream.addPC(connection, peerSocket);
-    connection.on('connection-failed', () => {
-      onConnectionFailed(connection);
-    });
+    connection.on('connection-failed', that.dispatchEvent.bind(this));
 
     stream.on('icestatechanged', (evt) => {
       log.debug(`message: icestatechanged, streamId: ${stream.getID()}, iceConnectionState: ${evt.msg.state}, ${toLog()}`);
@@ -270,9 +260,8 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     const connection = that.erizoConnectionManager
       .getOrBuildErizoConnection(connectionOpts, erizoId, spec.singlePC);
     stream.addPC(connection);
-    connection.on('connection-failed', () => {
-      onConnectionFailed(connection);
-    });
+    connection.on('connection-failed', that.dispatchEvent.bind(this));
+
     stream.on('added', dispatchStreamSubscribed.bind(null, stream));
     stream.on('icestatechanged', (evt) => {
       log.debug(`message: icestatechanged, ${stream.toLog()}, iceConnectionState: ${evt.msg.state}, ${toLog()}`);
@@ -292,9 +281,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     const connection = that.erizoConnectionManager
       .getOrBuildErizoConnection(connectionOpts, erizoId, spec.singlePC);
     stream.addPC(connection);
-    connection.on('connection-failed', () => {
-      onConnectionFailed(connection);
-    });
+    connection.on('connection-failed', that.dispatchEvent.bind(this));
     stream.on('icestatechanged', (evt) => {
       log.debug(`message: icestatechanged, ${stream.toLog()}, iceConnectionState: ${evt.msg.state}, ${toLog()}`);
       if (evt.msg.state === 'failed') {

--- a/erizo_controller/erizoClient/src/utils/FunctionQueue.js
+++ b/erizo_controller/erizoClient/src/utils/FunctionQueue.js
@@ -14,12 +14,12 @@ class FunctionQueue {
     return this._enqueuing;
   }
 
-  startEnqueuing() {
+  startEnqueuing(step) {
     this._enqueuing = true;
     clearTimeout(this._enqueueingTimeout);
     this._enqueueingTimeout = setTimeout(() => {
       if (this.onEnqueueingTimeout) {
-        this.onEnqueueingTimeout();
+        this.onEnqueueingTimeout(step);
       }
     }, this.maxEnqueueingTime);
   }

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -146,6 +146,7 @@ const startBasicExample = () => {
         }
       });
     };
+    room.on('connection-failed', console.log.bind(console));
 
     room.addEventListener('room-connected', (roomEvent) => {
       const options = { metadata: { type: 'publisher' } };


### PR DESCRIPTION
**Description**

This PR adds more info when Room objects dispatch a connection-failed event.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.