### PR TITLE
Force v8 promise resolving to publish/subscriber faster

### DIFF
--- a/erizoAPI/MediaStream.cc
+++ b/erizoAPI/MediaStream.cc
@@ -550,8 +550,11 @@ NAUV_WORK_CB(MediaStream::closePromiseResolver) {
     auto persistent = obj->futures.front();
     v8::Local<v8::Promise::Resolver> resolver = Nan::New(*persistent);
     resolver->Resolve(Nan::GetCurrentContext(), Nan::New("").ToLocalChecked()).IsNothing();
+    persistent->Reset();
+    delete persistent;
     obj->futures.pop();
     obj->Unref();
+    v8::Isolate::GetCurrent()->RunMicrotasks();
   }
   obj->closeEvents();
   obj->Unref();

--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -595,8 +595,11 @@ NAUV_WORK_CB(WebRtcConnection::promiseResolver) {
       ELOG_WARN("%s, message: Resolving promise with no valid value, using empty string", obj->toLog());
       resolver->Resolve(Nan::GetCurrentContext(), Nan::New("").ToLocalChecked()).IsNothing();
     }
+    persistent->Reset();
+    delete persistent;
     obj->futures.pop();
     obj->Unref();
+    v8::Isolate::GetCurrent()->RunMicrotasks();
   }
   ELOG_DEBUG("%s, message: promiseResolver finished", obj->toLog());
 }

--- a/erizo_controller/erizoClient/src/webrtc-stacks/PeerConnectionFsm.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/PeerConnectionFsm.js
@@ -106,7 +106,7 @@ const PeerConnectionFsm = StateMachine.factory({
     },
 
     onPendingTransition: function onPendingTransition(transition, from, to) {
-      const lastTransition = this.history.lenth > 0 ? this.history[this.history.length - 1].transition : 'none';
+      const lastTransition = this.history.length > 0 ? this.history[this.history.length - 1].transition : 'none';
       log.warning(`message: Error Pending transition, transition: ${transition}, from: ${from}, to: ${to}, lastTransition: ${lastTransition}`);
     },
   },


### PR DESCRIPTION
**Description**

There was a long delay of some seconds between a promise was resolved and the corresponding listeners were triggered in ErizoAPI. This fix aims to force those triggers to complete Promise resolving quicker.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.