### PR TITLE
Update Nuve MongoDB client

### DIFF
--- a/nuve/nuveAPI/mdb/dataBase.js
+++ b/nuve/nuveAPI/mdb/dataBase.js
@@ -1,13 +1,14 @@
 /* global require, exports */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-const mongojs = require('mongojs');
+const { MongoClient, ObjectId } = require('mongodb');
 
 // eslint-disable-next-line import/no-unresolved
 const config = require('./../../../licode_config');
 
 config.nuve = config.nuve || {};
-config.nuve.dataBaseURL = config.nuve.dataBaseURL || 'localhost/nuvedb';
+config.nuve.dataBaseURL = config.nuve.dataBaseURL || 'mongodb://localhost/nuvedb';
+config.nuve.dataBaseName = config.nuve.dataBaseName || 'nuvedb';
 config.nuve.superserviceID = config.nuve.superserviceID || '';
 config.nuve.superserviceKey = config.nuve.superserviceKey || '';
 config.nuve.testErizoController = config.nuve.testErizoController || 'localhost:8080';
@@ -35,9 +36,20 @@ const databaseUrl = config.nuve.dataBaseURL;
  *  };
  *
  */
-const collections = ['rooms', 'tokens', 'services', 'erizoControllers'];
+// Create a new MongoClient
+exports.client = new MongoClient(databaseUrl, { useUnifiedTopology: true });
 
-exports.db = mongojs(databaseUrl, collections);
+// Use connect method to connect to the Server
+exports.client.connect((err) => {
+  if (err) {
+    // eslint-disable-next-line no-console
+    console.log('Error connecting to MongoDB server', databaseUrl, err);
+    return;
+  }
+  exports.db = exports.client.db(config.nuve.dataBaseName);
+});
+
+exports.ObjectId = ObjectId;
 
 // Superservice ID
 exports.superService = config.nuve.superserviceID;

--- a/nuve/nuveAPI/mdb/erizoControllerRegistry.js
+++ b/nuve/nuveAPI/mdb/erizoControllerRegistry.js
@@ -1,7 +1,6 @@
 /* global require, exports */
 
-
-const db = require('./dataBase').db;
+const dataBase = require('./dataBase');
 
 const logger = require('./../logger').logger;
 
