### PR TITLE
Stop padding if the distributor does not assign all the available

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -890,7 +890,7 @@ void WebRtcConnection::setBwDistributionConfigSync(BwDistributionConfig distribu
     break;
   case STREAM_PRIORITY:
     distributor_ = std::unique_ptr<BandwidthDistributionAlgorithm>(
-        new StreamPriorityBWDistributor(distribution_config.priority_strategy));
+        new StreamPriorityBWDistributor(distribution_config.priority_strategy, stats_));
     break;
   }
 }

--- a/erizo/src/erizo/bandwidth/StreamPriorityBWDistributor.cpp
+++ b/erizo/src/erizo/bandwidth/StreamPriorityBWDistributor.cpp
@@ -12,7 +12,8 @@
 namespace erizo {
 DEFINE_LOGGER(StreamPriorityBWDistributor, "bandwidth.StreamPriorityBWDistributor");
 
-  StreamPriorityBWDistributor::StreamPriorityBWDistributor(StreamPriorityStrategy strategy): strategy_{strategy} {
+  StreamPriorityBWDistributor::StreamPriorityBWDistributor(StreamPriorityStrategy strategy,
+  std::shared_ptr<Stats>stats): strategy_{strategy}, stats_{stats} {
   }
 
 std::string StreamPriorityBWDistributor::getStrategyId() {
@@ -99,6 +100,7 @@ void StreamPriorityBWDistributor::distribute(uint32_t remb, uint32_t ssrc,
           remb, stream_info.stream->getId().c_str(), remaining_bitrate);
     }
   }
+  stats_->getNode()["total"].insertStat("unnasignedBitrate", CumulativeStat{remaining_bitrate});
   for (const auto& kv_pair : stream_infos) {
     for (MediaStreamPriorityInfo& stream_info : stream_infos[kv_pair.first]) {
       auto generated_remb = RtpUtils::createREMB(ssrc,

--- a/erizo/src/erizo/bandwidth/StreamPriorityBWDistributor.h
+++ b/erizo/src/erizo/bandwidth/StreamPriorityBWDistributor.h
@@ -2,6 +2,7 @@
 #define ERIZO_SRC_ERIZO_BANDWIDTH_STREAMPRIORITYBWDISTRIBUTOR_H_
 
 #include "./logger.h"
+#include "./Stats.h"
 #include "bandwidth/BwDistributionConfig.h"
 #include "bandwidth/BandwidthDistributionAlgorithm.h"
 
@@ -18,7 +19,7 @@ class MediaStreamPriorityInfo {
 class StreamPriorityBWDistributor : public BandwidthDistributionAlgorithm {
 DECLARE_LOGGER();
  public:
-  explicit StreamPriorityBWDistributor(StreamPriorityStrategy strategy);
+  explicit StreamPriorityBWDistributor(StreamPriorityStrategy strategy, std::shared_ptr<Stats> stats);
   virtual ~StreamPriorityBWDistributor() {}
   void distribute(uint32_t remb, uint32_t ssrc, std::vector<std::shared_ptr<MediaStream>> streams,
                   Transport *transport) override;
@@ -26,6 +27,7 @@ DECLARE_LOGGER();
 
  private:
   StreamPriorityStrategy strategy_;
+  std::shared_ptr<Stats> stats_;
 };
 
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -349,7 +349,7 @@ void QualityManager::forceLayers(int spatial_layer, int temporal_layer) {
 }
 
 void QualityManager::enableSlideShowBelowSpatialLayer(bool enable, int spatial_layer) {
-  if (enable_fallback_below_min_layer_ == enable && slideshow_below_spatial_layer_ == spatial_layer_) {
+  if (enable_fallback_below_min_layer_ == enable && slideshow_below_spatial_layer_ == spatial_layer) {
     return;
   }
   ELOG_DEBUG("message: enableSlideShowBelowSpatialLayer, enable %d, spatial_layer: %d", enable, spatial_layer);

--- a/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
@@ -17,6 +17,7 @@ static constexpr duration kStatsPeriod = std::chrono::milliseconds(100);
 static constexpr duration kMinDurationToSendPaddingAfterPacketLosses = std::chrono::seconds(180);
 static constexpr double kBitrateComparisonMargin = 1.3;
 static constexpr uint64_t kInitialBitrate = 300000;
+static constexpr uint64_t kUnnasignedBitrateMargin = 50000;
 
 RtpPaddingManagerHandler::RtpPaddingManagerHandler(std::shared_ptr<erizo::Clock> the_clock) :
   initialized_{false},
@@ -112,7 +113,11 @@ void RtpPaddingManagerHandler::recalculatePaddingRate() {
 
   bool can_send_more_bitrate = (kBitrateComparisonMargin * media_bitrate) < estimated_bandwidth;
   bool estimated_is_high_enough = estimated_bandwidth > (target_bitrate * kBitrateComparisonMargin);
-  if (estimated_is_high_enough) {
+  bool has_unnasigned_bitrate = false;
+  if (stats_->getNode()["total"].hasChild("unnasignedBitrate")) {
+    has_unnasigned_bitrate = stats_->getNode()["total"]["unnasignedBitrate"].value() > kUnnasignedBitrateMargin;
+  }
+  if (estimated_is_high_enough || has_unnasigned_bitrate) {
     target_padding_bitrate = 0;
   }
 

--- a/erizo/src/test/bandwidth/StreamPriorityBWDistributor.cpp
+++ b/erizo/src/test/bandwidth/StreamPriorityBWDistributor.cpp
@@ -6,6 +6,8 @@
 #include <MediaDefinitions.h>
 #include <bandwidth/StreamPriorityBWDistributor.h>
 #include <bandwidth/BwDistributionConfig.h>
+#include <stats/StatNode.h>
+#include <Stats.h>
 
 #include <string>
 #include <tuple>
@@ -26,6 +28,7 @@ using erizo::IceConfig;
 using erizo::RtpMap;
 using erizo::RtpUtils;
 using erizo::MediaStream;
+using erizo::Stats;
 using erizo::StreamPriorityBWDistributor;
 using erizo::StreamPriorityStep;
 using erizo::StreamPriorityStrategy;
@@ -146,6 +149,7 @@ class BasicStreamPriorityBWDistributorTest {
   uint32_t index;
   std::shared_ptr<StreamPriorityBWDistributor> distributor;
   std::queue<std::shared_ptr<DataPacket>> packet_queue;
+  std::shared_ptr<Stats> stats;
 };
 
 class StreamPriorityBWDistributorTest : public BasicStreamPriorityBWDistributorTest,
@@ -162,10 +166,10 @@ class StreamPriorityBWDistributorTest : public BasicStreamPriorityBWDistributorT
     bitrate_value = std::tr1::get<2>(GetParam());
     add_to_remb_list = std::tr1::get<3>(GetParam());
     expected_bitrates = std::tr1::get<4>(GetParam());
-
+    stats = std::make_shared<erizo::Stats>();
     setUpStrategy();
 
-    distributor = std::make_shared<erizo::StreamPriorityBWDistributor>(strategy);
+    distributor = std::make_shared<erizo::StreamPriorityBWDistributor>(strategy, stats);
 
     setUpStreams();
   }


### PR DESCRIPTION
bitrate

<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR addresses an issue where erizo would keep generating padding unnecessarily when using the `StreamPriorityBWDistribution`.
If the distributor does not use all the available bitrate, the `PaddingManager` would still assign padding bitrate to the mediaStreams. We don't actually need that since the distributor has already assigned all the needed bitrate according to the defined strategy.
This PR addresses this by instructing the `PaddingManager` to stop generating padding when there's unneeded available bitrate after a pass of the distribution algorithm.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.