### PR TITLE
Default dataBaseURL fix

### DIFF
--- a/scripts/licode_default.js
+++ b/scripts/licode_default.js
@@ -23,7 +23,7 @@ config.cloudProvider.name = '';
  NUVE CONFIGURATION
 **********************************************************/
 config.nuve = {};
-config.nuve.dataBaseURL = "localhost/nuvedb"; // default value: 'localhost/nuvedb'
+config.nuve.dataBaseURL = "mongodb://localhost/nuvedb"; // default value: 'mongodb://localhost/nuvedb'
 config.nuve.superserviceID = '_auto_generated_ID_'; // default value: ''
 config.nuve.superserviceKey = '_auto_generated_KEY_'; // default value: ''
 config.nuve.testErizoController = 'localhost:8080'; // default value: 'localhost:8080'


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

Licode initalization was crashing as it was not able to connect with mongo db with the following error:
Error connecting to MongoDB server localhost/nuvedb MongoParseError: Invalid connection string

To fix it we have to change the defatult parameter config.nuve.dataBaseURL in licode_default  from /localhost/nuvedb to the newURL mongodb://localhost/nuvedb. This url was changed in licode/blob/master/nuve/nuveAPI/mdb/dataBase.js but not in the licode_default file.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

No changes needed

[] It includes documentation for these changes in `/doc`.