### PR TITLE
Fix typedef structs and compiler version for erizoAPI

### DIFF
--- a/erizo/src/erizo/rtp/RtpVP8Parser.h
+++ b/erizo/src/erizo/rtp/RtpVP8Parser.h
@@ -10,7 +10,7 @@ enum VP8FrameTypes {
   kVP8PFrame   // Delta frame
 };
 
-typedef struct {
+typedef struct RTPPayloadVP8 {
   bool nonReferenceFrame = false;
   bool beginningOfPartition = false;
   int partitionID = -1;

--- a/erizo/src/erizo/rtp/RtpVP9Parser.h
+++ b/erizo/src/erizo/rtp/RtpVP9Parser.h
@@ -17,7 +17,7 @@ enum VP9FrameTypes {
   kVP9PFrame   // Delta frame
 };
 
-typedef struct {
+typedef struct RTPPayloadVP9 {
   bool hasPictureID = false;
   bool interPicturePrediction = false;
   bool hasLayerIndices = false;

--- a/erizoAPI/binding.gyp
+++ b/erizoAPI/binding.gyp
@@ -14,13 +14,13 @@
           'xcode_settings': {
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',        # -fno-exceptions
             'GCC_ENABLE_CPP_RTTI': 'YES',              # -fno-rtti
-            'MACOSX_DEPLOYMENT_TARGET' : '10.11',      #from MAC OS 10.7
-            'OTHER_CFLAGS': ['-Werror -Qunused-arguments -g -O3 -stdlib=libc++ -std=c++11 -DBOOST_THREAD_PROVIDES_FUTURE -DBOOST_THREAD_PROVIDES_FUTURE_CONTINUATION -DBOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY @$(ERIZO_HOME)/conanbuildinfo.args',]
+            'MACOSX_DEPLOYMENT_TARGET' : '10.15',      #from MAC OS 10.7
+            'OTHER_CFLAGS': ['-Werror -Qunused-arguments -g -O3 -stdlib=libc++ -std=c++14 -DBOOST_THREAD_PROVIDES_FUTURE -DBOOST_THREAD_PROVIDES_FUTURE_CONTINUATION -DBOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY @$(ERIZO_HOME)/conanbuildinfo.args',]
           },
         }, { # OS!="mac"
           'cflags!' : ['-fno-exceptions'],
           'cflags' : ['-D__STDC_CONSTANT_MACROS'],
-          'cflags_cc' : ['-Werror', '-Wall', '-O3', '-g' , '-std=c++11', '-fexceptions', '-DBOOST_THREAD_PROVIDES_FUTURE', '-DBOOST_THREAD_PROVIDES_FUTURE_CONTINUATION', '-DBOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY', '@$(ERIZO_HOME)/conanbuildinfo.args'],
+          'cflags_cc' : ['-Werror', '-Wall', '-O3', '-g' , '-std=c++14', '-fexceptions', '-DBOOST_THREAD_PROVIDES_FUTURE', '-DBOOST_THREAD_PROVIDES_FUTURE_CONTINUATION', '-DBOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY', '@$(ERIZO_HOME)/conanbuildinfo.args'],
           'cflags_cc!' : ['-fno-exceptions'],
           'cflags_cc!' : ['-fno-rtti']
         }],
@@ -36,13 +36,13 @@
           'xcode_settings': {
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',        # -fno-exceptions
             'GCC_ENABLE_CPP_RTTI': 'YES',              # -fno-rtti
-            'MACOSX_DEPLOYMENT_TARGET' : '10.11',      #from MAC OS 10.7
-            'OTHER_CFLAGS': ['-Werror -Qunused-arguments -g -stdlib=libc++ -std=c++11 -DBOOST_THREAD_PROVIDES_FUTURE -DBOOST_THREAD_PROVIDES_FUTURE_CONTINUATION -DBOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY @$(ERIZO_HOME)/conanbuildinfo.args']
+            'MACOSX_DEPLOYMENT_TARGET' : '10.15',      #from MAC OS 10.7
+            'OTHER_CFLAGS': ['-Werror -Qunused-arguments -g -stdlib=libc++ -std=c++14 -DBOOST_THREAD_PROVIDES_FUTURE -DBOOST_THREAD_PROVIDES_FUTURE_CONTINUATION -DBOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY @$(ERIZO_HOME)/conanbuildinfo.args']
           },
         }, { # OS!="mac"
           'cflags!' : ['-fno-exceptions'],
           'cflags' : ['-D__STDC_CONSTANT_MACROS'],
-          'cflags_cc' : ['-Werror', '-Wall', '-g' , '-std=c++11', '-fexceptions', '-DBOOST_THREAD_PROVIDES_FUTURE', '-DBOOST_THREAD_PROVIDES_FUTURE_CONTINUATION', '-DBOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY', '@$(ERIZO_HOME)/conanbuildinfo.args'],
+          'cflags_cc' : ['-Werror', '-Wall', '-g' , '-std=c++14', '-fexceptions', '-DBOOST_THREAD_PROVIDES_FUTURE', '-DBOOST_THREAD_PROVIDES_FUTURE_CONTINUATION', '-DBOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY', '@$(ERIZO_HOME)/conanbuildinfo.args'],
           'cflags_cc!' : ['-fno-exceptions'],
           'cflags_cc!' : ['-fno-rtti']
         }],


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This fixes an issue that created problems when compiling ErizoAPI in mac with the last xcode update.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.