### PR TITLE
Add Performance Metrics about ErizoJS to Prometheus

### DIFF
--- a/erizo_controller/common/PerformanceStats.js
+++ b/erizo_controller/common/PerformanceStats.js
@@ -1,0 +1,286 @@
+/* global require, exports */
+
+const Stats = require('fast-stats').Stats;
+const { performance } = require('perf_hooks');
+
+const logger = require('./logger').logger;
+
+const log = logger.getLogger('PerformanceStats');
+
+let performanceStats;
+
+// This file provides a way to measure performance in Licode components
+// by using NodeJS native Performance class to set marks (timestamps) and
+// calculate measures (durations in milliseconds) and process stats with
+// those mesaures (min, max, arithmetic mean, arithmetic standard deviation).
+// It also provides mechanisms to ROV to export the resulting stats to
+// Prometheus.
+
+// Stats that FastStats will compute for each measure
+// We will end up publishing the tuples <measure, stat> to Prometheus:
+// Examples: subscribe_total_min, subscribe_total_amean
+const StatMetrics = ['min', 'max', 'amean', 'stddev'];
+
+// All Measures we will send to prometheus. A measure is a duration.
+const Measures = {
+  SUBSCRIBE_TOTAL: 'subscribe_total',
+  SUBSCRIBE_STREAM_CREATED: 'subscribe_connection_started',
+  SUBSCRIBE_CANDIDATES_GATHERED: 'subscribe_candidates_gathered',
+  SUBSCRIBE_CONNECTION_INIT: 'subscribe_connection_init',
+  SUBSCRIBE_OFFER_QUEUE: 'subscribe_offer_queue',
+  SUBSCRIBE_OFFER_CREATED: 'subscribe_offer_created',
+  SUBSCRIBE_OFFER_SENT: 'subscribe_offer_sent',
+
+  UNSUBSCRIBE_OFFER_QUEUE: 'unsubscribe_offer_queue',
+  UNSUBSCRIBE_OFFER_CREATED: 'unsubscribe_offer_created',
+  UNSUBSCRIBE_OFFER_SENT: 'unsubscribe_offer_sent',
+  UNSUBSCRIBE_REMOVE_STREAM: 'unsubscribe_remove_stream',
+  UNSUBSCRIBE_CLOSE_STREAM: 'unsubscribe_close_stream',
+  UNSUBSCRIBE_TOTAL: 'unsubscribe_total',
+};
+
+// Timestamp marks that will take part of the Measures.
+const Marks = {
+  SUBSCRIBE_REQUEST_RECEIVED: 'subscribe_request_received',
+  SUBSCRIBE_STREAM_CREATED: 'subscribe_stream_created',
+  SUBSCRIBE_CONNECTION_INIT: 'subscribe_connection_init',
+  SUBSCRIBE_CANDIDATES_GATHERED: 'subscribe_candidates_gathered',
+  SUBSCRIBE_RESPONSE_SENT: 'subscribe_response_sent',
+
+  UNSUBSCRIBE_REQUEST_RECEIVED: 'unsubscribe_request_received',
+  UNSUBSCRIBE_RESPONSE_SENT: 'unsubscribe_response_sent',
+
+  CONNECTION_OFFER_SENT: 'connection_offer_sent',
+  CONNECTION_OFFER_ENQUEUED: 'connection_offer_enqueued',
+  CONNECTION_OFFER_DEQUEUED: 'connection_offer_dequeued',
+  CONNECTION_OFFER_CREATED: 'connection_offer_created',
+  CONNECTION_STREAM_CLOSED: 'connection_stream_closed',
+  CONNECTION_STREAM_REMOVED: 'connection_stream_removed',
+  CONNECTION_STREAM_REMOVED_AND_CLOSED: 'connection_stream_closed_and_removed',
+};
+
+const COMPUTE_MEASURES_INTERVAL = 15000;
+
+// This class creates a Measure (duration) from two Marks (timestamps).
+class PerfromanceMeasure {
+  constructor(measure, from, to) {
+    this.measure = measure;
+    this.from = from;
+    this.to = to;
+  }
+}
+
+// Definition of all the Measures in Licode components
+const PerformanceMeasures = [
+  // ErizoJS addSubscriber requests
+  new PerfromanceMeasure(Measures.SUBSCRIBE_TOTAL,
+    Marks.SUBSCRIBE_REQUEST_RECEIVED,
+    Marks.SUBSCRIBE_RESPONSE_SENT),
+  new PerfromanceMeasure(Measures.SUBSCRIBE_STREAM_CREATED,
+    Marks.SUBSCRIBE_REQUEST_RECEIVED,
+    Marks.SUBSCRIBE_STREAM_CREATED),
+  new PerfromanceMeasure(Measures.SUBSCRIBE_CONNECTION_INIT,
+    Marks.SUBSCRIBE_STREAM_CREATED,
+    Marks.SUBSCRIBE_CONNECTION_INIT),
+  new PerfromanceMeasure(Measures.SUBSCRIBE_CANDIDATES_GATHERED,
+    Marks.SUBSCRIBE_CONNECTION_INIT,
+    Marks.SUBSCRIBE_CANDIDATES_GATHERED),
+  new PerfromanceMeasure(Measures.SUBSCRIBE_OFFER_QUEUE,
+    Marks.CONNECTION_OFFER_ENQUEUED,
+    Marks.CONNECTION_OFFER_DEQUEUED),
+  new PerfromanceMeasure(Measures.SUBSCRIBE_OFFER_CREATED,
+    Marks.CONNECTION_OFFER_DEQUEUED,
+    Marks.CONNECTION_OFFER_CREATED),
+  new PerfromanceMeasure(Measures.SUBSCRIBE_OFFER_SENT,
+    Marks.CONNECTION_OFFER_CREATED,
+    Marks.CONNECTION_OFFER_SENT),
+
+  // ErizoJS removeSubscriber requests
+  new PerfromanceMeasure(Measures.UNSUBSCRIBE_TOTAL,
+    Marks.UNSUBSCRIBE_REQUEST_RECEIVED,
+    Marks.UNSUBSCRIBE_RESPONSE_SENT),
+  new PerfromanceMeasure(Measures.UNSUBSCRIBE_REMOVE_STREAM,
+    Marks.UNSUBSCRIBE_REQUEST_RECEIVED,
+    Marks.CONNECTION_STREAM_REMOVED),
+  new PerfromanceMeasure(Measures.UNSUBSCRIBE_CLOSE_STREAM,
+    Marks.UNSUBSCRIBE_REQUEST_RECEIVED,
+    Marks.CONNECTION_STREAM_CLOSED),
+  new PerfromanceMeasure(Measures.UNSUBSCRIBE_OFFER_QUEUE,
+    Marks.CONNECTION_OFFER_ENQUEUED,
+    Marks.CONNECTION_OFFER_DEQUEUED),
+  new PerfromanceMeasure(Measures.UNSUBSCRIBE_OFFER_CREATED,
+    Marks.CONNECTION_OFFER_DEQUEUED,
+    Marks.CONNECTION_OFFER_CREATED),
+  new PerfromanceMeasure(Measures.UNSUBSCRIBE_OFFER_SENT,
+    Marks.CONNECTION_OFFER_CREATED,
+    Marks.CONNECTION_OFFER_SENT),
+
+];
+
+// Class that will be executed in Licode components
+class PerformanceStats {
+  constructor() {
+    this.measures = new Map();
+    this.marks = new Map();
+    this.ids = new Set();
+    // eslint-disable-next-line no-restricted-syntax
+    for (const measure of PerformanceMeasures) {
+      const performanceMeasure = Object.assign({}, measure);
+      performanceMeasure.stats = new Stats();
+      this.measures.set(performanceMeasure.measure, performanceMeasure);
+    }
+
+    // We can loss some measures when calculating through intervals, but it looks
+    // like a reasonable trade-off to process marks and measures.
+    this.computeMeasuresInterval = setInterval(() => {
+      this.computeAllMeasures();
+    }, COMPUTE_MEASURES_INTERVAL);
+  }
+
+  computeAllMeasures() {
+    this.ids.forEach((id) => {
+      this.computeMeasuresWithId(id);
+    });
+
+    this.marks.clear();
+    this.ids.clear();
+  }
+
+  forEachMeasure(func = () => {}) {
+    this.measures.forEach((performanceMeasure, measure) => {
+      func(measure, performanceMeasure);
+    });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  markWithId(id, mark) {
+    if (id) {
+      this.ids.add(id);
+      log.debug(`message: Marking with id: ${id}, mark: ${mark}`);
+      this.marks.set(`${id}_${mark}`, performance.now());
+    }
+  }
+
+  computeMeasuresWithId(id) {
+    // Compute times
+    this.measures.forEach((performanceMeasure) => {
+      const to = `${id}_${performanceMeasure.to}`;
+      const from = `${id}_${performanceMeasure.from}`;
+      if (this.marks.has(to) && this.marks.has(from)) {
+        const value = this.marks.get(to) - this.marks.get(from);
+        performanceMeasure.stats.push(value);
+      } else {
+        log.debug(`message: failed when measuring between marks, id: ${id}, measure: ${performanceMeasure.measure}, ` +
+          `from: ${performanceMeasure.from} (${this.marks.has(from)}), to: ${performanceMeasure.to} (${this.marks.has(to)})`);
+      }
+    });
+  }
+
+  resetStats() {
+    this.measures.forEach((performanceMeasure) => {
+      performanceMeasure.stats.reset();
+    });
+  }
+
+  process() {
+    const result = {};
+    this.measures.forEach((performanceMeasure) => {
+      // eslint-disable-next-line no-restricted-syntax
+      for (const stat of StatMetrics) {
+        try {
+          const statFunction = performanceMeasure.stats[stat];
+          let value;
+          if (statFunction instanceof Function) {
+            value = statFunction.apply(performanceMeasure.stats);
+          } else {
+            value = statFunction || NaN;
+          }
+          result[`${performanceMeasure.measure}_${stat}`] = value;
+        } catch (e) {
+          log.error(`message: Error computing stat, mesasure: ${performanceMeasure.measure}, stat: ${stat}, error: ${e.stack}`);
+        }
+      }
+    });
+    this.resetStats();
+    log.debug(`message: Processing results, results: ${JSON.stringify(result)}`);
+    return result;
+  }
+}
+
+// Class that will be executed in RovMetricsServer to gather all
+// measures obtained by ROV from Licode components, compute the max among them
+// and set them to Prometheus Client.
+class PrometheusExporter {
+  constructor(prometheusClient, getNameWithPrefix) {
+    this.promClient = prometheusClient;
+    this.metrics = new Map();
+    this.getNameWithPrefix = getNameWithPrefix;
+    // eslint-disable-next-line no-restricted-syntax
+    for (const measure of PerformanceMeasures) {
+      StatMetrics.forEach((stat) => {
+        this.defineMetricFromMeasure(measure.measure, stat);
+      });
+    }
+  }
+
+  defineMetricFromMeasure(measure, stat) {
+    const finalMeasure = `${measure}_${stat}`;
+    this.metrics.set(finalMeasure, {
+      metric: new this.promClient.Gauge({
+        name: this.getNameWithPrefix(finalMeasure),
+        help: finalMeasure }),
+      max: 0,
+    });
+  }
+
+  exportToPrometheus(results) {
+    // Calculate Max value from all results
+    results.forEach((data) => {
+      const result = JSON.parse(data);
+      Object.getOwnPropertyNames(result).forEach((measureName) => {
+        if (this.metrics.has(measureName)) {
+          const metric = this.metrics.get(measureName);
+          metric.max = Math.max(metric.max, result[measureName]);
+        } else {
+          log.error('Does not have metric', this.getNameWithPrefix(measureName));
+        }
+      });
+    });
+
+    // Export it to prometheus and reset for the next iteration
+    this.metrics.forEach((metric) => {
+      metric.metric.set(metric.max);
+      // eslint-disable-next-line no-param-reassign
+      metric.max = 0;
+    });
+  }
+}
+
+exports.init = () => {
+  performanceStats = new PerformanceStats();
+};
+
+exports.mark = (id, mark) => {
+  log.debug(`message: Premarking with id: ${id}, mark: ${mark}, contains: ${Object.values(Marks).indexOf(mark)}`);
+  if (id && performanceStats && Object.values(Marks).indexOf(mark) !== -1) {
+    performanceStats.markWithId(id, mark);
+  }
+};
+
+exports.computeMeasuresWithId = (id) => {
+  if (performanceStats) {
+    performanceStats.computeMeasuresWithId(id);
+  }
+};
+
+exports.process = () => {
+  if (performanceStats) {
+    return performanceStats.process();
+  }
+  return {};
+};
+
+exports.PerformanceMeasures = PerformanceMeasures;
+exports.PrometheusExporter = PrometheusExporter;
+exports.Marks = Marks;
+exports.Measures = Measures;

--- a/erizo_controller/common/amqper.js
+++ b/erizo_controller/common/amqper.js
@@ -121,6 +121,7 @@ exports.bind = (id, callback) => {
             rpcExc.publish(message.replyTo,
               { data: result, corrID: message.corrID, type });
           });
