### PR TITLE
Properly check is slideshow is enabled in QualityManager

### DIFF
--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -349,7 +349,7 @@ void QualityManager::forceLayers(int spatial_layer, int temporal_layer) {
 }
 
 void QualityManager::enableSlideShowBelowSpatialLayer(bool enable, int spatial_layer) {
-  if (enable_fallback_below_min_layer_ == enable && slideshow_below_spatial_layer_ == spatial_layer) {
+  if (enable_slideshow_below_spatial_layer_ == enable && slideshow_below_spatial_layer_ == spatial_layer) {
     return;
   }
   ELOG_DEBUG("message: enableSlideShowBelowSpatialLayer, enable %d, spatial_layer: %d", enable, spatial_layer);


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR fixes a bad check in QualityManager to avoid calling `enableSlideshowBelowSpatialLayer` if the new call does not change the configuration


[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.