### PR TITLE
Https by default in Licode and BasicExample

### DIFF
--- a/doc/docker.md
+++ b/doc/docker.md
@@ -11,10 +11,13 @@ Both options require that you have [docker](https://docs.docker.com/installation
 
 The easiest way to run licode is to use the [image we provide](https://hub.docker.com/r/lynckia/licode/) in Docker Hub. In this case you have only to execute the run command. But now the image name is lynckia/licode:*version* where `version` is the release you want to use:
 
-	PUBLIC_IP=<YOUR_ACTUAL_IP> MIN_PORT=30000; MAX_PORT=30050; sudo docker run --name licode -p  3000:3000 -p $MIN_PORT-$MAX_PORT:$MIN_PORT-$MAX_PORT/udp -p 3001:3001  -p 8080:8080 -e "MIN_PORT=$MIN_PORT" -e "MAX_PORT=$MAX_PORT" -e "PUBLIC_IP=$PUBLIC_IP" -e "NETWORK_INTERFACE=eth0" lynckia/licode
+	PUBLIC_IP=<YOUR_ACTUAL_IP> MIN_PORT=30000; MAX_PORT=30050; sudo docker run --name licode -p 3000:3000 -p $MIN_PORT-$MAX_PORT:$MIN_PORT-$MAX_PORT/udp -p 3004:3004 -p 8080:8080 -e "MIN_PORT=$MIN_PORT" -e "MAX_PORT=$MAX_PORT" -e "PUBLIC_IP=$PUBLIC_IP" -e "NETWORK_INTERFACE=eth0" lynckia/licode
 
 > **Note**
 > If you do not specify a version you are pulling from `latest` by default.
+
+> **Note**
+> Remember validate the certificate for _https://YOUR_ACTUAL_IP:3004_ and _https://YOUR_ACTUAL_IP:8080_
 
 > **Note**
 > If you do not want to have to use `sudo` in this or in the next section follow [these instructions](https://docs.docker.com/installation/ubuntulinux/#create-a-docker-group).
@@ -60,5 +63,7 @@ This builds a new Docker image following the steps in `Dockerfile` and saves it 
 
 Now you can run a new container from the image you have just created with:
 ```
-	PUBLIC_IP=<YOUR_ACTUAL_IP> MIN_PORT=30000; MAX_PORT=30050; sudo docker run --name licode -p  3000:3000 -p $MIN_PORT-$MAX_PORT:$MIN_PORT-$MAX_PORT/udp -p 3001:3001  -p 8080:8080 -e "MIN_PORT=$MIN_PORT" -e "MAX_PORT=$MAX_PORT" -e "PUBLIC_IP=$PUBLIC_IP" licode-image
+	PUBLIC_IP=<YOUR_ACTUAL_IP> MIN_PORT=30000; MAX_PORT=30050; sudo docker run --name licode -p 3000:3000 -p $MIN_PORT-$MAX_PORT:$MIN_PORT-$MAX_PORT/udp -p 3004:3004 -p 8080:8080 -e "MIN_PORT=$MIN_PORT" -e "MAX_PORT=$MAX_PORT" -e "PUBLIC_IP=$PUBLIC_IP" licode-image
 ```
+> **Note**
+> Remember validate the certificate for _https://YOUR_ACTUAL_IP:3004_ and _https://YOUR_ACTUAL_IP:8080_

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -17,7 +17,7 @@ The easiest way to run licode is to use the [image we provide](https://hub.docke
 > If you do not specify a version you are pulling from `latest` by default.
 
 > **Note**
-> Remember validate the certificate for _https://YOUR_ACTUAL_IP:3004_ and _https://YOUR_ACTUAL_IP:8080_
+> Remember to validate the certificate for _https://YOUR_ACTUAL_IP:3004_ and _https://YOUR_ACTUAL_IP:8080_
 
 > **Note**
 > If you do not want to have to use `sudo` in this or in the next section follow [these instructions](https://docs.docker.com/installation/ubuntulinux/#create-a-docker-group).
@@ -66,4 +66,4 @@ Now you can run a new container from the image you have just created with:
 	PUBLIC_IP=<YOUR_ACTUAL_IP> MIN_PORT=30000; MAX_PORT=30050; sudo docker run --name licode -p 3000:3000 -p $MIN_PORT-$MAX_PORT:$MIN_PORT-$MAX_PORT/udp -p 3004:3004 -p 8080:8080 -e "MIN_PORT=$MIN_PORT" -e "MAX_PORT=$MAX_PORT" -e "PUBLIC_IP=$PUBLIC_IP" licode-image
 ```
 > **Note**
-> Remember validate the certificate for _https://YOUR_ACTUAL_IP:3004_ and _https://YOUR_ACTUAL_IP:8080_
+> Remember to validate the certificate for _https://YOUR_ACTUAL_IP:3004_ and _https://YOUR_ACTUAL_IP:8080_

--- a/doc/from_source.md
+++ b/doc/from_source.md
@@ -53,7 +53,8 @@ After that, we just have to start our node application, we also have a script fo
 ```
 ./scripts/initBasicExample.sh
 ```
-** Now you can connect to _http://localhost:3001_ with Chrome or Firefox and test your basic videoconference example! **
+** Now you can connect to _https://localhost:3004_ with Chrome or Firefox and test your basic videoconference example! **
+** Remember validate the certificate for _https://localhost:3004_ and _https://localhost:8080_
 
 # What's next?
 

--- a/doc/from_source.md
+++ b/doc/from_source.md
@@ -54,7 +54,7 @@ After that, we just have to start our node application, we also have a script fo
 ./scripts/initBasicExample.sh
 ```
 ** Now you can connect to _https://localhost:3004_ with Chrome or Firefox and test your basic videoconference example! **
-** Remember validate the certificate for _https://localhost:3004_ and _https://localhost:8080_
+** Remember to validate the certificate for _https://localhost:3004_ and _https://localhost:8080_ **
 
 # What's next?
 

--- a/extras/basic_example/basicServer.js
+++ b/extras/basic_example/basicServer.js
@@ -236,6 +236,5 @@ cleanExampleRooms(() => {
     const server = https.createServer(options, app);
     server.listen(tlsPort);
     log.info(`BasicExample started and listenting on port ${tlsPort}`);
-
   });
 });

--- a/extras/basic_example/basicServer.js
+++ b/extras/basic_example/basicServer.js
@@ -234,7 +234,8 @@ cleanExampleRooms(() => {
 
     app.listen(port);
     const server = https.createServer(options, app);
-    log.info(`BasicExample started and listenting on port ${port}`);
     server.listen(tlsPort);
+    log.info(`BasicExample started and listenting on port ${tlsPort}`);
+
   });
 });

--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -66,11 +66,11 @@ config.erizoController.networkinterface = ''; //default value: ''
 config.erizoController.hostname = ''; //default value: ''
 config.erizoController.port = 8080; //default value: 8080
 // Use true if clients communicate with erizoController over SSL
-config.erizoController.ssl = false; //default value: false
+config.erizoController.ssl = true; //default value: true
 
 // This configuration is used by erizoController server to listen for connections
 // Use true if erizoController listens in HTTPS.
-config.erizoController.listen_ssl = false; //default value: false
+config.erizoController.listen_ssl = true; //default value: true
 config.erizoController.listen_port = 8080; //default value: 8080
 
 // Custom location for SSL certificates. Default located in /cert


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

Changes the default configuration to https to avoid problems with the browsers.

Since browsers require https to access the camera and microphone. It is mandatory to change the default configuration of Licode in order to test it. 

https://blog.mozilla.org/webrtc/camera-microphone-require-https-in-firefox-68/
https://www.chromestatus.com/feature/5703419427815424
https://www.digicert.com/blog/https-only-features-in-browsers/
https://caniuse.com/mdn-api_mediadevices_getusermedia_secure_context_required

[x] It includes documentation for these changes in `/doc`.