### PR TITLE
Two minor fixes in metrics and tests

### DIFF
--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -675,13 +675,7 @@ exports.ErizoJSController = (erizoJSId, threadPool, ioThreadPool) => {
   };
 
   const sumArrays = (array1, array2) => {
-    if (array1.length === 0) {
-      return array2;
-    }
-    if (array1.length === array2.length) {
-      return array1.map((a, i) => a + array2[i]);
-    }
-    return array1;
+    return array2.map((a, i) => a + array1[i]);
   };
 
   that.getAndResetMetrics = () => {
@@ -689,8 +683,8 @@ exports.ErizoJSController = (erizoJSId, threadPool, ioThreadPool) => {
     metrics.totalConnections = 0;
     metrics.connectionLevels = Array(10).fill(0);
     metrics.publishers = publisherManager.getPublisherCount();
-    metrics.streamDelayDistribution = [];
-    metrics.streamDurationDistribution = [];
+    metrics.streamDelayDistribution = Array(10).fill(0);
+    metrics.streamDurationDistribution = Array(10).fill(0);
     let subscribers = 0;
     publisherManager.forEach((publisher) => {
       subscribers += publisher.numSubscribers;
@@ -713,8 +707,8 @@ exports.ErizoJSController = (erizoJSId, threadPool, ioThreadPool) => {
     });
     metrics.subscribers = subscribers;
 
-    metrics.connectionDelayDistribution = [];
-    metrics.connectionDurationDistribution = [];
+    metrics.connectionDelayDistribution = Array(10).fill(0);
+    metrics.connectionDurationDistribution = Array(10).fill(0);
     metrics.durationDistribution = threadPool.getDurationDistribution();
     metrics.delayDistribution = threadPool.getDelayDistribution();
     threadPool.resetStats();
@@ -738,6 +732,7 @@ exports.ErizoJSController = (erizoJSId, threadPool, ioThreadPool) => {
       });
     });
     initMetrics();
+    console.log(metrics);
     return metrics;
   };
 

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -732,7 +732,6 @@ exports.ErizoJSController = (erizoJSId, threadPool, ioThreadPool) => {
       });
     });
     initMetrics();
-    console.log(metrics);
     return metrics;
   };
 

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -674,9 +674,7 @@ exports.ErizoJSController = (erizoJSId, threadPool, ioThreadPool) => {
     }
   };
 
-  const sumArrays = (array1, array2) => {
-    return array2.map((a, i) => a + array1[i]);
-  };
+  const sumArrays = (array1, array2) => array2.map((a, i) => a + array1[i]);
 
   that.getAndResetMetrics = () => {
     const metrics = Object.assign({}, that.metrics);

--- a/erizo_controller/test/erizoJS/erizoJSController.js
+++ b/erizo_controller/test/erizoJS/erizoJSController.js
@@ -222,6 +222,7 @@ describe('Erizo JS Controller', () => {
     beforeEach(() => {
       callback = sinon.stub();
       mocks.WebRtcConnection.setRemoteDescription.returns(Promise.resolve());
+      mocks.WebRtcConnection.close.returns(Promise.resolve());
       global.config.erizo = {};
       global.config.erizoController = { report: {
         connection_events: true,


### PR DESCRIPTION
**Description**

This is a small PR to implement two small fixes:
- We were not populating Prometheus metrics about promises when there were no connections/streams.
- We were having some warnings when running tests.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.