### PR TITLE
Adjust bandwidth estimation stats for stream priority distributor

### DIFF
--- a/erizo/src/erizo/bandwidth/BwDistributionConfig.h
+++ b/erizo/src/erizo/bandwidth/BwDistributionConfig.h
@@ -31,7 +31,6 @@ class StreamPriorityStrategy {
   explicit StreamPriorityStrategy(const std::string& strategy_id = "none");
   std::vector<StreamPriorityStep> strategy;
   uint16_t step_index;
-  std::string strategy_id;
   void addStep(StreamPriorityStep step);
   void initWithVector(std::vector<StreamPriorityStep> strat_vector);
   int getHighestLayerForPriority(std::string priority);

--- a/erizo/src/erizo/bandwidth/StreamPriorityBWDistributor.cpp
+++ b/erizo/src/erizo/bandwidth/StreamPriorityBWDistributor.cpp
@@ -6,6 +6,7 @@
 
 #include "StreamPriorityBWDistributor.h"
 #include "MediaStream.h"
+#include "rtp/QualityManager.h"
 #include "Transport.h"
 #include "rtp/RtpUtils.h"
 
@@ -86,6 +87,8 @@ void StreamPriorityBWDistributor::distribute(uint32_t remb, uint32_t ssrc,
         needed_bitrate_for_stream =
           bitrate_for_higher_temporal_in_spatial == 0 ? max_bitrate_that_meets_constraints :
           std::min(bitrate_for_higher_temporal_in_spatial, max_bitrate_that_meets_constraints);
+        needed_bitrate_for_stream = needed_bitrate_for_stream * (1 + QualityManager::kIncreaseLayerBitrateThreshold);
+        
       }
       uint64_t bitrate = std::min(needed_bitrate_for_stream, remaining_avg_bitrate);
       uint64_t remb = std::min(static_cast<uint64_t>(stream_info.stream->getMaxVideoBW()), bitrate);

--- a/erizo/src/erizo/bandwidth/StreamPriorityBWDistributor.cpp
+++ b/erizo/src/erizo/bandwidth/StreamPriorityBWDistributor.cpp
@@ -88,7 +88,6 @@ void StreamPriorityBWDistributor::distribute(uint32_t remb, uint32_t ssrc,
           bitrate_for_higher_temporal_in_spatial == 0 ? max_bitrate_that_meets_constraints :
           std::min(bitrate_for_higher_temporal_in_spatial, max_bitrate_that_meets_constraints);
         needed_bitrate_for_stream = needed_bitrate_for_stream * (1 + QualityManager::kIncreaseLayerBitrateThreshold);
-        
       }
       uint64_t bitrate = std::min(needed_bitrate_for_stream, remaining_avg_bitrate);
       uint64_t remb = std::min(static_cast<uint64_t>(stream_info.stream->getMaxVideoBW()), bitrate);

--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -243,7 +243,8 @@ void QualityManager::storeLayersAndBitratesInMediaStream() {
 
   for (int spatial_layer = 0; spatial_layer <= max_spatial_layer_available; spatial_layer++) {
     for (int temporal_layer = 0; temporal_layer <= max_temporal_layer_available; temporal_layer++) {
-      stream_->setBitrateForLayer(spatial_layer, temporal_layer, getMaxLayerBitrateInInterval(spatial_layer, temporal_layer));
+      stream_->setBitrateForLayer(spatial_layer, temporal_layer,
+          getMaxLayerBitrateInInterval(spatial_layer, temporal_layer));
       if (doesLayerMeetConstraints(spatial_layer, temporal_layer)) {
         max_available_spatial_layer_that_meets_constraints = spatial_layer;
         max_available_temporal_layer_that_meets_constraints = temporal_layer;
@@ -251,7 +252,8 @@ void QualityManager::storeLayersAndBitratesInMediaStream() {
     }
   }
 
-  stream_->setBitrateFromMaxQualityLayer(getMaxLayerBitrateInInterval(max_available_spatial_layer_that_meets_constraints,
+  stream_->setBitrateFromMaxQualityLayer(
+      getMaxLayerBitrateInInterval(max_available_spatial_layer_that_meets_constraints,
         max_available_temporal_layer_that_meets_constraints));
 }
 

--- a/erizo/src/erizo/rtp/QualityManager.cpp
+++ b/erizo/src/erizo/rtp/QualityManager.cpp
@@ -73,17 +73,16 @@ void QualityManager::notifyQualityUpdate() {
   uint64_t current_layer_instant_bitrate = getInstantLayerBitrate(spatial_layer_, temporal_layer_);
   bool estimated_is_under_layer_bitrate = current_estimated_bitrate_ < current_layer_instant_bitrate;
 
-  if (now - last_activity_check_ > kActiveLayerInterval) {
-    calculateMaxActiveLayer();
-    last_activity_check_ = now;
-  }
+  maybeUpdateAvailableLayersAndBitrates();
 
   bool layer_is_active = spatial_layer_ <= max_active_spatial_layer_;
 
   if (!layer_is_active || (estimated_is_under_layer_bitrate && !freeze_fallback_active_)) {
     ELOG_DEBUG("message: Forcing calculate new layer, "
-        "estimated_is_under_layer_bitrate: %d, layer_is_active: %d, freeze_fallback_active_: %d",
-        estimated_is_under_layer_bitrate, layer_is_active, freeze_fallback_active_);
+        "estimated_is_under_layer_bitrate: %d, layer_is_active: %d, freeze_fallback_active_: %d,"
+        "estimated %lu, layer_bitrate %lu",
+        estimated_is_under_layer_bitrate, layer_is_active, freeze_fallback_active_,
+        current_estimated_bitrate_, current_layer_instant_bitrate);
     selectLayer(false);
   } else if (now - last_quality_check_ > kMinLayerSwitchInterval) {
     selectLayer(true);
@@ -121,39 +120,16 @@ bool QualityManager::doesLayerMeetConstraints(int spatial_layer, int temporal_la
   return meets_resolution && meets_frame_rate;
 }
 
-void QualityManager::calculateMaxBitrateThatMeetsConstraints() {
-  int max_available_spatial_layer_that_meets_constraints = 0;
-  int max_available_temporal_layer_that_meets_constraints = 0;
-
-  int max_spatial_layer_with_resolution_info = 0;
-  if (video_frame_width_list_.size() > 0 && video_frame_height_list_.size() > 0) {
-    max_spatial_layer_with_resolution_info = std::min(static_cast<int>(video_frame_width_list_.size()) - 1,
-                                                      static_cast<int>(video_frame_height_list_.size()) - 1);
-  }
-  int max_temporal_layer_with_frame_rate_info = std::max(static_cast<int>(video_frame_rate_list_.size()) - 1, 0);
-
-  int max_spatial_layer_available = std::min(max_spatial_layer_with_resolution_info, max_active_spatial_layer_);
-  int max_temporal_layer_available = std::min(max_temporal_layer_with_frame_rate_info, max_active_temporal_layer_);
-
-  //  reset layers
-  for (int spatial_layer = 5; spatial_layer >=0; spatial_layer--) {
-    for (int temporal_layer = 5; temporal_layer >=0; temporal_layer--) {
-      stream_->setBitrateForLayer(spatial_layer, temporal_layer, 0);
-    }
+void QualityManager::maybeUpdateAvailableLayersAndBitrates() {
+  time_point now = clock_->now();
+  if (now - last_activity_check_ > kActiveLayerInterval) {
+    last_activity_check_ = now;
+  } else {
+    return;
   }
 
-  for (int spatial_layer = 0; spatial_layer <= max_spatial_layer_available; spatial_layer++) {
-    for (int temporal_layer = 0; temporal_layer <= max_temporal_layer_available; temporal_layer++) {
-      stream_->setBitrateForLayer(spatial_layer, temporal_layer, getInstantLayerBitrate(spatial_layer, temporal_layer));
-      if (doesLayerMeetConstraints(spatial_layer, temporal_layer)) {
-        max_available_spatial_layer_that_meets_constraints = spatial_layer;
-        max_available_temporal_layer_that_meets_constraints = temporal_layer;
-      }
-    }
-  }
-
-  stream_->setBitrateFromMaxQualityLayer(getInstantLayerBitrate(max_available_spatial_layer_that_meets_constraints,
-                                                                max_available_temporal_layer_that_meets_constraints));
+  calculateMaxActiveLayer();
+  storeLayersAndBitratesInMediaStream();
 }
 
 void QualityManager::selectLayer(bool try_higher_layers) {
@@ -162,7 +138,7 @@ void QualityManager::selectLayer(bool try_higher_layers) {
   }
   stream_->setSimulcast(true);
   last_quality_check_ = clock_->now();
-  calculateMaxBitrateThatMeetsConstraints();
+  maybeUpdateAvailableLayersAndBitrates();
 
   int min_requested_spatial_layer =
     enable_slideshow_below_spatial_layer_ ? std::max(slideshow_below_spatial_layer_, 0) : 0;
@@ -244,6 +220,41 @@ void QualityManager::selectLayer(bool try_higher_layers) {
                                                 CumulativeStat{layer_capped_by_constraints});
 }
 
+void QualityManager::storeLayersAndBitratesInMediaStream() {
+  int max_available_spatial_layer_that_meets_constraints = 0;
+  int max_available_temporal_layer_that_meets_constraints = 0;
+
+  int max_spatial_layer_with_resolution_info = 0;
+  if (video_frame_width_list_.size() > 0 && video_frame_height_list_.size() > 0) {
+    max_spatial_layer_with_resolution_info = std::min(static_cast<int>(video_frame_width_list_.size()) - 1,
+                                                      static_cast<int>(video_frame_height_list_.size()) - 1);
+  }
+  int max_temporal_layer_with_frame_rate_info = std::max(static_cast<int>(video_frame_rate_list_.size()) - 1, 0);
+
+  int max_spatial_layer_available = std::min(max_spatial_layer_with_resolution_info, max_active_spatial_layer_);
+  int max_temporal_layer_available = std::min(max_temporal_layer_with_frame_rate_info, max_active_temporal_layer_);
+
+  //  reset layers
+  for (int spatial_layer = 5; spatial_layer >=0; spatial_layer--) {
+    for (int temporal_layer = 5; temporal_layer >=0; temporal_layer--) {
+      stream_->setBitrateForLayer(spatial_layer, temporal_layer, 0);
+    }
+  }
+
+  for (int spatial_layer = 0; spatial_layer <= max_spatial_layer_available; spatial_layer++) {
+    for (int temporal_layer = 0; temporal_layer <= max_temporal_layer_available; temporal_layer++) {
+      stream_->setBitrateForLayer(spatial_layer, temporal_layer, getMaxLayerBitrateInInterval(spatial_layer, temporal_layer));
+      if (doesLayerMeetConstraints(spatial_layer, temporal_layer)) {
+        max_available_spatial_layer_that_meets_constraints = spatial_layer;
+        max_available_temporal_layer_that_meets_constraints = temporal_layer;
+      }
+    }
+  }
+
+  stream_->setBitrateFromMaxQualityLayer(getMaxLayerBitrateInInterval(max_available_spatial_layer_that_meets_constraints,
+        max_available_temporal_layer_that_meets_constraints));
+}
+
 void QualityManager::calculateMaxActiveLayer() {
   int max_active_spatial_layer = 5;
   int max_active_temporal_layer = 5;
@@ -277,6 +288,17 @@ uint64_t QualityManager::getInstantLayerBitrate(int spatial_layer, int temporal_
   MovingIntervalRateStat* layer_stat =
     reinterpret_cast<MovingIntervalRateStat*>(&stats_->getNode()["qualityLayers"][spatial_layer][temporal_layer]);
   return layer_stat->value(kActiveLayerInterval);
+}
+
+uint64_t QualityManager::getMaxLayerBitrateInInterval(int spatial_layer, int temporal_layer) {
+  if (!stats_->getNode()["qualityLayers"].hasChild(spatial_layer) ||
+      !stats_->getNode()["qualityLayers"][spatial_layer].hasChild(temporal_layer)) {
+    return 0;
+  }
+
+  MovingIntervalRateStat* layer_stat =
+    reinterpret_cast<MovingIntervalRateStat*>(&stats_->getNode()["qualityLayers"][spatial_layer][temporal_layer]);
+  return layer_stat->maxValueForIntervalSize(std::chrono::milliseconds(1000));
 }
 
 bool QualityManager::isInBaseLayer() {

--- a/erizo/src/erizo/rtp/QualityManager.h
+++ b/erizo/src/erizo/rtp/QualityManager.h
@@ -39,9 +39,11 @@ class QualityManager: public Service, public std::enable_shared_from_this<Qualit
 
  private:
   void calculateMaxActiveLayer();
-  void calculateMaxBitrateThatMeetsConstraints();
+  void maybeUpdateAvailableLayersAndBitrates();
+  void storeLayersAndBitratesInMediaStream();
   void selectLayer(bool try_higher_layers);
   uint64_t getInstantLayerBitrate(int spatial_layer, int temporal_layer);
+  uint64_t getMaxLayerBitrateInInterval(int spatial_layer, int temporal_layer);
   bool isInBaseLayer();
   bool isInMaxLayer();
   bool doesLayerMeetConstraints(int spatial_layer, int temporal_layer);

--- a/erizo/src/erizo/stats/StatNode.cpp
+++ b/erizo/src/erizo/stats/StatNode.cpp
@@ -177,13 +177,13 @@ std::string MovingIntervalRateStat::toString() {
   return std::to_string(value());
 }
 
-uint64_t MovingIntervalRateStat::calculateRateForInterval(uint64_t interval_to_calculate_ms) {
+uint64_t MovingIntervalRateStat::calculateRateForInterval(uint64_t interval_to_calculate_ms, uint64_t start_interval_offset_ms) {
   if (!initialized_) {
     return 0;
   }
 
   uint64_t now_ms = ClockUtils::timePointToMs(clock_->now());
-  uint64_t start_of_requested_interval = now_ms - interval_to_calculate_ms;
+  uint64_t start_of_requested_interval = now_ms - interval_to_calculate_ms - start_interval_offset_ms;
   uint64_t interval_start_time = std::max(start_of_requested_interval, current_window_start_ms_);
   uint32_t intervals_to_pass = (interval_start_time - current_window_start_ms_) / interval_size_ms_;
   //  We check if it's within the data we have
@@ -217,6 +217,27 @@ uint64_t MovingIntervalRateStat::calculateRateForInterval(uint64_t interval_to_c
   }
   double rate = static_cast<double> (total_sum) / (now_ms - interval_start_time);
   return (rate * 1000 * scale_);
+}
+
+uint64_t MovingIntervalRateStat::maxValueForIntervalSize(duration requested_interval_size) {
+  if (!initialized_) {
+    return 0;
+  }
+
+  uint64_t requested_interval_size_ms = ClockUtils::durationToMs(requested_interval_size);
+
+  uint64_t window_size_ms = interval_size_ms_ * intervals_in_window_;
+  int64_t interval_offset_ms =
+    std::max(static_cast<int64_t>(window_size_ms - requested_interval_size_ms), static_cast<int64_t>(0));
+  uint64_t max_rate = 0;
+
+  do {
+    uint64_t rate = calculateRateForInterval(requested_interval_size_ms, interval_offset_ms);
+    interval_offset_ms -= requested_interval_size_ms;
+    max_rate = rate > max_rate? rate: max_rate;
+  } while (interval_offset_ms >= 0);
+
+  return max_rate;
 }
 
 uint32_t MovingIntervalRateStat::getIntervalForTimeMs(uint64_t time_ms) {

--- a/erizo/src/erizo/stats/StatNode.cpp
+++ b/erizo/src/erizo/stats/StatNode.cpp
@@ -177,7 +177,8 @@ std::string MovingIntervalRateStat::toString() {
   return std::to_string(value());
 }
 
-uint64_t MovingIntervalRateStat::calculateRateForInterval(uint64_t interval_to_calculate_ms, uint64_t start_interval_offset_ms) {
+uint64_t MovingIntervalRateStat::calculateRateForInterval(uint64_t interval_to_calculate_ms,
+    uint64_t start_interval_offset_ms) {
   if (!initialized_) {
     return 0;
   }

--- a/erizo/src/erizo/stats/StatNode.h
+++ b/erizo/src/erizo/stats/StatNode.h
@@ -128,13 +128,14 @@ class MovingIntervalRateStat : public StatNode {
 
   uint64_t value() override;
   uint64_t value(duration stat_interval);
+  uint64_t maxValueForIntervalSize(duration requested_interval_size);
 
   std::string toString() override;
 
 
  private:
   void add(uint64_t value);
-  uint64_t calculateRateForInterval(uint64_t interval_to_calculate_ms);
+  uint64_t calculateRateForInterval(uint64_t interval_to_calculate_ms, uint64_t start_interval_offset_ms = 0);
   uint32_t getIntervalForTimeMs(uint64_t time_ms);
   uint32_t getNextInterval(uint32_t interval);
   void updateWindowTimes();

--- a/erizo/src/test/bandwidth/StreamPriorityBWDistributor.cpp
+++ b/erizo/src/test/bandwidth/StreamPriorityBWDistributor.cpp
@@ -3,6 +3,7 @@
 
 #include <rtp/RtpHeaders.h>
 #include <rtp/RtpUtils.h>
+#include <rtp/QualityManager.h>
 #include <MediaDefinitions.h>
 #include <bandwidth/StreamPriorityBWDistributor.h>
 #include <bandwidth/BwDistributionConfig.h>
@@ -25,6 +26,7 @@ using testing::Invoke;
 using erizo::DataPacket;
 using erizo::ExtMap;
 using erizo::IceConfig;
+using erizo::QualityManager;
 using erizo::RtpMap;
 using erizo::RtpUtils;
 using erizo::MediaStream;
@@ -48,7 +50,7 @@ struct StreamPriorityConfig {
 typedef std::vector<StreamPriorityConfig> StreamConfigList;
 typedef std::vector<StreamPriorityStep> StrategyVector;
 typedef std::vector<bool>     EnabledList;
-typedef std::vector<int32_t>  ExpectedList;
+typedef std::vector<uint32_t>  ExpectedList;
 
 class BasicStreamPriorityBWDistributorTest {
  protected:
@@ -209,7 +211,8 @@ INSTANTIATE_TEST_CASE_P(
       StreamPriorityStep("0", "0"),
       StreamPriorityStep("20", "1")
       },
-      500, EnabledList{1},    ExpectedList{50}),
+      500, EnabledList{1},    ExpectedList{
+        50}),
     make_tuple(StreamConfigList{{1000, 0, 450, "20",
       std::vector<std::vector<uint64_t>>({ { 100, 150, 200 }, { 250, 300, 450} }), false, true}},
       StrategyVector{
@@ -218,7 +221,8 @@ INSTANTIATE_TEST_CASE_P(
       StreamPriorityStep("0", "0"),
       StreamPriorityStep("20", "1")
       },
-      500, EnabledList{1},    ExpectedList{450}),
+      500, EnabledList{1},    ExpectedList{
+        static_cast<uint32_t>(450 * (1 + QualityManager::kIncreaseLayerBitrateThreshold))}),
     make_tuple(StreamConfigList{{1000, 0, 450, "20",
         std::vector<std::vector<uint64_t>>({ { 100, 150, 200 }, { 250, 300, 450} }), false, true}},
       StrategyVector{
@@ -228,7 +232,8 @@ INSTANTIATE_TEST_CASE_P(
       StreamPriorityStep("20", "1"),
       StreamPriorityStep("20", "2")
       },
-      1500, EnabledList{1},    ExpectedList{450}),
+      1500, EnabledList{1},    ExpectedList{
+        static_cast<uint32_t>(450 * (1 + QualityManager::kIncreaseLayerBitrateThreshold))}),
     make_tuple(StreamConfigList{{1000, 0, 450, "0",
         std::vector<std::vector<uint64_t>>({ { 100, 150, 200 }, { 250, 300, 450} }), false, true}},
       StrategyVector{
@@ -238,7 +243,8 @@ INSTANTIATE_TEST_CASE_P(
       StreamPriorityStep("20", "1"),
       StreamPriorityStep("20", "2")
       },
-      500, EnabledList{1},    ExpectedList{200}),
+      500, EnabledList{1},    ExpectedList{
+        static_cast<uint32_t>(200 * (1 + QualityManager::kIncreaseLayerBitrateThreshold))}),
     make_tuple(StreamConfigList{
       {1000, 0, 450, "0", std::vector<std::vector<uint64_t>>({ { 100, 150, 200 }, { 250, 300, 450} }), false, true},
       {1000, 0, 450, "0", std::vector<std::vector<uint64_t>>({ { 100, 150, 200 }, { 250, 300, 450} }), false, true}
@@ -250,7 +256,9 @@ INSTANTIATE_TEST_CASE_P(
       StreamPriorityStep("20", "1"),
       StreamPriorityStep("20", "2")
       },
-      500, EnabledList{1, 1},    ExpectedList{200, 200}),
+      500, EnabledList{1, 1},    ExpectedList{
+        static_cast<uint32_t>(200 * (1 + QualityManager::kIncreaseLayerBitrateThreshold)),
+        static_cast<uint32_t>(200 * (1 + QualityManager::kIncreaseLayerBitrateThreshold))}),
     make_tuple(StreamConfigList{
       {450, 0, 450, "10", std::vector<std::vector<uint64_t>>({ { 100, 150, 200 }, { 250, 300, 450} }), false, false},
       {1000, 0, 450, "10", std::vector<std::vector<uint64_t>>({ { 100, 150, 200 }, { 250, 300, 450} }), false, true}
@@ -262,7 +270,9 @@ INSTANTIATE_TEST_CASE_P(
       StreamPriorityStep("10", "1"),
       StreamPriorityStep("20", "1")
       },
-      1000, EnabledList{1, 1},    ExpectedList{450, 450}),
+      1000, EnabledList{1, 1},   ExpectedList{
+        450,
+        static_cast<uint32_t>(450 * (1 + QualityManager::kIncreaseLayerBitrateThreshold))}),
     make_tuple(StreamConfigList{
       {450, 0, 450, "10", std::vector<std::vector<uint64_t>>({ { 100, 150, 200 }, { 250, 300, 450} }), false, false},
       {1000, 0, 450, "10", std::vector<std::vector<uint64_t>>({ { 100, 150, 200 }, { 250, 300, 450} }), false, true}
@@ -274,7 +284,9 @@ INSTANTIATE_TEST_CASE_P(
       StreamPriorityStep("10", "1"),
       StreamPriorityStep("20", "1")
       },
-      1000, EnabledList{1, 1},    ExpectedList{450, 450}),
+      1000, EnabledList{1, 1},    ExpectedList{
+        450,
+        static_cast<uint32_t>(450 * (1 + QualityManager::kIncreaseLayerBitrateThreshold))}),
     make_tuple(StreamConfigList{
       {1000, 0, 450, "0", std::vector<std::vector<uint64_t>>({ { 100, 150, 200 }, { 250, 300, 450} }), false, true},
       {1000, 0, 450, "20", std::vector<std::vector<uint64_t>>({ { 100, 150, 200 }, { 250, 300, 450} }), false, true}
@@ -286,7 +298,9 @@ INSTANTIATE_TEST_CASE_P(
       StreamPriorityStep("20", "1"),
       StreamPriorityStep("20", "2")
       },
-      500, EnabledList{1, 1},    ExpectedList{200, 300}),
+      500, EnabledList{1, 1},    ExpectedList{
+        static_cast<uint32_t>(200 * (1 + QualityManager::kIncreaseLayerBitrateThreshold)),
+        280}),
     make_tuple(StreamConfigList{
       {1000, 0, 450, "0", std::vector<std::vector<uint64_t>>({ { 100, 150, 300 }, { 250, 300, 450} }), false, true},
       {1000, 0, 450, "20", std::vector<std::vector<uint64_t>>({ { 100, 150, 200 }, { 250, 300, 450} }), false, true}
@@ -298,7 +312,9 @@ INSTANTIATE_TEST_CASE_P(
       StreamPriorityStep("20", "1"),
       StreamPriorityStep("20", "2")
       },
-      500, EnabledList{1, 1},    ExpectedList{300, 200}),
+      550, EnabledList{1, 1},    ExpectedList{
+        static_cast<uint32_t>(300 * (1 + QualityManager::kIncreaseLayerBitrateThreshold)),
+        static_cast<uint32_t>(200 * (1 + QualityManager::kIncreaseLayerBitrateThreshold))}),
     make_tuple(StreamConfigList{
       {1000, 0, 450, "0", std::vector<std::vector<uint64_t>>({ { 100, 150, 200 }, { 250, 300, 450} }), false, true},
       {1000, 0, 450, "20", std::vector<std::vector<uint64_t>>({ { 100, 150, 200 }, { 250, 300, 450} }), false, true}
@@ -310,7 +326,9 @@ INSTANTIATE_TEST_CASE_P(
       StreamPriorityStep("20", "1"),
       StreamPriorityStep("20", "2")
       },
-      1500, EnabledList{1, 1},    ExpectedList{200, 450}),
+      1500, EnabledList{1, 1},    ExpectedList{
+        static_cast<uint32_t>(200 * (1 + QualityManager::kIncreaseLayerBitrateThreshold)),
+        static_cast<uint32_t>(450 * (1 + QualityManager::kIncreaseLayerBitrateThreshold))}),
     make_tuple(StreamConfigList{
       {1000, 0, 450, "0", std::vector<std::vector<uint64_t>>({ { 100, 150, 300 }, { 250, 300, 450} }), false, true},
       {1000, 0, 450, "20", std::vector<std::vector<uint64_t>>({ { 100, 150, 300 }, { 250, 300, 450} }), false, true}
@@ -322,7 +340,9 @@ INSTANTIATE_TEST_CASE_P(
       StreamPriorityStep("20", "1"),
       StreamPriorityStep("20", "2")
       },
-      500, EnabledList{1, 1},    ExpectedList{200, 300}),
+      500, EnabledList{1, 1},    ExpectedList{
+        170,
+        static_cast<uint32_t>(300 * (1 + QualityManager::kIncreaseLayerBitrateThreshold))}),
     make_tuple(StreamConfigList{
       {1000, 0, 450, "20", std::vector<std::vector<uint64_t>>({ { 100, 150, 300 }, { 250, 300, 450} }), false, true},
       {300, 0, 450, "20", std::vector<std::vector<uint64_t>>({ { 100, 150, 300 }, { 250, 300, 450} }), false, true},
@@ -336,7 +356,11 @@ INSTANTIATE_TEST_CASE_P(
       StreamPriorityStep("20", "1"),
       StreamPriorityStep("20", "2")
       },
-      2500, EnabledList{1, 1, 1, 1},    ExpectedList{450, 300, 300, 300}),
+      2500, EnabledList{1, 1, 1, 1},    ExpectedList{
+        static_cast<uint32_t>(450 * (1 + QualityManager::kIncreaseLayerBitrateThreshold)),
+        300,
+        static_cast<uint32_t>(300 * (1 + QualityManager::kIncreaseLayerBitrateThreshold)),
+        static_cast<uint32_t>(300 * (1 + QualityManager::kIncreaseLayerBitrateThreshold))}),
     make_tuple(StreamConfigList{
       {1000, 0, 450, "20", std::vector<std::vector<uint64_t>>({ { 100, 150, 300 }, { 250, 300, 450} }), false, true},
       {1000, 0, 450, "20", std::vector<std::vector<uint64_t>>({ { 100, 150, 300 }, { 250, 300, 450} }), false, true},
@@ -350,7 +374,11 @@ INSTANTIATE_TEST_CASE_P(
       StreamPriorityStep("20", "1"),
       StreamPriorityStep("20", "2")
       },
-      1000, EnabledList{1, 1, 1, 1},    ExpectedList{300, 300, 200, 200}),
+      1000, EnabledList{1, 1, 1, 1},    ExpectedList{
+        static_cast<uint32_t>(300 * (1 + QualityManager::kIncreaseLayerBitrateThreshold)),
+        static_cast<uint32_t>(300 * (1 + QualityManager::kIncreaseLayerBitrateThreshold)),
+        170,
+        170}),
     make_tuple(StreamConfigList{
       {1000, 0, 450, "20", std::vector<std::vector<uint64_t>>({ { 100, 150, 300 }, { 250, 300, 450} }), false, true},
       {1000, 0, 450, "20", std::vector<std::vector<uint64_t>>({ { 100, 150, 300 }, { 250, 300, 450} }), false, true},


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR improves the use of stats in `StreamPriorityBandwidthDistributor` by:
1. Updating the stats stored in MediaStream more often (every 100ms at most)
2. Improving the stats stored in MediaStream so not only the last 500ms are taken into account but using the highest value for each second inside the 3 second window we are currently using
3. Adding to the calculated desired bitrate the same offset used in `QualityManager`

This PR also updates the tests accordingly. 

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.