### PR TITLE
Change sleep to timeout in docker init script

### DIFF
--- a/extras/docker/initDockerLicode.sh
+++ b/extras/docker/initDockerLicode.sh
@@ -64,7 +64,7 @@ check_result() {
 run_rabbitmq() {
   echo "Starting Rabbitmq"
   rabbitmq-server -detached
-  sleep 5
+  timeout 15 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 1; done' localhost 5672
 }
 
 run_mongo() {
@@ -75,7 +75,7 @@ run_mongo() {
     fi
     mongod --repair --dbpath $DB_DIR
     mongod --nojournal --dbpath $DB_DIR --logpath $BUILD_DIR/mongo.log --fork
-    sleep 5
+    timeout 15 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 1; done' localhost 27017
   else
     echo [licode] mongodb already running
   fi
@@ -112,7 +112,13 @@ run_nuve() {
   echo "Starting Nuve"
   cd $ROOT/nuve/nuveAPI
   node nuve.js &
-  sleep 5
+
+  nuvePort=`grep "config.nuve.port" $SCRIPTS/licode_default.js`
+
+  nuvePort=`echo $nuvePort| cut -d';' -f 1`
+  nuvePort=`echo $nuvePort| cut -d'=' -f 2`
+
+  timeout 15 bash -c 'until printf "" 2>>/dev/null >>/dev/tcp/$0/$1; do sleep 1; done' localhost $nuvePort
 }
 run_erizoController() {
 


### PR DESCRIPTION
Change sleep to timeout to avoid errors on slow computers and speed the init

<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
Use the timeout command to wait until the tcp port of the service is open.
The rabbitmq and mongodb ports are hardcoded, because always start with this ports inside de docker
The nuve tcp port is queried in the config

The init time of the docker with this change: 15 s
Without the change: 26 s

With raspberry pi need more than 5 seconds to start the services

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.