### PR TITLE
Add stats about the delay added to running tasks in Workers

### DIFF
--- a/erizo/src/erizo/thread/ThreadPool.cpp
+++ b/erizo/src/erizo/thread/ThreadPool.cpp
@@ -56,6 +56,14 @@ DurationDistribution ThreadPool::getDurationDistribution() {
   return total_durations;
 }
 
+DurationDistribution ThreadPool::getDelayDistribution() {
+  DurationDistribution total_delays;
+  for (auto worker : workers_) {
+    total_delays += worker->getDelayDistribution();
+  }
+  return total_delays;
+}
+
 void ThreadPool::resetStats() {
   for (auto worker : workers_) {
     worker->resetStats();

--- a/erizo/src/erizo/thread/ThreadPool.h
+++ b/erizo/src/erizo/thread/ThreadPool.h
@@ -20,6 +20,7 @@ class ThreadPool {
 
   void resetStats();
   DurationDistribution getDurationDistribution();
+  DurationDistribution getDelayDistribution();
 
  private:
   std::vector<std::shared_ptr<Worker>> workers_;

--- a/erizo/src/erizo/thread/Worker.h
+++ b/erizo/src/erizo/thread/Worker.h
@@ -65,11 +65,13 @@ class Worker : public std::enable_shared_from_this<Worker> {
 
   void resetStats();
   DurationDistribution getDurationDistribution() { return durations_; }
+  DurationDistribution getDelayDistribution() { return delays_; }
 
  private:
   void scheduleEvery(ScheduledTask f, duration period, duration next_delay);
   std::function<void()> safeTask(std::function<void(std::shared_ptr<Worker>)> f);
-  void addToStats(duration task_duration);
+  void addToDurationStats(duration task_duration);
+  void addToDelayStats(duration task_delay);
 
  protected:
   int next_scheduled_ = 0;
@@ -83,6 +85,7 @@ class Worker : public std::enable_shared_from_this<Worker> {
   std::atomic<bool> closed_;
   boost::thread::id thread_id_;
   DurationDistribution durations_;
+  DurationDistribution delays_;
 };
 
 class SimulatedWorker : public Worker {

--- a/erizoAPI/ThreadPool.cc
+++ b/erizoAPI/ThreadPool.cc
@@ -31,6 +31,7 @@ NAN_MODULE_INIT(ThreadPool::Init) {
   Nan::SetPrototypeMethod(tpl, "close", close);
   Nan::SetPrototypeMethod(tpl, "start", start);
   Nan::SetPrototypeMethod(tpl, "getDurationDistribution", getDurationDistribution);
+  Nan::SetPrototypeMethod(tpl, "getDelayDistribution", getDelayDistribution);
   Nan::SetPrototypeMethod(tpl, "resetStats", resetStats);
 
   constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
@@ -66,6 +67,19 @@ NAN_METHOD(ThreadPool::start) {
 NAN_METHOD(ThreadPool::getDurationDistribution) {
   ThreadPool* obj = Nan::ObjectWrap::Unwrap<ThreadPool>(info.Holder());
   DurationDistribution duration_distribution = obj->me->getDurationDistribution();
+  v8::Local<v8::Array> array = Nan::New<v8::Array>(5);
+  Nan::Set(array, 0, Nan::New(duration_distribution.duration_0_10_ms));
+  Nan::Set(array, 1, Nan::New(duration_distribution.duration_10_50_ms));
+  Nan::Set(array, 2, Nan::New(duration_distribution.duration_50_100_ms));
+  Nan::Set(array, 3, Nan::New(duration_distribution.duration_100_1000_ms));
+  Nan::Set(array, 4, Nan::New(duration_distribution.duration_1000_ms));
+
+  info.GetReturnValue().Set(array);
+}
+
+NAN_METHOD(ThreadPool::getDelayDistribution) {
+  ThreadPool* obj = Nan::ObjectWrap::Unwrap<ThreadPool>(info.Holder());
+  DurationDistribution duration_distribution = obj->me->getDelayDistribution();
   v8::Local<v8::Array> array = Nan::New<v8::Array>(5);
   Nan::Set(array, 0, Nan::New(duration_distribution.duration_0_10_ms));
   Nan::Set(array, 1, Nan::New(duration_distribution.duration_10_50_ms));

--- a/erizoAPI/ThreadPool.h
+++ b/erizoAPI/ThreadPool.h
@@ -36,6 +36,7 @@ class ThreadPool : public Nan::ObjectWrap {
     static NAN_METHOD(start);
 
     static NAN_METHOD(getDurationDistribution);
+    static NAN_METHOD(getDelayDistribution);
     static NAN_METHOD(resetStats);
 
     static Nan::Persistent<v8::Function> constructor;

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -686,6 +686,7 @@ exports.ErizoJSController = (erizoJSId, threadPool, ioThreadPool) => {
     metrics.subscribers = subscribers;
 
     metrics.durationDistribution = threadPool.getDurationDistribution();
+    metrics.delayDistribution = threadPool.getDelayDistribution();
     threadPool.resetStats();
 
     clients.forEach((client) => {


### PR DESCRIPTION
**Description**
We wanted to add even more information about the tasks that are being run within Erizo's Workers. I also added more data about the time it takes for these tasks to be completed.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.