### PR TITLE
Fixed installation in Ubuntu 20

### DIFF
--- a/erizo_controller/initErizo_agent.sh
+++ b/erizo_controller/initErizo_agent.sh
@@ -10,6 +10,8 @@ NVM_CHECK="$LICODE_ROOT"/scripts/checkNvm.sh
 
 . $NVM_CHECK
 
+sudo ldconfig $LICODE_ROOT/build/libdeps/build/lib
+
 cd $ROOT/erizoAgent
 nvm use
 node erizoAgent.js $* &

--- a/erizo_controller/initErizo_agent.sh
+++ b/erizo_controller/initErizo_agent.sh
@@ -8,9 +8,9 @@ LICODE_ROOT="$ROOT"/..
 CURRENT_DIR=`pwd`
 NVM_CHECK="$LICODE_ROOT"/scripts/checkNvm.sh
 
-. $NVM_CHECK
+export LD_LIBRARY_PATH="$LICODE_ROOT/build/libdeps/build/lib"
 
-sudo ldconfig $LICODE_ROOT/build/libdeps/build/lib
+. $NVM_CHECK
 
 cd $ROOT/erizoAgent
 nvm use


### PR DESCRIPTION
**Fixed init script for Ubuntu 20.04**

<!--
Add a short description here, please.
If the contribution needs and includes Unit Tests check the box below.
-->
Fixed a problem in Ubuntu 20.04 where it didn't find libraries in folder /build/libdeps/build/lib
[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->
No changes

[] It includes documentation for these changes in `/doc`.