### PR TITLE
Fix a typo when calling to logger API

### DIFF
--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -640,7 +640,7 @@ class Client extends events.EventEmitter {
               || !stream.hasAvSubscriber(this.id)) {
             log.warn(`message: addSubscriber of removed subscriber, messageType: ${signMess.type},` +
               `clientId: ${this.id}, streamId: ${options.streamId},`,
-            logger.objetToLog(this.token));
+            logger.objectToLog(this.token));
             return;
           }
           if (signMess.type === 'initializing') {


### PR DESCRIPTION
**Description**

Fixes a typo when calling the logger API.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.