### PR TITLE
Fix Firefox onnnegotiation needed

### DIFF
--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -275,7 +275,6 @@ const BaseStack = (specInput) => {
   that.protectedCalls = {
     protectedAddStream: (stream) => {
       try {
-        console.warn('Protected addStream', stream);
         that.peerConnection.addStream(stream);
       } catch (e) {
         setTimeout(() => {

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -232,7 +232,7 @@ const BaseStack = (specInput) => {
 
       addStream: negotiationQueue.protectFunction((stream) => {
         logSDP('queue - addStream');
-        that.tracksToBeNegotiated += stream.getTracks().length;
+        that._gatherTracksToBeNegotiatedFromStream(stream);
         negotiationQueue.startEnqueuing('addStream');
         const promise = that.peerConnectionFsm.addStream(stream);
         if (promise) {
@@ -244,7 +244,7 @@ const BaseStack = (specInput) => {
       }),
 
       removeStream: negotiationQueue.protectFunction((stream) => {
-        that.tracksToBeNegotiated += stream.getTracks().length;
+        that._gatherTracksToBeNegotiatedFromStream(stream);
         logSDP('queue - removeStream');
         negotiationQueue.startEnqueuing('removeStream');
         const promise = that.peerConnectionFsm.removeStream(stream);
@@ -275,6 +275,7 @@ const BaseStack = (specInput) => {
   that.protectedCalls = {
     protectedAddStream: (stream) => {
       try {
+        console.warn('Protected addStream', stream);
         that.peerConnection.addStream(stream);
       } catch (e) {
         setTimeout(() => {
@@ -545,6 +546,11 @@ const BaseStack = (specInput) => {
 
   // Peerconnection events
   that.peerConnection.onicecandidate = onIceCandidate;
+
+  // private functions
+  that._gatherTracksToBeNegotiatedFromStream = (stream) => {
+    that.tracksToBeNegotiated += stream.getTracks().length;
+  };
   // public functions
 
   that.setStartVideoBW = (sdpInput) => {

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -232,7 +232,7 @@ const BaseStack = (specInput) => {
 
       addStream: negotiationQueue.protectFunction((stream) => {
         logSDP('queue - addStream');
-        that._gatherTracksToBeNegotiatedFromStream(stream);
+        that._updateTracksToBeNegotiatedFromStream(stream);
         negotiationQueue.startEnqueuing('addStream');
         const promise = that.peerConnectionFsm.addStream(stream);
         if (promise) {
@@ -244,7 +244,7 @@ const BaseStack = (specInput) => {
       }),
 
       removeStream: negotiationQueue.protectFunction((stream) => {
-        that._gatherTracksToBeNegotiatedFromStream(stream);
+        that._updateTracksToBeNegotiatedFromStream(stream);
         logSDP('queue - removeStream');
         negotiationQueue.startEnqueuing('removeStream');
         const promise = that.peerConnectionFsm.removeStream(stream);
@@ -548,7 +548,7 @@ const BaseStack = (specInput) => {
   that.peerConnection.onicecandidate = onIceCandidate;
 
   // private functions
-  that._gatherTracksToBeNegotiatedFromStream = (stream) => {
+  that._updateTracksToBeNegotiatedFromStream = (stream) => {
     that.tracksToBeNegotiated += stream.getTracks().length;
   };
   // public functions

--- a/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
@@ -50,6 +50,11 @@ const FirefoxStack = (specInput) => {
     return Promise.all(promises);
   };
 
+  // private functions
+  that._gatherTracksToBeNegotiatedFromStream = () => {
+    that.tracksToBeNegotiated += 1;
+  };
+
   return that;
 };
 

--- a/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/FirefoxStack.js
@@ -51,7 +51,7 @@ const FirefoxStack = (specInput) => {
   };
 
   // private functions
-  that._gatherTracksToBeNegotiatedFromStream = () => {
+  that._updateTracksToBeNegotiatedFromStream = () => {
     that.tracksToBeNegotiated += 1;
   };
 


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR fixes an issue caused by Firefox behaving differently than Chrome when issuing `onnegotiationneeded`. Chrome calls it once per track in the stream while Firefox seems to call it only once per stream. This was causing issues in all Firefox connections.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.