### PR TITLE
Fix a crash in depacketizer that happened when we reset it

### DIFF
--- a/erizo/src/erizo/media/Depacketizer.cpp
+++ b/erizo/src/erizo/media/Depacketizer.cpp
@@ -139,6 +139,7 @@ bool H264Depacketizer::processPacket() {
     case single: {
       if (search_state_ == SearchState::lookingForEnd) {
         reset();
+        return false;
       }
       if (last_payload_->dataLength == 0) {
         return false;


### PR DESCRIPTION
after calling reset last_payload_ is null_ptr, so it is crashing.


**Description**

<!--
Add a short description here, please.
If the contribution needs and includes Unit Tests check the box below.
-->


**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.