### PR TITLE
Fix addStream not triggering createOffer

### DIFF
--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -75,12 +75,14 @@ const BaseStack = (specInput) => {
   that.peerConnection.onnegotiationneeded = () => { // one per media which is added
     that.tracksToBeNegotiated -= 1;
 
-    if (that.tracksToBeNegotiated <= 0) { // We also fire the offer in case of a mismatch
+    if (that.tracksToBeNegotiated === 0) {
       logSDP('onnegotiationneeded - createOffer');
       const promise = that.peerConnectionFsm.createOffer(false);
       if (promise) {
         promise.catch(onFsmError.bind(this));
       }
+    } else if (that.tracksToBeNegotiated < 0) {
+      log.warning(`message: Negative tracks to be negotiated in connection, ${that.tracksToBeNegotiated}`);
     }
   };
 

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -49,6 +49,7 @@ const BaseStack = (specInput) => {
   if (specBase.forceTurn === true) {
     that.pcConfig.iceTransportPolicy = 'relay';
   }
+  that.tracksToBeNegotiated = 0;
   that.audio = specBase.audio;
   that.video = specBase.video;
   if (that.audio === undefined) {
@@ -71,18 +72,16 @@ const BaseStack = (specInput) => {
   };
 
   that.peerConnection = new RTCPeerConnection(that.pcConfig, that.con);
-  let negotiationneededCount = 0;
   that.peerConnection.onnegotiationneeded = () => { // one per media which is added
-    let medias = that.audio ? 1 : 0;
-    medias += that.video ? 1 : 0;
-    if (negotiationneededCount % medias === 0) {
+    that.tracksToBeNegotiated -= 1;
+
+    if (that.tracksToBeNegotiated <= 0) { // We also fire the offer in case of a mismatch
       logSDP('onnegotiationneeded - createOffer');
       const promise = that.peerConnectionFsm.createOffer(false);
       if (promise) {
         promise.catch(onFsmError.bind(this));
       }
     }
-    negotiationneededCount += 1;
   };
 
   const configureLocalSdpAsAnswer = () => {
@@ -231,6 +230,7 @@ const BaseStack = (specInput) => {
 
       addStream: negotiationQueue.protectFunction((stream) => {
         logSDP('queue - addStream');
+        that.tracksToBeNegotiated += stream.getTracks().length;
         negotiationQueue.startEnqueuing('addStream');
         const promise = that.peerConnectionFsm.addStream(stream);
         if (promise) {
@@ -242,6 +242,7 @@ const BaseStack = (specInput) => {
       }),
 
       removeStream: negotiationQueue.protectFunction((stream) => {
+        that.tracksToBeNegotiated += stream.getTracks().length;
         logSDP('queue - removeStream');
         negotiationQueue.startEnqueuing('removeStream');
         const promise = that.peerConnectionFsm.removeStream(stream);


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

When adding or removing multiple streams, the connection level video and audio flags are not valid when trying to decide if we should trigger a new offer.
This PR takes into account the amount of video and audio tracks that have been modified to trigger `createOffer`.
[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.