### PR TITLE
Update remove client in erizoJS

### DIFF
--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -418,10 +418,13 @@ exports.deleteRoom = (roomId, callback) => {
     return;
   }
 
+  // delete all clients and their streams
+  room.forEachClient((client) => {
+    client.channel.disconnect();
+  });
+
+  // delete the remaining publishers (externalInputs)
   if (!room.p2p) {
-    room.forEachClient((client) => {
-      client.removeSubscriptions();
-    });
     room.streamManager.forEachPublishedStream((stream) => {
       if (stream.hasAudio() || stream.hasVideo() || stream.hasScreen()) {
         room.controller.removePublisher(stream.getID());
@@ -430,12 +433,7 @@ exports.deleteRoom = (roomId, callback) => {
     room.streamManager.publishedStreams.clear();
   }
 
-  room.forEachClient((client) => {
-    client.channel.disconnect();
-  });
-
   rooms.deleteRoom(roomId);
-
   updateMyState();
   callback('Success');
 };

--- a/erizo_controller/erizoJS/models/NodeManager.js
+++ b/erizo_controller/erizoJS/models/NodeManager.js
@@ -1,0 +1,45 @@
+// const logger = require('./../../common/logger').logger;
+
+// const log = logger.getLogger('NodeManager');
+
+class NodeManager {
+  constructor() {
+    // streamId: Publisher
+    this.publisherNodes = new Map();
+  }
+
+  addPublisherNode(streamId, publisherNode) {
+    this.publisherNodes.set(streamId, publisherNode);
+  }
+
+  removePublisherNode(id) {
+    return this.publisherNodes.delete(id);
+  }
+
+  forEachPublisherNode(doSomething) {
+    this.publisherNodes.forEach((publisherNode) => {
+      doSomething(publisherNode);
+    });
+  }
+
+  getPublisherNodeById(id) {
+    return this.publisherNodes.get(id);
+  }
+
+  getPublisherNodesByClientId(clientId) {
+    const nodes = this.publisherNodes.values();
+    const publisherNodes = Array.from(nodes).filter(node => node.clientId === clientId);
+    return publisherNodes;
+  }
+
+  hasPublisherNode(id) {
+    return this.publisherNodes.has(id);
+  }
+
+  getPublisherCount() {
+    return this.publisherNodes.size;
+  }
+}
+
+exports.NodeManager = NodeManager;
+

--- a/erizo_controller/erizoJS/models/PublisherManager.js
+++ b/erizo_controller/erizoJS/models/PublisherManager.js
@@ -1,38 +1,34 @@
-// const logger = require('./../../common/logger').logger;
-
-// const log = logger.getLogger('NodeManager');
-
-class NodeManager {
+class PublisherManager {
   constructor() {
     // streamId: Publisher
     this.publisherNodes = new Map();
   }
 
-  addPublisherNode(streamId, publisherNode) {
+  add(streamId, publisherNode) {
     this.publisherNodes.set(streamId, publisherNode);
   }
 
-  removePublisherNode(id) {
+  remove(id) {
     return this.publisherNodes.delete(id);
   }
 
-  forEachPublisherNode(doSomething) {
+  forEach(doSomething) {
     this.publisherNodes.forEach((publisherNode) => {
       doSomething(publisherNode);
     });
   }
 
-  getPublisherNodeById(id) {
+  getPublisherById(id) {
     return this.publisherNodes.get(id);
   }
 
-  getPublisherNodesByClientId(clientId) {
+  getPublishersByClientId(clientId) {
     const nodes = this.publisherNodes.values();
     const publisherNodes = Array.from(nodes).filter(node => node.clientId === clientId);
     return publisherNodes;
   }
 
-  hasPublisherNode(id) {
+  has(id) {
     return this.publisherNodes.has(id);
   }
 
@@ -41,5 +37,5 @@ class NodeManager {
   }
 }
 
-exports.NodeManager = NodeManager;
+exports.PublisherManager = PublisherManager;
 

--- a/erizo_controller/test/erizoController/Client.js
+++ b/erizo_controller/test/erizoController/Client.js
@@ -77,7 +77,6 @@ describe('Erizo Controller / Client', () => {
     expect(client.sendMessage).not.to.be.undefined;
     expect(client.on).not.to.be.undefined;
     expect(client.setNewChannel).not.to.be.undefined;
-    expect(client.removeSubscriptions).not.to.be.undefined;
     expect(client.disconnect).not.to.be.undefined;
   });
 

--- a/erizo_controller/test/erizoController/erizoController.js
+++ b/erizo_controller/test/erizoController/erizoController.js
@@ -1133,18 +1133,18 @@ describe('Erizo Controller / Erizo Controller', () => {
                       .to.equal(1);
                   });
 
-                  it('should call removePublisher', () => {
+                  it('should call removeClient', () => {
                     onDisconnect();
 
-                    expect(mocks.roomControllerInstance.removePublisher.callCount).to.equal(1);
+                    expect(mocks.roomControllerInstance.removeClient.callCount).to.equal(1);
                   });
 
-                  it('should not call removePublisher if room is p2p', () => {
+                  it('should not call removeClient if room is p2p', () => {
                     room.p2p = true;
 
                     onDisconnect();
 
-                    expect(mocks.roomControllerInstance.removePublisher.callCount).to.equal(0);
+                    expect(mocks.roomControllerInstance.removeClient.callCount).to.equal(0);
                   });
                 });
               });

--- a/erizo_controller/test/erizoJS/erizoJSController.js
+++ b/erizo_controller/test/erizoJS/erizoJSController.js
@@ -733,7 +733,7 @@ describe('Erizo JS Controller', () => {
         controller.removeClient(kArbitrarySubClientId, removeCallback);
         setTimeout(() => {
           expect(removeCallback.args[0]).to.deep.equal(['callback', true]);
-          expect(mocks.OneToManyProcessor.removeSubscriber).to.equal(1);
+          expect(mocks.OneToManyProcessor.removeSubscriber.callCount).to.equal(1);
         }, 0);
       });
 


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR changes the way `removeClient` works in erizoJS. 
Before, when a Client left, erizoController would issue the commands to erizoJS to remove all published streams and subscriptions from that particular Client and then it would request the removal of the client itself. This approach lent itself to a number of race conditions.
With this PR, erizoController will only have to request the removal of the Client and only remove locally the data structures associated with that client (published and subscribed streams). ErizoJS will now process this removeClient as a command to remove the subscriptions and the published streams in the same operation.

The new `NodeManager` makes it easier for erizoJS to find published streams owned by a Client.

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.