### PR TITLE
Update client with setStreamPriorityStrategy

### DIFF
--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -930,6 +930,8 @@ class Client extends events.EventEmitter {
   }
 
   onSetStreamPriorityStrategy(strategyId, callback = () => {}) {
+    this.options.streamPriorityStrategy =
+      Client.getStreamPriorityStrategy(strategyId);
     this.room.amqper.broadcast('ErizoJS', { method: 'setClientStreamPriorityStrategy', args: [this.id, strategyId] });
     callback();
   }


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR fixes a race condition by properly updating the `Client` in ErizoController when `setStreamPriorityStrategy` is called.
[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.