+          message.args.push(message.corrID);
           rpcPublic[message.method](...message.args);
         } catch (error) {
           log.error('message: error processing call, ' +

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -1,6 +1,6 @@
 /* global require, exports, setInterval, clearInterval, Promise */
-
 const perfHooks = require('perf_hooks');
+
 const logger = require('./../common/logger').logger;
 const amqper = require('./../common/amqper');
 const RovReplManager = require('./../common/ROV/rovReplManager').RovReplManager;
@@ -8,6 +8,7 @@ const Client = require('./models/Client').Client;
 const Publisher = require('./models/Publisher').Publisher;
 const ExternalInput = require('./models/Publisher').ExternalInput;
 const PublisherManager = require('./models/PublisherManager').PublisherManager;
+const PerformanceStats = require('../common/PerformanceStats');
 
 // Logger
 const log = logger.getLogger('ErizoJSController');
@@ -24,6 +25,7 @@ exports.ErizoJSController = (erizoJSId, threadPool, ioThreadPool) => {
   const statsSubscriptions = {};
   const WARN_NOT_FOUND = 404;
   const WARN_CONFLICT = 409;
+  PerformanceStats.init();
 
   const MAX_INACTIVE_UPTIME = global.config.erizo.activeUptimeLimit * 24 * 60 * 60 * 1000;
   const MAX_TIME_SINCE_LAST_OP =
@@ -104,12 +106,12 @@ exports.ErizoJSController = (erizoJSId, threadPool, ioThreadPool) => {
     return client;
   };
 
-  const closeNode = (node, sendOffer) => {
+  const closeNode = (node, sendOffer, requestId) => {
     const clientId = node.clientId;
     const connection = node.connection;
     log.debug(`message: closeNode, clientId: ${node.clientId}, streamId: ${node.streamId}`);
 
-    const closePromise = node.close(sendOffer);
+    const closePromise = node.close(sendOffer, requestId);
 
     return closePromise.then(() => {
       log.debug(`message: Node Closed, clientId: ${node.clientId}, streamId: ${node.streamId}`);
@@ -327,8 +329,10 @@ exports.ErizoJSController = (erizoJSId, threadPool, ioThreadPool) => {
    * This WebRtcConnection will be added to the subscribers list of the
    * OneToManyProcessor.
    */
-  that.addSubscriber = (erizoControllerId, clientId, streamId, options, callbackRpc) => {
+  that.addSubscriber = (erizoControllerId, clientId, streamId, options, callbackRpc, requestId) => {
     updateUptimeInfo();
+    PerformanceStats.mark(requestId, PerformanceStats.Marks.SUBSCRIBE_REQUEST_RECEIVED);
+
     const publisher = publisherManager.getPublisherById(streamId);
     if (publisher === undefined) {
       log.warn('message: addSubscriber to unknown publisher, ',
@@ -366,12 +370,26 @@ exports.ErizoJSController = (erizoJSId, threadPool, ioThreadPool) => {
 
     if (options.offerFromErizo) {
       subscriber.promise
+        .then(() => PerformanceStats.mark(requestId,
+          PerformanceStats.Marks.SUBSCRIBE_STREAM_CREATED))
         .then(() => connection.init({ audio: true, video: true, bundle: true }))
+        .then(() => PerformanceStats.mark(requestId,
+          PerformanceStats.Marks.SUBSCRIBE_CONNECTION_INIT))
         .then(() => connection.onGathered)
-        .then(() => connection.sendOffer());
+        .then(() => PerformanceStats.mark(requestId,
+          PerformanceStats.Marks.SUBSCRIBE_CANDIDATES_GATHERED))
+        .then(() => connection.sendOffer(requestId))
+        .then(() => PerformanceStats.mark(requestId,
+          PerformanceStats.Marks.SUBSCRIBE_RESPONSE_SENT));
     } else {
       subscriber.promise
-        .then(() => connection.init(options.createOffer));
+        .then(() => PerformanceStats.mark(requestId,
+          PerformanceStats.Marks.SUBSCRIBE_STREAM_CREATED))
+        .then(() => connection.init(options.createOffer))
+        .then(() => PerformanceStats.mark(requestId,
+          PerformanceStats.Marks.SUBSCRIBE_CONNECTION_INIT))
+        .then(() => PerformanceStats.mark(requestId,
+          PerformanceStats.Marks.SUBSCRIBE_RESPONSE_SENT));
     }
 
     connection.onInitialized.then(() => {
@@ -559,17 +577,19 @@ exports.ErizoJSController = (erizoJSId, threadPool, ioThreadPool) => {
    * Removes a subscriber from the room.
    * This also removes it from the associated OneToManyProcessor.
    */
-  that.removeSubscriber = (clientId, streamId, callback = () => {}) => {
+  that.removeSubscriber = (clientId, streamId, callback = () => {}, requestId = undefined) => {
     const publisher = publisherManager.getPublisherById(streamId);
     if (publisher && publisher.hasSubscriber(clientId)) {
+      PerformanceStats.mark(requestId, PerformanceStats.Marks.UNSUBSCRIBE_REQUEST_RECEIVED);
       const subscriber = publisher.getSubscriber(clientId);
       log.info(`message: removing subscriber, streamId: ${subscriber.streamId}, ` +
         `clientId: ${clientId},`,
       logger.objectToLog(subscriber.options), logger.objectToLog(subscriber.options.metadata));
-      return closeNode(subscriber).then(() => {
+      return closeNode(subscriber, true, requestId).then(() => {
         publisher.removeSubscriber(clientId);
         log.info(`message: subscriber node Closed, streamId: ${subscriber.streamId}`);
         callback('callback', true);
+        PerformanceStats.mark(requestId, PerformanceStats.Marks.UNSUBSCRIBE_RESPONSE_SENT);
       });
     }
     log.warn(`message: removeSubscriber no publisher has this subscriber, clientId: ${clientId}, streamId: ${streamId}`);
@@ -746,6 +766,8 @@ exports.ErizoJSController = (erizoJSId, threadPool, ioThreadPool) => {
     p95: histogram.percentile(90) / 1e9,
     p99: histogram.percentile(99) / 1e9,
   });
+
+  that.computePerformanceStats = () => PerformanceStats.process();
 
   return that;
 };

--- a/erizo_controller/erizoJS/models/Connection.js
+++ b/erizo_controller/erizoJS/models/Connection.js
@@ -7,6 +7,7 @@ const addon = require('./../../../erizoAPI/build/Release/addon');
 const logger = require('./../../common/logger').logger;
 const SessionDescription = require('./SessionDescription');
 const SemanticSdp = require('./../../common/semanticSdp/SemanticSdp');
+const PerformanceStats = require('./../../common/PerformanceStats');
 const sdpTransform = require('sdp-transform');
 
 const log = logger.getLogger('Connection');
@@ -154,8 +155,9 @@ class Connection extends events.EventEmitter {
     });
   }
 
-  createOffer() {
+  createOffer(requestId = undefined) {
     return this.getLocalSdp().then((info) => {
+      PerformanceStats.mark(requestId, PerformanceStats.Marks.CONNECTION_OFFER_CREATED);
       log.debug('getting local sdp for offer', info, ',',
         logger.objectToLog(this.options), logger.objectToLog(this.options.metadata));
       return { type: 'offer', sdp: info };
@@ -196,26 +198,33 @@ class Connection extends events.EventEmitter {
     }
   }
 
-  sendOffer() {
+  sendOffer(requestId = undefined) {
+    PerformanceStats.mark(requestId, PerformanceStats.Marks.CONNECTION_OFFER_ENQUEUED);
+    return this._enqueueOrSendOffer(requestId);
+  }
+
+  _enqueueOrSendOffer(requestId = undefined) {
     if (this.isNegotiationLocked) {
-      this._logSdp('Dropping sendOffer, id:', this.id);
-      return this._enqueueNegotiation(this.sendOffer.bind(this));
+      this._logSdp('Enqueueing sendOffer, id:', this.id);
+      return this._enqueueNegotiation(this._enqueueOrSendOffer.bind(this, requestId));
     }
     this._logSdp('SendOffer');
 
     this._lockNegotiation('sendOffer');
-    return this._sendOffer();
+    PerformanceStats.mark(requestId, PerformanceStats.Marks.CONNECTION_OFFER_DEQUEUED);
+    return this._sendOffer(requestId);
   }
 
-  _sendOffer() {
+  _sendOffer(requestId = undefined) {
     if (!this.alreadyGathered && !this.trickleIce) {
       return Promise.resolve();
     }
     this._logSdp('_sendOffer');
-    return this.createOffer().then((info) => {
+    return this.createOffer(requestId).then((info) => {
       log.debug(`message: sendOffer sending event, type: ${info.type}, sessionVersion: ${this.sessionVersion},`,
         logger.objectToLog(this.options), logger.objectToLog(this.options.metadata));
       this._onStatusEvent(info, CONN_SDP);
+      PerformanceStats.mark(requestId, PerformanceStats.Marks.CONNECTION_OFFER_SENT);
     });
   }
 
@@ -309,15 +318,19 @@ class Connection extends events.EventEmitter {
     return promise;
   }
 
-  removeMediaStream(id, sendOffer = true) {
+  removeMediaStream(id, sendOffer = true, requestId = undefined) {
     const promise = Promise.resolve();
     if (this.mediaStreams.get(id) !== undefined) {
       const removePromise = this.wrtc.removeMediaStream(id);
       const closePromise = this.mediaStreams.get(id).close();
+      removePromise.then(() => PerformanceStats.mark(requestId,
+        PerformanceStats.Marks.CONNECTION_STREAM_REMOVED));
+      closePromise.then(() => PerformanceStats.mark(requestId,
+        PerformanceStats.Marks.CONNECTION_STREAM_CLOSED));
       this.mediaStreams.delete(id);
       return Promise.all([removePromise, closePromise]).then(() => {
         if (sendOffer) {
-          this.sendOffer();
+          return this.sendOffer(requestId);
         }
         return Promise.resolve();
       });

--- a/erizo_controller/erizoJS/models/Subscriber.js
+++ b/erizo_controller/erizoJS/models/Subscriber.js
@@ -108,14 +108,14 @@ class Subscriber extends NodeClass {
     this.mediaStream.resetStats();
   }
 
-  close(sendOffer = true) {
+  close(sendOffer = true, requestId = undefined) {
     log.debug(`message: Closing subscriber, clientId: ${this.clientId}, streamId: ${this.streamId}, `,
       logger.objectToLog(this.options), logger.objectToLog(this.options.metadata));
     this.publisher = undefined;
     let promise = Promise.resolve();
     if (this.connection) {
       log.debug(`message: Removing Media Stream, clientId: ${this.clientId}, streamId: ${this.streamId}`);
-      promise = this.connection.removeMediaStream(this.mediaStream.id, sendOffer);
+      promise = this.connection.removeMediaStream(this.mediaStream.id, sendOffer, requestId);
       this.connection.removeListener('media_stream_event', this._mediaStreamListener);
     }
     if (this.mediaStream && this.mediaStream.monitorInterval) {

--- a/erizo_controller/log4js_configuration.json
+++ b/erizo_controller/log4js_configuration.json
@@ -19,6 +19,7 @@
     "ErizoAgent": "INFO",
     "ErizoAgentReporter": "ERROR",
     "EcCloudHandler": "INFO",
+    "PerformanceStats": "INFO",
     "Publisher": "INFO",
     "Subscriber": "INFO",
     "Room": "INFO",

--- a/erizo_controller/package-lock.json
+++ b/erizo_controller/package-lock.json
@@ -400,6 +400,11 @@
         "time-stamp": "^1.0.0"
       }
     },
+    "fast-stats": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/fast-stats/-/fast-stats-0.0.6.tgz",
+      "integrity": "sha512-m0zkwa7Z07Wc4xm1YtcrCHmhzNxiYRrrfUyhkdhSZPzaAH/Ewbocdaq7EPVBFz19GWfIyyPcLfRHjHJYe83jlg=="
+    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",

--- a/erizo_controller/package.json
+++ b/erizo_controller/package.json
@@ -10,6 +10,7 @@
     "aws-sdk": "~2.566.0",
     "express": "~4.17.1",
     "fancy-log": "^1.3.3",
+    "fast-stats": "0.0.6",
     "log4js": "~1.0.1",
     "node-getopt": "~0.3.2",
     "prom-client": "~11.2.1",

--- a/erizo_controller/test/utils.js
+++ b/erizo_controller/test/utils.js
@@ -167,7 +167,7 @@ module.exports.reset = () => {
       .returns(Promise.resolve(module.exports.ConnectionDescription)),
     addRemoteCandidate: sinon.stub(),
     addMediaStream: sinon.stub().returns(Promise.resolve()),
-    removeMediaStream: sinon.stub(),
+    removeMediaStream: sinon.stub().returns(Promise.resolve()),
     getConnectionQualityLevel: sinon.stub().returns(2),
     setMetadata: sinon.stub(),
   };
@@ -176,7 +176,7 @@ module.exports.reset = () => {
     minVideoBW: '',
     scheme: '',
     periodicPlis: '',
-    close: sinon.stub(),
+    close: sinon.stub().returns(Promise.resolve()),
     configure: sinon.stub(),
     setAudioReceiver: sinon.stub(),
     setVideoReceiver: sinon.stub(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -838,6 +838,15 @@
         "type-detect": "^1.0.0"
       }
     },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
+      }
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -855,6 +864,12 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "chokidar": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "devDependencies": {
     "async": "^2.1.2",
     "chai": "^3.5.0",
+    "chai-as-promised": "^7.1.1",
     "del": "~3.0.0",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^15.0.1",


### PR DESCRIPTION
**Description**

Add perf metrics about ErizoJS (requests to subscribe and unsubscribe streams) and export them to Prometheus through ROV.

This PR adds the structure needed to seamlessly add new metrics about the duration of tasks performed in ErizoJS and I add use it to calculate the performance of subscriptions/unsubscriptions.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.