### PR TITLE
Fix linking with bzip and zlib2 when building erizo

### DIFF
--- a/erizo/conanfile.txt
+++ b/erizo/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-boost/1.69.0@conan/stable
+boost/1.69.0
 IncludePathsGenerator/0.1@lynckia/includes
 
 [generators]

--- a/erizo/src/CMakeLists.txt
+++ b/erizo/src/CMakeLists.txt
@@ -68,8 +68,8 @@ ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 # BOOST
 include(${CMAKE_CURRENT_SOURCE_DIR}/../conan_paths.cmake)
 set (BOOST_LIBS thread regex system)
-find_package(boost)
-include_directories(${boost_INCLUDE_DIRS})
+find_package(Boost)
+include_directories(${Boost_INCLUDE_DIRS})
 
 set(ERIZO_CMAKE_CXX_FLAGS "${ERIZO_CMAKE_CXX_FLAGS} -DBOOST_THREAD_PROVIDES_FUTURE -DBOOST_THREAD_PROVIDES_FUTURE_CONTINUATION -DBOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY")
 

--- a/erizo/src/erizo/CMakeLists.txt
+++ b/erizo/src/erizo/CMakeLists.txt
@@ -23,4 +23,4 @@ file(GLOB_RECURSE ERIZO_SOURCES "${ERIZO_SOURCE_DIR}/*.h" "${ERIZO_SOURCE_DIR}/*
 add_library(erizo SHARED ${ERIZO_SOURCES})
 
 
-target_link_libraries(erizo ${boost_LIBRARIES} ${SRTP} ${SSL} ${CRYPTO} ${LIBS} ${LOG} webrtc nicer nrappkit)
+target_link_libraries(erizo ${Boost_LIBRARIES} ${SRTP} ${SSL} ${CRYPTO} ${LIBS} ${LOG} webrtc nicer nrappkit)

--- a/scripts/installMacDeps.sh
+++ b/scripts/installMacDeps.sh
@@ -54,13 +54,13 @@ check_result() {
 install_homebrew_from_cache(){
   if [ -f cache/homebrew-cache.tar.gz ]; then
     tar xzf cache/homebrew-cache.tar.gz --directory /usr/local/Cellar
-    brew link pkg-config boost cmake yasm log4cxx gettext coreutils
+    brew link pkg-config cmake yasm log4cxx gettext coreutils
   fi
 }
 
 copy_homebrew_to_cache(){
   mkdir cache
-  tar czf cache/homebrew-cache.tar.gz --directory /usr/local/Cellar pkg-config boost cmake yasm log4cxx gettext coreutils
+  tar czf cache/homebrew-cache.tar.gz --directory /usr/local/Cellar pkg-config cmake yasm log4cxx gettext coreutils
 }
 
 install_nvm_node() {


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR addresses issues I experienced when linking against some boost dependencies: bzip2 and zlib.
We no longer need to use  `@conan/stable` for things that are in the Conan Index.

Additionally, I remove the conan brew installation for mac, that is not needed anymore.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.