### PR TITLE
Fix some ICE connectivity issues

### DIFF
--- a/erizo/src/erizo/IceConnection.h
+++ b/erizo/src/erizo/IceConnection.h
@@ -50,6 +50,7 @@ class IceConfig {
     std::string stun_server, network_interface;
     uint16_t stun_port, turn_port, min_port, max_port;
     bool should_trickle;
+    std::string public_ip;
     IceConfig()
       : media_type{MediaType::OTHER},
         transport_name{""},

--- a/erizo/src/erizo/lib/NicerInterface.cpp
+++ b/erizo/src/erizo/lib/NicerInterface.cpp
@@ -49,6 +49,10 @@ void NicerInterfaceImpl::IceContextFinalize(nr_ice_ctx *ctx, nr_ice_peer_ctx *pc
   nr_ice_ctx_finalize(ctx, pctxp);
 }
 
+void NicerInterfaceImpl::IcePeerContextDumpState(nr_ice_peer_ctx *pctx, uint log_level) {
+  nr_ice_peer_ctx_dump_state(pctx, log_level);
+}
+
 int NicerInterfaceImpl::IceContextSetStunServers(nr_ice_ctx *ctx, nr_ice_stun_server *servers, int ct) {
   return nr_ice_ctx_set_stun_servers(ctx, servers, ct);
 }

--- a/erizo/src/erizo/lib/NicerInterface.h
+++ b/erizo/src/erizo/lib/NicerInterface.h
@@ -38,6 +38,7 @@ class NicerInterface {
   virtual int IceContextSetTrickleCallback(nr_ice_ctx *ctx, nr_ice_trickle_candidate_cb cb, void *cb_arg) = 0;
   virtual void IceContextSetSocketFactory(nr_ice_ctx *ctx, nr_socket_factory *factory) = 0;
   virtual void IceContextFinalize(nr_ice_ctx *ctx, nr_ice_peer_ctx *pctxp) = 0;
+  virtual void IcePeerContextDumpState(nr_ice_peer_ctx *pctx, uint log_level) = 0;
   virtual int IceContextSetStunServers(nr_ice_ctx *ctx, nr_ice_stun_server *servers, int ct) = 0;
   virtual int IceContextSetTurnServers(nr_ice_ctx *ctx, nr_ice_turn_server *servers, int ct) = 0;
   virtual void IceContextSetPortRange(nr_ice_ctx *ctx, uint16_t min_port, uint16_t max_port) = 0;
@@ -71,6 +72,7 @@ class NicerInterfaceImpl: public NicerInterface {
   int IceContextSetTrickleCallback(nr_ice_ctx *ctx, nr_ice_trickle_candidate_cb cb, void *cb_arg) override;
   void IceContextSetSocketFactory(nr_ice_ctx *ctx, nr_socket_factory *factory) override;
   void IceContextFinalize(nr_ice_ctx *ctx, nr_ice_peer_ctx *pctxp) override;
+  void IcePeerContextDumpState(nr_ice_peer_ctx *pctx, uint log_level) override;
   int IceContextSetStunServers(nr_ice_ctx *ctx, nr_ice_stun_server *servers, int ct) override;
   int IceContextSetTurnServers(nr_ice_ctx *ctx, nr_ice_turn_server *servers, int ct) override;
   void IceContextSetPortRange(nr_ice_ctx *ctx, uint16_t min_port, uint16_t max_port) override;

--- a/erizo/src/test/NicerConnectionTest.cpp
+++ b/erizo/src/test/NicerConnectionTest.cpp
@@ -40,6 +40,7 @@ class MockNicer: public erizo::NicerInterface {
   MOCK_METHOD3(IceContextSetTrickleCallback, int(nr_ice_ctx *, nr_ice_trickle_candidate_cb, void *));
   MOCK_METHOD2(IceContextSetSocketFactory, void(nr_ice_ctx *, nr_socket_factory *));
   MOCK_METHOD2(IceContextFinalize, void(nr_ice_ctx *, nr_ice_peer_ctx *));
+  MOCK_METHOD2(IcePeerContextDumpState, void(nr_ice_peer_ctx *, uint));
   MOCK_METHOD3(IceContextSetStunServers, int(nr_ice_ctx *, nr_ice_stun_server *, int));
   MOCK_METHOD3(IceContextSetTurnServers, int(nr_ice_ctx *, nr_ice_turn_server *, int));
   MOCK_METHOD3(IceContextSetPortRange, void(nr_ice_ctx *, uint16_t, uint16_t));

--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -226,7 +226,7 @@ NAN_METHOD(WebRtcConnection::New) {
     }
 
     erizo::IceConfig iceConfig;
-    if (info.Length() == 15) {
+    if (info.Length() == 16) {
       Nan::Utf8String param2(Nan::To<v8::String>(info[10]).ToLocalChecked());
       std::string turnServer = std::string(*param2);
       int turnPort = Nan::To<int>(info[11]).FromJust();
@@ -236,12 +236,15 @@ NAN_METHOD(WebRtcConnection::New) {
       std::string turnPass = std::string(*param4);
       Nan::Utf8String param5(Nan::To<v8::String>(info[14]).ToLocalChecked());
       std::string network_interface = std::string(*param5);
+      Nan::Utf8String param5(Nan::To<v8::String>(info[15]).ToLocalChecked());
+      std::string public_ip = std::string(*param5);
 
       iceConfig.turn_server = turnServer;
       iceConfig.turn_port = turnPort;
       iceConfig.turn_username = turnUsername;
       iceConfig.turn_pass = turnPass;
       iceConfig.network_interface = network_interface;
+      iceConfig.public_ip = public_ip;
     }
 
 

--- a/erizo_controller/common/semanticSdp/CandidateInfo.js
+++ b/erizo_controller/common/semanticSdp/CandidateInfo.js
@@ -21,16 +21,16 @@ class CandidateInfo {
   plain() {
     const plain = {
       foundation: this.foundation,
-      componentId: this.componentId,
+      component: this.componentId,
       transport: this.transport,
       priority: this.priority,
-      address: this.address,
+      ip: this.address,
       port: this.port,
       type: this.type,
       generation: this.generation,
     };
-    if (this.relAddr) plain.relAddr = this.relAddr;
-    if (this.relPort) plain.relPort = this.relPort;
+    if (this.relAddr) plain.raddr = this.relAddr;
+    if (this.relPort) plain.rport = this.relPort;
     return plain;
   }
 

--- a/erizo_controller/common/semanticSdp/SDPInfo.js
+++ b/erizo_controller/common/semanticSdp/SDPInfo.js
@@ -270,18 +270,7 @@ class SDPInfo {
 
       const candidates = media.getCandidates();
       candidates.forEach((candidate) => {
-        md.candidates.push({
-          foundation: candidate.getFoundation(),
-          component: candidate.getComponentId(),
-          transport: candidate.getTransport(),
-          priority: candidate.getPriority(),
-          ip: candidate.getAddress(),
-          port: candidate.getPort(),
-          type: candidate.getType(),
-          relAddr: candidate.getRelAddr(),
-          relPort: candidate.getRelPort(),
-          generation: candidate.getGeneration(),
-        });
+        md.candidates.push(candidate.plain());
       });
 
       ice = media.getICE();
@@ -749,8 +738,13 @@ SDPInfo.process = (sdp) => {
   let ufrag = sdp.iceUfrag;
   let pwd = sdp.icePwd;
   let iceOptions = sdp.iceOptions;
+  let iceLite = sdp.icelite === 'ice-lite';
   if (ufrag || pwd || iceOptions) {
-    sdpInfo.setICE(new ICEInfo(ufrag, pwd, iceOptions));
+    const iceInfo = new ICEInfo(ufrag, pwd, iceOptions);
+    if (iceLite) {
+      iceInfo.setLite(iceLite);
+    }
+    sdpInfo.setICE(iceInfo);
   }
 
   let fingerprintAttr = sdp.fingerprint;
@@ -785,8 +779,13 @@ SDPInfo.process = (sdp) => {
     ufrag = md.iceUfrag;
     pwd = md.icePwd;
     iceOptions = md.iceOptions;
+    iceLite = md.icelite === 'ice-lite';
+
     if (ufrag || pwd || iceOptions) {
       const thisIce = new ICEInfo(ufrag, pwd, iceOptions);
+      if (iceLite) {
+        thisIce.setLite(iceLite);
+      }
       if (md.endOfCandidates) {
         thisIce.setEndOfCandidates('end-of-candidates');
       }
@@ -822,7 +821,7 @@ SDPInfo.process = (sdp) => {
       candidates.forEach((candidate) => {
         mediaInfo.addCandidate(new CandidateInfo(candidate.foundation, candidate.component,
           candidate.transport, candidate.priority, candidate.ip, candidate.port, candidate.type,
-          candidate.generation, candidate.relAddr, candidate.relPort));
+          candidate.generation, candidate.raddr, candidate.rport));
       });
     }
 

--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -101,8 +101,8 @@ class Connection extends events.EventEmitter {
       global.config.erizo.turnusername,
       global.config.erizo.turnpass,
       global.config.erizo.networkinterface,
-      this.options.publicIP
-      );
+      this.options.publicIP,
+    );
 
     if (this.options) {
       const metadata = this.options.metadata || {};
@@ -177,7 +177,7 @@ class Connection extends events.EventEmitter {
       this.wrtc.localDescription = new SessionDescription(desc);
       const sdp = this.wrtc.localDescription.getSdp(this.sessionVersion);
       this.sessionVersion += 1;
-      let message = sdp.toString();
+      const message = sdp.toString();
       return message;
     });
   }

--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -100,7 +100,9 @@ class Connection extends events.EventEmitter {
       global.config.erizo.turnport,
       global.config.erizo.turnusername,
       global.config.erizo.turnpass,
-      global.config.erizo.networkinterface);
+      global.config.erizo.networkinterface,
+      this.options.publicIP
+      );
 
     if (this.options) {
       const metadata = this.options.metadata || {};
@@ -176,7 +178,6 @@ class Connection extends events.EventEmitter {
       const sdp = this.wrtc.localDescription.getSdp(this.sessionVersion);
       this.sessionVersion += 1;
       let message = sdp.toString();
-      message = message.replace(this.options.privateRegexp, this.options.publicIP);
       return message;
     });
   }
@@ -262,7 +263,6 @@ class Connection extends events.EventEmitter {
 
         case CONN_CANDIDATE:
           // eslint-disable-next-line no-param-reassign
-          mess = mess.replace(this.options.privateRegexp, this.options.publicIP);
           this._onStatusEvent({ type: 'candidate', candidate: mess }, newStatus);
           break;
 

--- a/erizo_controller/package-lock.json
+++ b/erizo_controller/package-lock.json
@@ -746,9 +746,9 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "sdp-transform": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.3.1.tgz",
-      "integrity": "sha512-ACHsqRKLiuWDgTs/T/29WNDiaOGHhnCZOsRbLVvCHuM47P6AEYrLIJHViRGf9F4Nt8uCLjCOUEepMQn9wepiYQ=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.14.0.tgz",
+      "integrity": "sha512-8ZYOau/o9PzRhY0aMuRzvmiM6/YVQR8yjnBScvZHSdBnywK5oZzAJK+412ZKkDq29naBmR3bRw8MFu0C01Gehg=="
     },
     "semver": {
       "version": "5.7.1",

--- a/erizo_controller/package.json
+++ b/erizo_controller/package.json
@@ -13,7 +13,7 @@
     "log4js": "~1.0.1",
     "node-getopt": "~0.3.2",
     "prom-client": "~11.2.1",
-    "sdp-transform": "~2.3.0",
+    "sdp-transform": "~2.14.0",
     "socket.io": "~2.0.3",
     "uuid": "~3.1.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6408,6 +6408,11 @@
         "raw-loader": "~0.5.1"
       }
     },
+    "sdp-transform": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.14.0.tgz",
+      "integrity": "sha512-8ZYOau/o9PzRhY0aMuRzvmiM6/YVQR8yjnBScvZHSdBnywK5oZzAJK+412ZKkDq29naBmR3bRw8MFu0C01Gehg=="
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -55,5 +55,7 @@
     "lintErizoAPI": "./erizo/utils/cpplint.py --filter=-legal/copyright,-build/include --linelength=120 ./erizoAPI/*.cc *.h",
     "buildErizoAPI": "export ERIZO_HOME=$(pwd)/erizo/ && echo $ERIZO_HOME && cd ./erizoAPI/ && env JOBS=4 ./build.sh"
   },
-  "dependencies": {}
+  "dependencies": {
+    "sdp-transform": "^2.14.0"
+  }
 }


### PR DESCRIPTION
**Description**

I've been investigating some issues that led to having different ICE states between browser and Erizo in some cases. Some of the issues were solved here, while others need to be fixed in nICEr (I'm also preparing a PR there).

The major issue was that Erizo considered all Host candidates as failed because they were using their private IP network, even if we define a Public IP one. For those cases, we now automatically add the Public IP as the Host candidates' address when it is set in the config file.

As part of this work, I've been experimenting a bit with ICE-LITE. I haven't completed it yet because it is low priority, as Firefox does not seem to support ICE-LITE MCUs. The good news is that I've solved some issues that I found during the process.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.