### PR TITLE
use avcodec_free_context instead avcodec_close

### DIFF
--- a/erizo/src/erizo/media/ExternalOutput.cpp
+++ b/erizo/src/erizo/media/ExternalOutput.cpp
@@ -112,13 +112,15 @@ void ExternalOutput::syncClose() {
       av_write_trailer(context_);
   }
 
-  if (video_stream_ && video_stream_->codec != nullptr) {
-      avcodec_close(video_stream_->codec);
-  }
+  //call avformat_free_context will close codec ,free video_stream_, codec
 
-  if (audio_stream_ && audio_stream_->codec != nullptr) {
-      avcodec_close(audio_stream_->codec);
-  }
+  // if (video_stream_ && video_stream_->codec != nullptr) {
+  //     avcodec_close(video_stream_->codec);
+  // }
+
+  // if (audio_stream_ && audio_stream_->codec != nullptr) {
+  //     avcodec_close(audio_stream_->codec);
+  // }
 
   if (context_ != nullptr) {
       avio_close(context_->pb);
@@ -411,9 +413,9 @@ bool ExternalOutput::initContext() {
     if (context_->oformat->flags & AVFMT_GLOBALHEADER) {
       audio_stream_->codec->flags |= CODEC_FLAG_GLOBAL_HEADER;
     }
-
-    context_->streams[0] = video_stream_;
-    context_->streams[1] = audio_stream_;
+    // call avformat_new_stream  will insert stream into streams
+    // context_->streams[0] = video_stream_;
+    // context_->streams[1] = audio_stream_;
     if (avio_open(&context_->pb, context_->filename, AVIO_FLAG_WRITE) < 0) {
       ELOG_ERROR("Error opening output file");
       return false;

--- a/erizo/src/erizo/media/codecs/AudioCodec.cpp
+++ b/erizo/src/erizo/media/codecs/AudioCodec.cpp
@@ -113,7 +113,7 @@ int AudioEncoder::encodeAudio(unsigned char* inBuffer, int nSamples, AVPacket* p
 
 int AudioEncoder::closeEncoder() {
   if (aCoderContext_ != NULL) {
-    avcodec_close(aCoderContext_);
+    avcodec_free_context(&aCoderContext_);
   }
   if (aFrame_ != NULL) {
     av_frame_free(&aFrame_);
@@ -246,7 +246,7 @@ int AudioDecoder::decodeAudio(unsigned char* inBuff, int inBuffLen,
 
 int AudioDecoder::closeDecoder() {
   if (aDecoderContext_ != NULL) {
-    avcodec_close(aDecoderContext_);
+    avcodec_free_context(&aDecoderContext_);
   }
   if (dFrame_ != NULL) {
     av_frame_free(&dFrame_);

--- a/erizo/src/erizo/media/codecs/VideoCodec.cpp
+++ b/erizo/src/erizo/media/codecs/VideoCodec.cpp
@@ -195,7 +195,7 @@ int VideoEncoder::encodeVideo(unsigned char* inBuffer, int inLength, unsigned ch
 
 int VideoEncoder::closeEncoder() {
   if (coder_context_ != NULL)
-    avcodec_close(coder_context_);
+    avcodec_free_context(&coder_context_);
   if (cPicture != NULL)
     av_frame_free(&cPicture);
 
@@ -361,7 +361,7 @@ decoding:
 
 int VideoDecoder::closeDecoder() {
   if (!initWithContext_ && vDecoderContext != NULL)
-    avcodec_close(vDecoderContext);
+    avcodec_free_context(&vDecoderContext);
   if (dPicture != NULL)
     av_frame_free(&dPicture);
   return 0;


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

*int avcodec_close ( AVCodecContext * avctx )*
---

Close a given AVCodecContext and free all the data associated with it (but not the AVCodecContext itself).
Calling this function on an AVCodecContext that hasn't been opened will free the codec-specific data allocated in avcodec_alloc_context3() with a non-NULL codec. Subsequent calls will do nothing.

Note
Do not use this function. Use avcodec_free_context() to destroy a codec context (either open or closed). Opening and closing a codec context multiple times is not supported anymore – use multiple codec contexts instead.