@@ -9,7 +8,7 @@ const logger = require('./../logger').logger;
 const log = logger.getLogger('ErizoControllerRegistry');
 
 exports.getErizoControllers = (callback) => {
-  db.erizoControllers.find({}).toArray((err, erizoControllers) => {
+  dataBase.db.collection('erizoControllers').find({}).toArray((err, erizoControllers) => {
     if (err || !erizoControllers) {
       log.info('message: service getList empty');
     } else {
@@ -19,7 +18,7 @@ exports.getErizoControllers = (callback) => {
 };
 
 const getErizoController = (id, callback) => {
-  db.erizoControllers.findOne({ _id: db.ObjectId(id) }, (err, erizoController) => {
+  dataBase.db.collection('erizoControllers').findOne({ _id: dataBase.ObjectId(id) }, (err, erizoController) => {
     if (erizoController === undefined) {
       log.warn(`message: getErizoController - ErizoController not found, Id: ${id}`);
     }
@@ -46,9 +45,9 @@ exports.hasErizoController = hasErizoController;
  * Adds a new ErizoController to the data base.
  */
 exports.addErizoController = (erizoController, callback) => {
-  db.erizoControllers.save(erizoController, (error, saved) => {
+  dataBase.db.collection('erizoControllers').insertOne(erizoController, (error, saved) => {
     if (error) log.warn(`message: addErizoController error, ${logger.objectToLog(error)}`);
-    callback(saved);
+    callback(saved.ops[0]);
   });
 };
 
@@ -57,13 +56,13 @@ exports.addErizoController = (erizoController, callback) => {
  * Updates a determined ErizoController
  */
 exports.updateErizoController = (id, erizoController) => {
-  db.erizoControllers.update({ _id: db.ObjectId(id) }, { $set: erizoController }, (error) => {
+  dataBase.db.collection('erizoControllers').updateOne({ _id: dataBase.ObjectId(id) }, { $set: erizoController }, (error) => {
     if (error) log.warn(`message: updateErizoController error, ${logger.objectToLog(error)}`);
   });
 };
 
 exports.incrementKeepAlive = (id) => {
-  db.erizoControllers.update({ _id: db.ObjectId(id) }, { $inc: { keepAlive: 1 } }, (error) => {
+  dataBase.db.collection('erizoControllers').updateOne({ _id: dataBase.ObjectId(id) }, { $inc: { keepAlive: 1 } }, (error) => {
     if (error) log.warn(`message: updateErizoController error, ${logger.objectToLog(error)}`);
   });
 };
@@ -74,10 +73,9 @@ exports.incrementKeepAlive = (id) => {
 exports.removeErizoController = (id) => {
   hasErizoController(id, (hasEC) => {
     if (hasEC) {
-      db.erizoControllers.remove({ _id: db.ObjectId(id) }, (error) => {
+      dataBase.db.collection('erizoControllers').deleteOne({ _id: dataBase.ObjectId(id) }, (error) => {
         if (error) {
-          log.warn('message: removeErizoController error, ',
-            `${logger.objectToLog(error)}`);
+          log.warn('message: removeErizoController error, ', logger.objectToLog(error));
         }
       });
     }

--- a/nuve/nuveAPI/mdb/serviceRegistry.js
+++ b/nuve/nuveAPI/mdb/serviceRegistry.js
@@ -1,6 +1,6 @@
 /* global require, exports */
 
-const db = require('./dataBase').db;
+const dataBase = require('./dataBase');
 const logger = require('./../logger').logger;
 
 // Logger
@@ -10,7 +10,7 @@ const log = logger.getLogger('ServiceRegistry');
  * Gets a list of the services in the data base.
  */
 exports.getList = (callback) => {
-  db.services.find({}).toArray((err, services) => {
+  dataBase.db.collection('services').find({}).toArray((err, services) => {
     if (err || !services) {
       log.info('message: service getList empty');
     } else {
@@ -20,7 +20,7 @@ exports.getList = (callback) => {
 };
 
 const getService = (id, callback) => {
-  db.services.findOne({ _id: db.ObjectId(id) }, (err, service) => {
+  dataBase.db.collection('services').findOne({ _id: dataBase.ObjectId(id) }, (err, service) => {
     if (service === undefined) {
       log.info(`message: getService service not found, serviceId ${id}`);
     }
@@ -50,9 +50,9 @@ exports.hasService = hasService;
 exports.addService = (service, callback) => {
   // eslint-disable-next-line no-param-reassign
   service.rooms = [];
-  db.services.save(service, (error, saved) => {
+  dataBase.db.collection('services').insertOne(service, (error, saved) => {
     if (error) log.info(`message: addService error, ${logger.objectToLog(error)}`);
-    callback(saved._id);
+    callback(saved.insertedId);
   });
 };
 
@@ -60,7 +60,7 @@ exports.addService = (service, callback) => {
  * Updates a service in the data base.
  */
 exports.updateService = (service, callback) => {
-  db.services.save(service, (error) => {
+  dataBase.db.collection('services').replaceOne({ _id: dataBase.ObjectId(service._id) }, service, (error) => {
     if (error) log.info(`message: updateService error, ${logger.objectToLog(error)}`);
     if (callback) callback();
   });
@@ -70,7 +70,7 @@ exports.updateService = (service, callback) => {
  * Updates a service in the data base with a new room.
  */
 exports.addRoomToService = (service, room, callback) => {
-  db.services.update({ _id: db.ObjectId(service._id) }, { $addToSet: { rooms: room } },
+  dataBase.db.collection('services').updateOne({ _id: dataBase.ObjectId(service._id) }, { $addToSet: { rooms: room } },
     (error) => {
       if (error) log.info(`message: updateService error, ${logger.objectToLog(error)}`);
       if (callback) callback();
@@ -83,7 +83,7 @@ exports.addRoomToService = (service, room, callback) => {
 exports.removeService = (id) => {
   hasService(id, (hasS) => {
     if (hasS) {
-      db.services.remove({ _id: db.ObjectId(id) }, (error) => {
+      dataBase.db.collection('services').deleteOne({ _id: dataBase.ObjectId(id) }, (error) => {
         if (error) log.info(`message: removeService error, ${logger.objectToLog(error)}`);
       });
     }

--- a/nuve/nuveAPI/mdb/tokenRegistry.js
+++ b/nuve/nuveAPI/mdb/tokenRegistry.js
@@ -3,7 +3,7 @@
 /* eslint-disable no-param-reassign */
 
 
-const db = require('./dataBase').db;
+const dataBase = require('./dataBase');
 
 const logger = require('./../logger').logger;
 
@@ -14,7 +14,7 @@ const log = logger.getLogger('TokenRegistry');
  * Gets a list of the tokens in the data base.
  */
 exports.getList = (callback) => {
-  db.tokens.find({}).toArray((err, tokens) => {
+  dataBase.db.collection('tokens').find({}).toArray((err, tokens) => {
     if (err || !tokens) {
       log.info('message: token getList empty');
     } else {
@@ -24,7 +24,7 @@ exports.getList = (callback) => {
 };
 
 const getToken = (id, callback) => {
-  db.tokens.findOne({ _id: db.ObjectId(id) }, (err, token) => {
+  dataBase.db.collection('tokens').findOne({ _id: dataBase.ObjectId(id) }, (err, token) => {
     if (token == null) {
       token = undefined;
       log.info(`message: getToken token not found, tokenId: ${id}`);
@@ -53,12 +53,12 @@ exports.hasToken = hasToken;
  * Adds a new token to the data base.
  */
 exports.addToken = (token, callback) => {
-  db.tokens.save(token, (error, saved) => {
+  dataBase.db.collection('tokens').insertOne(token, (error, saved) => {
     if (error) {
       log.warn('message: addToken error,', logger.objectToLog(error));
       return callback(null, true);
     }
-    return callback(saved._id, false);
+    return callback(saved.insertedId, false);
   });
 };
 
@@ -68,7 +68,7 @@ exports.addToken = (token, callback) => {
 const removeToken = (id, callback) => {
   hasToken(id, (hasT) => {
     if (hasT) {
-      db.tokens.remove({ _id: db.ObjectId(id) }, (error) => {
+      dataBase.db.collection('tokens').deleteOne({ _id: dataBase.ObjectId(id) }, (error) => {
         if (error) {
           log.warn('message: removeToken error,', logger.objectToLog(error));
         }
@@ -84,7 +84,7 @@ exports.removeToken = removeToken;
  * Updates a determined token in the data base.
  */
 exports.updateToken = (token) => {
-  db.tokens.save(token, (error) => {
+  dataBase.db.collection('tokens').replaceOne({ _id: dataBase.ObjectId(token._id) }, token, (error) => {
     if (error) log.warn('message: updateToken error,', logger.objectToLog(error));
   });
 };
@@ -94,7 +94,7 @@ exports.removeOldTokens = () => {
   let tokenTime;
   let dif;
 
-  db.tokens.find({ use: { $exists: false } }).toArray((err, tokens) => {
+  dataBase.db.collection('tokens').find({ use: { $exists: false } }).toArray((err, tokens) => {
     if (err || !tokens) {
       log.warn('message: error removingOldTokens or no tokens present');
     } else {

--- a/nuve/nuveAPI/test/mdb/dataBase.js
+++ b/nuve/nuveAPI/test/mdb/dataBase.js
@@ -11,8 +11,8 @@ describe('DataBase', () => {
     db = require('../../mdb/dataBase');
   });
 
-  it('should contain a db', () => {
-    expect(db).to.have.property('db');
+  it('should contain a client', () => {
+    expect(db).to.have.property('client');
   });
 
   it('should contain a superService', () => {

--- a/nuve/nuveAPI/test/mdb/erizoControllerRegistry.js
+++ b/nuve/nuveAPI/test/mdb/erizoControllerRegistry.js
@@ -28,7 +28,7 @@ describe('ErizoController Registry', () => {
   });
 
   it('should return a list of erizoControllers when getErizoControllers is called', () => {
-    dataBase.db.erizoControllers.find.returns({
+    dataBase.db.collection('erizoControllers').find.returns({
       toArray(cb) {
         cb(null, [kArbitraryErizoController]);
       },
@@ -41,7 +41,7 @@ describe('ErizoController Registry', () => {
 
   it('should return undefined if not found in the db when getEC is called', () => {
     const callback = sinon.stub();
-    dataBase.db.erizoControllers.findOne.callsArgWith(1, null, undefined);
+    dataBase.db.collection('erizoControllers').findOne.callsArgWith(1, null, undefined);
     erizoControllerRegistry.getErizoController(kArbitraryErizoControllerId, callback);
 
     // eslint-disable-next-line no-unused-expressions
@@ -50,7 +50,7 @@ describe('ErizoController Registry', () => {
 
   it('should return a erizoController from the db when getEC is called', () => {
     const callback = sinon.stub();
-    dataBase.db.erizoControllers.findOne.callsArgWith(1, null, kArbitraryErizoController);
+    dataBase.db.collection('erizoControllers').findOne.callsArgWith(1, null, kArbitraryErizoController);
     erizoControllerRegistry.getErizoController(kArbitraryErizoControllerId, callback);
 
     // eslint-disable-next-line no-unused-expressions
@@ -59,7 +59,7 @@ describe('ErizoController Registry', () => {
 
   it('should return false if the EC is not found in db when hasEC is called', () => {
     const callback = sinon.stub();
-    dataBase.db.erizoControllers.findOne.callsArgWith(1, null, undefined);
+    dataBase.db.collection('erizoControllers').findOne.callsArgWith(1, null, undefined);
     erizoControllerRegistry.hasErizoController(kArbitraryErizoControllerId, callback);
 
     // eslint-disable-next-line no-unused-expressions
@@ -68,45 +68,45 @@ describe('ErizoController Registry', () => {
 
   it('should return true if the erizoController is found in db when hasEC is called', () => {
     const callback = sinon.stub();
-    dataBase.db.erizoControllers.findOne.callsArgWith(1, null, kArbitraryErizoController);
+    dataBase.db.collection('erizoControllers').findOne.callsArgWith(1, null, kArbitraryErizoController);
     erizoControllerRegistry.hasErizoController(kArbitraryErizoControllerId, callback);
 
     // eslint-disable-next-line no-unused-expressions
     expect(callback.calledWith(true)).to.be.true;
   });
 
-  it('should call save on Database when calling addErizoController', () => {
+  it('should call insertOne on Database when calling addErizoController', () => {
     const callback = sinon.stub();
-    dataBase.db.erizoControllers.save.callsArgWith(1, null, kArbitraryErizoController);
+    dataBase.db.collection('erizoControllers').insertOne.callsArgWith(1, null, { ops: [kArbitraryErizoController] });
     erizoControllerRegistry.addErizoController(kArbitraryErizoController, callback);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(dataBase.db.erizoControllers.save.calledOnce).to.be.true;
+    expect(dataBase.db.collection('erizoControllers').insertOne.calledOnce).to.be.true;
     // eslint-disable-next-line no-unused-expressions
     expect(callback.calledWith(kArbitraryErizoController)).to.be.true;
   });
 
-  it('should call update on Database when calling updateEC', () => {
+  it('should call updateOne on Database when calling updateEC', () => {
     erizoControllerRegistry.updateErizoController(kArbitraryErizoControllerId,
       kArbitraryErizoController);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(dataBase.db.erizoControllers.update.calledOnce).to.be.true;
+    expect(dataBase.db.collection('erizoControllers').updateOne.calledOnce).to.be.true;
   });
 
-  it('should call remove on Database when removeEC is called and it exists', () => {
-    dataBase.db.erizoControllers.findOne.callsArgWith(1, null, undefined);
+  it('should call deleteOne on Database when removeEC is called and it exists', () => {
+    dataBase.db.collection('erizoControllers').findOne.callsArgWith(1, null, undefined);
     erizoControllerRegistry.removeErizoController(kArbitraryErizoControllerId);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(dataBase.db.erizoControllers.remove.called).to.be.false;
+    expect(dataBase.db.collection('erizoControllers').deleteOne.called).to.be.false;
   });
 
   it('should return true if the EC is found in the db when hasEC is called', () => {
-    dataBase.db.erizoControllers.findOne.callsArgWith(1, null, kArbitraryErizoController);
+    dataBase.db.collection('erizoControllers').findOne.callsArgWith(1, null, kArbitraryErizoController);
     erizoControllerRegistry.removeErizoController(kArbitraryErizoControllerId);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(dataBase.db.erizoControllers.remove.called).to.be.true;
+    expect(dataBase.db.collection('erizoControllers').deleteOne.called).to.be.true;
   });
 });

--- a/nuve/nuveAPI/test/mdb/roomRegistry.js
+++ b/nuve/nuveAPI/test/mdb/roomRegistry.js
@@ -28,7 +28,7 @@ describe('Room Registry', () => {
   });
 
   it('should return a list of rooms when getRooms is called', () => {
-    dataBase.db.rooms.find.returns({
+    dataBase.db.collection('rooms').find.returns({
       toArray(cb) {
         cb(null, [kArbitraryRoom]);
       },
@@ -42,7 +42,7 @@ describe('Room Registry', () => {
 
   it('should return undefined if not found in the database when getRoom is called', () => {
     const callback = sinon.stub();
-    dataBase.db.rooms.findOne.callsArgWith(1, null, undefined);
+    dataBase.db.collection('rooms').findOne.callsArgWith(1, null, undefined);
     roomRegistry.getRoom(kArbitraryRoomId, callback);
 
     // eslint-disable-next-line no-unused-expressions
@@ -51,7 +51,7 @@ describe('Room Registry', () => {
 
   it('should return a room from the database when getRoom is called', () => {
     const callback = sinon.stub();
-    dataBase.db.rooms.findOne.callsArgWith(1, null, kArbitraryRoom);
+    dataBase.db.collection('rooms').findOne.callsArgWith(1, null, kArbitraryRoom);
     roomRegistry.getRoom(kArbitraryRoomId, callback);
 
     // eslint-disable-next-line no-unused-expressions
@@ -60,7 +60,7 @@ describe('Room Registry', () => {
 
   it('should return false if the room is not found in database when hasRoom is called', () => {
     const callback = sinon.stub();
-    dataBase.db.rooms.findOne.callsArgWith(1, null, undefined);
+    dataBase.db.collection('rooms').findOne.callsArgWith(1, null, undefined);
     roomRegistry.hasRoom(kArbitraryRoomId, callback);
 
     // eslint-disable-next-line no-unused-expressions
@@ -69,44 +69,44 @@ describe('Room Registry', () => {
 
   it('should return true if the room is found in database when hasRoom is called', () => {
     const callback = sinon.stub();
-    dataBase.db.rooms.findOne.callsArgWith(1, null, kArbitraryRoom);
+    dataBase.db.collection('rooms').findOne.callsArgWith(1, null, kArbitraryRoom);
     roomRegistry.hasRoom(kArbitraryRoomId, callback);
 
     // eslint-disable-next-line no-unused-expressions
     expect(callback.calledWith(true)).to.be.true;
   });
 
-  it('should call save on Database when calling addRoom', () => {
+  it('should call insertOne on Database when calling addRoom', () => {
     const callback = sinon.stub();
-    dataBase.db.rooms.save.callsArgWith(1, null, kArbitraryRoom);
+    dataBase.db.collection('rooms').insertOne.callsArgWith(1, null, { ops: [kArbitraryRoom] });
     roomRegistry.addRoom(kArbitraryRoom, callback);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(dataBase.db.rooms.save.calledOnce).to.be.true;
+    expect(dataBase.db.collection('rooms').insertOne.calledOnce).to.be.true;
     // eslint-disable-next-line no-unused-expressions
     expect(callback.calledWith(kArbitraryRoom)).to.be.true;
   });
 
-  it('should call update on Database when calling updateRoom', () => {
+  it('should call updateOne on Database when calling updateRoom', () => {
     roomRegistry.updateRoom(kArbitraryRoomId, kArbitraryRoom);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(dataBase.db.rooms.update.calledOnce).to.be.true;
+    expect(dataBase.db.collection('rooms').replaceOne.calledOnce).to.be.true;
   });
 
-  it('should call remove on Database when removeRoom is called and it exists', () => {
-    dataBase.db.rooms.findOne.callsArgWith(1, null, undefined);
+  it('should call deleteOne on Database when removeRoom is called and it exists', () => {
+    dataBase.db.collection('rooms').findOne.callsArgWith(1, null, undefined);
     roomRegistry.removeRoom(kArbitraryRoomId);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(dataBase.db.rooms.remove.called).to.be.false;
+    expect(dataBase.db.collection('rooms').deleteOne.called).to.be.false;
   });
 
   it('should return true if the room is found in the database when hasRoom is called', () => {
-    dataBase.db.rooms.findOne.callsArgWith(1, null, kArbitraryRoom);
+    dataBase.db.collection('rooms').findOne.callsArgWith(1, null, kArbitraryRoom);
     roomRegistry.removeRoom(kArbitraryRoomId);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(dataBase.db.rooms.remove.called).to.be.true;
+    expect(dataBase.db.collection('rooms').deleteOne.called).to.be.true;
   });
 });

--- a/nuve/nuveAPI/test/mdb/serviceRegistry.js
+++ b/nuve/nuveAPI/test/mdb/serviceRegistry.js
@@ -29,7 +29,7 @@ describe('Service Registry', () => {
   });
 
   it('should return a list of services when getList is called', () => {
-    dataBase.db.services.find.returns({
+    dataBase.db.collection('services').find.returns({
       toArray(cb) {
         cb(null, [kArbitraryService]);
       },
@@ -43,7 +43,7 @@ describe('Service Registry', () => {
 
   it('should return undefined if not found in the database when getService is called', () => {
     const callback = sinon.stub();
-    dataBase.db.services.findOne.callsArgWith(1, null, undefined);
+    dataBase.db.collection('services').findOne.callsArgWith(1, null, undefined);
     serviceRegistry.getService(kArbitraryServiceId, callback);
 
     // eslint-disable-next-line no-unused-expressions
@@ -52,7 +52,7 @@ describe('Service Registry', () => {
 
   it('should return a service from the database when getService is called', () => {
     const callback = sinon.stub();
-    dataBase.db.services.findOne.callsArgWith(1, null, kArbitraryService);
+    dataBase.db.collection('services').findOne.callsArgWith(1, null, kArbitraryService);
     serviceRegistry.getService(kArbitraryServiceId, callback);
 
     // eslint-disable-next-line no-unused-expressions
@@ -61,7 +61,7 @@ describe('Service Registry', () => {
 
   it('should return false if the service is not found when hasService is called', () => {
     const callback = sinon.stub();
-    dataBase.db.services.findOne.callsArgWith(1, null, undefined);
+    dataBase.db.collection('services').findOne.callsArgWith(1, null, undefined);
     serviceRegistry.hasService(kArbitraryServiceId, callback);
 
     // eslint-disable-next-line no-unused-expressions
@@ -70,52 +70,52 @@ describe('Service Registry', () => {
 
   it('should return true if the service is found when hasService is called', () => {
     const callback = sinon.stub();
-    dataBase.db.services.findOne.callsArgWith(1, null, kArbitraryService);
+    dataBase.db.collection('services').findOne.callsArgWith(1, null, kArbitraryService);
     serviceRegistry.hasService(kArbitraryServiceId, callback);
 
     // eslint-disable-next-line no-unused-expressions
     expect(callback.calledWith(true)).to.be.true;
   });
 
-  it('should call save on Database when calling addService', () => {
+  it('should call insertOne on Database when calling addService', () => {
     const callback = sinon.stub();
-    dataBase.db.services.save.callsArgWith(1, null, { _id: kArbitraryServiceId });
+    dataBase.db.collection('services').insertOne.callsArgWith(1, null, { insertedId: kArbitraryServiceId });
     serviceRegistry.addService(kArbitraryService, callback);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(dataBase.db.services.save.calledOnce).to.be.true;
+    expect(dataBase.db.collection('services').insertOne.calledOnce).to.be.true;
     // eslint-disable-next-line no-unused-expressions
     expect(callback.calledWith(kArbitraryServiceId)).to.be.true;
   });
 
-  it('should call update on Database when calling updateService', () => {
+  it('should call replaceOne on Database when calling updateService', () => {
     serviceRegistry.updateService(kArbitraryService);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(dataBase.db.services.save.calledOnce).to.be.true;
+    expect(dataBase.db.collection('services').replaceOne.calledOnce).to.be.true;
   });
 
-  it('should call update on Database when calling addRoomToService', () => {
+  it('should call updateOne on Database when calling addRoomToService', () => {
     serviceRegistry.addRoomToService(kArbitraryService, kArbitraryRoom);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(dataBase.db.services.update.calledOnce).to.be.true;
+    expect(dataBase.db.collection('services').updateOne.calledOnce).to.be.true;
   });
 
-  it('should call remove on Database when removeService is called and it exists', () => {
-    dataBase.db.services.findOne.callsArgWith(1, null, undefined);
+  it('should call deleteOne on Database when removeService is called and it exists', () => {
+    dataBase.db.collection('services').findOne.callsArgWith(1, null, undefined);
     serviceRegistry.removeService(kArbitraryServiceId);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(dataBase.db.services.remove.called).to.be.false;
+    expect(dataBase.db.collection('services').deleteOne.called).to.be.false;
   });
 
   it('should return true if the service is found when hasService is called', () => {
-    dataBase.db.services.findOne.callsArgWith(1, null, kArbitraryService);
+    dataBase.db.collection('services').findOne.callsArgWith(1, null, kArbitraryService);
     serviceRegistry.removeService(kArbitraryServiceId);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(dataBase.db.services.remove.called).to.be.true;
+    expect(dataBase.db.collection('services').deleteOne.called).to.be.true;
   });
 
   const service = {

--- a/nuve/nuveAPI/test/mdb/tokenRegistry.js
+++ b/nuve/nuveAPI/test/mdb/tokenRegistry.js
@@ -28,7 +28,7 @@ describe('Token Registry', () => {
   });
 
   it('should return a list of tokens when getList is called', () => {
-    dataBase.db.tokens.find.returns({
+    dataBase.db.collection('tokens').find.returns({
       toArray(cb) {
         cb(null, [kArbitraryToken]);
       },
@@ -42,7 +42,7 @@ describe('Token Registry', () => {
 
   it('should return undefined if not found in the database when getToken is called', () => {
     const callback = sinon.stub();
-    dataBase.db.tokens.findOne.callsArgWith(1, null, undefined);
+    dataBase.db.collection('tokens').findOne.callsArgWith(1, null, undefined);
     tokenRegistry.getToken(kArbitraryTokenId, callback);
 
     // eslint-disable-next-line no-unused-expressions
@@ -51,7 +51,7 @@ describe('Token Registry', () => {
 
   it('should return a token from the database when getToken is called', () => {
     const callback = sinon.stub();
-    dataBase.db.tokens.findOne.callsArgWith(1, null, kArbitraryToken);
+    dataBase.db.collection('tokens').findOne.callsArgWith(1, null, kArbitraryToken);
     tokenRegistry.getToken(kArbitraryTokenId, callback);
 
     // eslint-disable-next-line no-unused-expressions
@@ -60,7 +60,7 @@ describe('Token Registry', () => {
 
   it('should return false if the token is not found when hasToken is called', () => {
     const callback = sinon.stub();
-    dataBase.db.tokens.findOne.callsArgWith(1, null, undefined);
+    dataBase.db.collection('tokens').findOne.callsArgWith(1, null, undefined);
     tokenRegistry.hasToken(kArbitraryTokenId, callback);
 
     // eslint-disable-next-line no-unused-expressions
@@ -69,51 +69,51 @@ describe('Token Registry', () => {
 
   it('should return true if the token is found in database when hasToken is called', () => {
     const callback = sinon.stub();
-    dataBase.db.tokens.findOne.callsArgWith(1, null, kArbitraryToken);
+    dataBase.db.collection('tokens').findOne.callsArgWith(1, null, kArbitraryToken);
     tokenRegistry.hasToken(kArbitraryTokenId, callback);
 
     // eslint-disable-next-line no-unused-expressions
     expect(callback.calledWith(true)).to.be.true;
   });
 
-  it('should call save on Database when calling addToken', () => {
+  it('should call insertOne on Database when calling addToken', () => {
     const callback = sinon.stub();
-    dataBase.db.tokens.save.callsArgWith(1, null, { _id: kArbitraryTokenId });
+    dataBase.db.collection('tokens').insertOne.callsArgWith(1, null, { insertedId: kArbitraryTokenId });
     tokenRegistry.addToken(kArbitraryToken, callback);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(dataBase.db.tokens.save.calledOnce).to.be.true;
+    expect(dataBase.db.collection('tokens').insertOne.calledOnce).to.be.true;
     // eslint-disable-next-line no-unused-expressions
     expect(callback.calledWith(kArbitraryTokenId)).to.be.true;
   });
 
-  it('should call update on Database when calling updateToken', () => {
+  it('should call replaceOne on Database when calling updateToken', () => {
     tokenRegistry.updateToken(kArbitraryToken);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(dataBase.db.tokens.save.calledOnce).to.be.true;
+    expect(dataBase.db.collection('tokens').replaceOne.calledOnce).to.be.true;
   });
 
-  it('should not call remove on Database when removeToken is called ' +
+  it('should not call deleteOne on Database when removeToken is called ' +
      'and it does not exist', () => {
-    dataBase.db.tokens.findOne.callsArgWith(1, null, undefined);
+    dataBase.db.collection('tokens').findOne.callsArgWith(1, null, undefined);
     tokenRegistry.removeToken(kArbitraryTokenId);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(dataBase.db.tokens.remove.called).to.be.false;
+    expect(dataBase.db.collection('tokens').deleteOne.called).to.be.false;
   });
 
   it('should return true if the token is found when removeToken is called', () => {
-    dataBase.db.tokens.findOne.callsArgWith(1, null, kArbitraryToken);
+    dataBase.db.collection('tokens').findOne.callsArgWith(1, null, kArbitraryToken);
     tokenRegistry.removeToken(kArbitraryTokenId);
 
     // eslint-disable-next-line no-unused-expressions
-    expect(dataBase.db.tokens.remove.called).to.be.true;
+    expect(dataBase.db.collection('tokens').deleteOne.called).to.be.true;
   });
 
   it('should remove a list of tokens when removeOldTokens is called', () => {
-    dataBase.db.tokens.findOne.callsArgWith(1, null, kArbitraryToken);
-    dataBase.db.tokens.find.returns({
+    dataBase.db.collection('tokens').findOne.callsArgWith(1, null, kArbitraryToken);
+    dataBase.db.collection('tokens').find.returns({
       toArray(cb) {
         cb(null, [kArbitraryToken]);
       },
@@ -121,6 +121,6 @@ describe('Token Registry', () => {
     tokenRegistry.removeOldTokens();
 
     // eslint-disable-next-line no-unused-expressions
-    expect(dataBase.db.tokens.remove.calledOnce).to.be.true;
+    expect(dataBase.db.collection('tokens').deleteOne.calledOnce).to.be.true;
   });
 });

--- a/nuve/nuveAPI/test/utils.js
+++ b/nuve/nuveAPI/test/utils.js
@@ -32,9 +32,18 @@ const dbEntry = () => {
   return {
     find: sinon.stub(),
     findOne: sinon.stub(),
-    save: sinon.stub(),
-    update: sinon.stub(),
-    remove: sinon.stub(),
+    insertOne: sinon.stub(),
+    replaceOne: sinon.stub(),
+    updateOne: sinon.stub(),
+    deleteOne: sinon.stub(),
+  };
+};
+
+// eslint-disable-next-line
+const dbSession = () => {
+  return {
+    endSession: sinon.stub(),
+    withTransaction: sinon.stub(),
   };
 };
 
@@ -92,12 +101,12 @@ const reset = () => {
     superService: 'superService',
     nuveKey: 'nuveKey',
     testErizoController: 'testErizoController',
+    ObjectId: sinon.stub(),
+    client: {
+      startSession: sinon.stub().returns(dbSession()),
+    },
     db: {
-      ObjectId: sinon.stub(),
-      rooms: dbEntry(),
-      services: dbEntry(),
-      tokens: dbEntry(),
-      erizoControllers: dbEntry(),
+      collection: sinon.stub().returns(dbEntry()),
     },
   });
 

--- a/nuve/package.json
+++ b/nuve/package.json
@@ -13,7 +13,7 @@
     "body-parser": "~1.19.0",
     "express": "~4.17.1",
     "log4js": "~1.0.1",
-    "mongojs": "~2.6.0",
+    "mongodb": "^3.6.3"
     "node-getopt": "~0.3.2"
   },
   "contributors": [

--- a/nuve/package.json
+++ b/nuve/package.json
@@ -13,7 +13,7 @@
     "body-parser": "~1.19.0",
     "express": "~4.17.1",
     "log4js": "~1.0.1",
-    "mongodb": "^3.6.3"
+    "mongodb": "^3.6.3",
     "node-getopt": "~0.3.2"
   },
   "contributors": [


### PR DESCRIPTION
**Description**

We were stuck in versions of MongoDB < 4.2 because we were using the eval function, which had been deprecated. This PR adapts the code to use the newer transactions.

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.