### PR TITLE
Enable basic features by default in basic example

### DIFF
--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -30,11 +30,13 @@ const getParameterByName = (name) => {
   name = name.replace(/[\[]/, '\\\[').replace(/[\]]/, '\\\]');
   const regex = new RegExp(`[\\?&]${name}=([^&#]*)`);
   const results = regex.exec(location.search);
-  let parsedResult = results == null ? configFlags[name] : decodeURIComponent(results[1].replace(/\+/g, ' '));
-  if (typeof configFlags[name] === 'boolean') {
-    parsedResult = !!parseInt(parsedResult, 0);
+  let parameter = configFlags[name];
+  if (results != null &&
+      typeof configFlags[name] === 'boolean') {
+    parameter = decodeURIComponent(results[1].replace(/\+/g, ' '));
+    parameter = !!parseInt(parameter, 0);
   }
-  return parsedResult;
+  return parameter;
 };
 
 const fillInConfigFlagsFromParameters = (config) => {

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -31,7 +31,7 @@ const getParameterByName = (name) => {
   const regex = new RegExp(`[\\?&]${name}=([^&#]*)`);
   const results = regex.exec(location.search);
   let parameter = configFlags[name];
-  if (results != null &&
+  if (results !== null &&
       typeof configFlags[name] === 'boolean') {
     parameter = decodeURIComponent(results[1].replace(/\+/g, ' '));
     parameter = !!parseInt(parameter, 0);

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -31,10 +31,11 @@ const getParameterByName = (name) => {
   const regex = new RegExp(`[\\?&]${name}=([^&#]*)`);
   const results = regex.exec(location.search);
   let parameter = configFlags[name];
-  if (results !== null &&
-      typeof configFlags[name] === 'boolean') {
+  if (results !== null) {
     parameter = decodeURIComponent(results[1].replace(/\+/g, ' '));
-    parameter = !!parseInt(parameter, 0);
+    if (typeof configFlags[name] === 'boolean') {
+      parameter = !!parseInt(parameter, 0);
+    }
   }
   return parameter;
 };

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -31,8 +31,8 @@ const getParameterByName = (name) => {
   const regex = new RegExp(`[\\?&]${name}=([^&#]*)`);
   const results = regex.exec(location.search);
   let parsedResult = results == null ? configFlags[name] : decodeURIComponent(results[1].replace(/\+/g, ' '));
-  if (typeof configFlags[name] === "boolean") {
-    parsedResult = !!parseInt(parsedResult);
+  if (typeof configFlags[name] === 'boolean') {
+    parsedResult = !!parseInt(parsedResult, 0);
   }
   return parsedResult;
 };

--- a/extras/basic_example/public/script.js
+++ b/extras/basic_example/public/script.js
@@ -14,15 +14,15 @@ const configFlags = {
   forceStart: false, // force start button in all cases
   screen: false, // screensharinug
   room: 'basicExampleRoom', // room name
-  singlePC: false,
+  singlePC: true,
   type: 'erizo', // room type
   onlyAudio: false,
   mediaConfiguration: 'default',
   onlySubscribe: false,
   onlyPublish: false,
   autoSubscribe: false,
-  offerFromErizo: false,
-  simulcast: false,
+  offerFromErizo: true,
+  simulcast: true,
 };
 
 const getParameterByName = (name) => {
@@ -30,7 +30,11 @@ const getParameterByName = (name) => {
   name = name.replace(/[\[]/, '\\\[').replace(/[\]]/, '\\\]');
   const regex = new RegExp(`[\\?&]${name}=([^&#]*)`);
   const results = regex.exec(location.search);
-  return results == null ? false : decodeURIComponent(results[1].replace(/\+/g, ' '));
+  let parsedResult = results == null ? configFlags[name] : decodeURIComponent(results[1].replace(/\+/g, ' '));
+  if (typeof configFlags[name] === "boolean") {
+    parsedResult = !!parseInt(parsedResult);
+  }
+  return parsedResult;
 };
 
 const fillInConfigFlagsFromParameters = (config) => {

--- a/scripts/initLicode.sh
+++ b/scripts/initLicode.sh
@@ -13,6 +13,7 @@ export PATH=$PATH:/usr/local/sbin
 if ! pgrep -f rabbitmq; then
   sudo echo
   sudo rabbitmq-server > $BUILD_DIR/rabbit.log &
+  sleep 5
 fi
 
 cd $ROOT/nuve


### PR DESCRIPTION
**Description**

This PR enables Simulcast, Single Peer Connection, and Offers From Erizo by default when using the basic example. They can be disabled manually with the corresponding URL queries set to 0. For example, if we want to disable Simulcast we would use this URL: `https://<licode_url>/?simulcast=0`.

I'm also adding some delay after starting RabbitMQ because it was failing to me almost 100% of the time.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.