### PR TITLE
update ssl and port for docker in erizo

### DIFF
--- a/extras/docker/initDockerLicode.sh
+++ b/extras/docker/initDockerLicode.sh
@@ -189,6 +189,9 @@ if [ "$ERIZOAGENT" == "true" ]; then
   if [[ ! -z "$ERIZOCONTROLLER_SSL" ]]; then
     sed -i "s/config\.erizoController\.ssl = .*/config\.erizoController\.ssl = $ERIZOCONTROLLER_SSL;/" /opt/licode/licode_config.js
   fi
+  if [[ ! -z "$ERIZOCONTROLLER_HOSTNAME" ]]; then
+    sed -i "s/config\.erizoController\.hostname = .*/config\.erizoController\.hostname = $ERIZOCONTROLLER_HOSTNAME;/" /opt/licode/licode_config.js
+  fi
   run_erizoAgent
 fi
 

--- a/extras/docker/initDockerLicode.sh
+++ b/extras/docker/initDockerLicode.sh
@@ -183,6 +183,12 @@ if [ "$ERIZOAGENT" == "true" ]; then
   if [[ ! -z "$NETWORK_INTERFACE" ]]; then
     echo "config.erizo.networkinterface = '$NETWORK_INTERFACE';" >> /opt/licode/licode_config.js
   fi
+  if [[ ! -z "$ERIZOCONTROLLER_PORT" ]]; then
+    sed -i "s/config\.erizoController\.port = .*/config\.erizoController\.port = $ERIZOCONTROLLER_PORT;/" /opt/licode/licode_config.js
+  fi
+  if [[ ! -z "$ERIZOCONTROLLER_SSL" ]]; then
+    sed -i "s/config\.erizoController\.ssl = .*/config\.erizoController\.ssl = $ERIZOCONTROLLER_SSL;/" /opt/licode/licode_config.js
+  fi
   run_erizoAgent
 fi
 


### PR DESCRIPTION
Hello,

Apologies. I am new to docker, licode and this is my first patch thinking this will work for everyone. Hoping for the best :) .

[] It needs and includes Unit Tests

When playing with docker, the websocket was always using the IP addresss and port 8080 without ssl . So licode didnot worked on real server. In local system things may be different.

So currently added env value which will be replaced.

[] It includes documentation for these changes in `/doc`.

No