### PR TITLE
Add protections when unpublishing, subscribing and unsubscribing streams

### DIFF
--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -914,7 +914,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
 
   // It unpublishes the local stream in the room, dispatching a StreamEvent("stream-removed")
   that.unpublish = (streamInput, callback = () => {}) => {
-    const stream = streamInput;
+    const stream = that.localStreams.get(streamInput.getID());
     // Unpublish stream from Erizo-Controller
     if (stream && stream.local) {
       // Media stream
@@ -959,7 +959,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
 
   // It subscribe to a remote stream and draws it inside the HTML tag given by the ID='elementID'
   that.subscribe = (streamInput, optionsInput = {}, callback = () => {}) => {
-    const stream = streamInput;
+    const stream = that.remoteStreams.get(streamInput.getID());
     const options = optionsInput;
 
     if (stream && !stream.local && !stream.failed) {
@@ -1024,7 +1024,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
 
   // It unsubscribes from the stream, removing the HTML element.
   that.unsubscribe = (streamInput, callback = () => {}) => {
-    const stream = streamInput;
+    const stream = that.remoteStreams.get(streamInput.getID());
     // Unsubscribe from stream
     if (socket !== undefined) {
       if (stream && !stream.local) {

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -963,7 +963,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     const options = optionsInput;
 
     if (stream && !stream.local && !stream.failed) {
-      if (stream.state !== 'unsubscribed') {
+      if (stream.state !== 'unsubscribed' && stream.state !== 'unsubscribing') {
         log.warning(`message: Cannot subscribe to a subscribed stream, ${stream.toLog()}, ${toLog()}`);
         callback(undefined, 'Stream already subscribed');
         return;
@@ -1028,7 +1028,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     // Unsubscribe from stream
     if (socket !== undefined) {
       if (stream && !stream.local) {
-        if (stream.state !== 'subscribed') {
+        if (stream.state !== 'subscribed' && stream.state !== 'subscribing') {
           log.warning(`message: Cannot unsubscribe to a stream that is not subscribed, ${stream.toLog()}, ${toLog()}`);
           callback(undefined, 'Stream not subscribed');
           return;


### PR DESCRIPTION
**Description**

This PR adds some protections when we subscribe, unsubscribe and unpublish streams.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.