### PR TITLE
Support for multiple simulcast configurations for published streams in one connection

### DIFF
--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -122,7 +122,7 @@ class ErizoConnection extends EventEmitterConst {
     log.debug(`message: Adding stream to Connection, ${this.toLog()}, ${stream.toLog()}`);
     this.streamsMap.add(stream.getID(), stream);
     if (stream.local) {
-      this.stack.addStream(stream.stream);
+      this.stack.addStream(stream);
     }
   }
 
@@ -164,12 +164,12 @@ class ErizoConnection extends EventEmitterConst {
     this.stack.updateSpec(configInput, streamId, callback);
   }
 
-  updateSimulcastLayersBitrate(bitrates) {
-    this.stack.updateSimulcastLayersBitrate(bitrates);
+  updateSimulcastLayersBitrate(bitrates, licodeStream) {
+    this.stack.updateSimulcastLayersBitrate(bitrates, licodeStream);
   }
 
-  updateSimulcastActiveLayers(layersInfo) {
-    this.stack.updateSimulcastActiveLayers(layersInfo);
+  updateSimulcastActiveLayers(layersInfo, licodeStream) {
+    this.stack.updateSimulcastActiveLayers(layersInfo, licodeStream);
   }
 
   setQualityLevel(level) {

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -252,7 +252,6 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       isRemote,
     };
     if (!isRemote) {
-      connectionOpts.simulcast = options.simulcast;
       connectionOpts.startVideoBW = options.startVideoBW;
       connectionOpts.hardMinVideoBW = options.hardMinVideoBW;
     }
@@ -283,6 +282,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
   const createLocalStreamErizoConnection = (streamInput, connectionId, erizoId, options) => {
     const stream = streamInput;
     const connectionOpts = getErizoConnectionOptions(stream, connectionId, erizoId, options);
+    stream.setSimulcastConfig(options.simulcast);
     const connection = that.erizoConnectionManager
       .getOrBuildErizoConnection(connectionOpts, erizoId, spec.singlePC);
     stream.addPC(connection);

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -37,6 +37,7 @@ const Stream = (altConnectionHelpers, specInput) => {
     callbackReceived: false,
     pcEventReceived: false,
   };
+  that.simulcast = {};
   that.p2p = false;
   that.ConnectionHelpers =
     altConnectionHelpers === undefined ? ConnectionHelpers : altConnectionHelpers;
@@ -129,6 +130,16 @@ const Stream = (altConnectionHelpers, specInput) => {
   that.hasMedia = () => spec.audio || spec.video || spec.screen;
 
   that.isExternal = () => that.url !== undefined || that.recording !== undefined;
+  that.hasSimulcast = () => Object.keys(that.simulcast).length !== 0;
+  that.setSimulcastConfig = (simulcast) => {
+    that.simulcast = Object.assign(that.simulcast, simulcast);
+  };
+  that.getSimulcastConfig = () => that.simulcast;
+  that.setSpatialLayersConfigs = (config) => {
+    if (that.hasSimulcast()) {
+      that.simulcast.spatialLayerConfigs = config;
+    }
+  };
 
   that.addPC = (pc, p2pKey = undefined) => {
     if (p2pKey) {
@@ -494,13 +505,13 @@ const Stream = (altConnectionHelpers, specInput) => {
 
   that.updateSimulcastLayersBitrate = (bitrates) => {
     if (that.pc && that.local) {
-      that.pc.updateSimulcastLayersBitrate(bitrates);
+      that.pc.updateSimulcastLayersBitrate(bitrates, that);
     }
   };
 
   that.updateSimulcastActiveLayers = (layersInfo) => {
     if (that.pc && that.local) {
-      that.pc.updateSimulcastActiveLayers(layersInfo);
+      that.pc.updateSimulcastActiveLayers(layersInfo, that);
     }
   };
 

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -246,7 +246,7 @@ const BaseStack = (specInput) => {
     nativeStream.transceivers = [];
     nativeStream.getTracks().forEach(async (track) => {
       let options = {};
-      if (track.kind === 'video' && streamInput.getSimulcastConfig()) {
+      if (track.kind === 'video' && streamInput.hasSimulcast()) {
         options = {
           sendEncodings: getSimulcastParameters(streamInput),
         };

--- a/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
@@ -14,64 +14,6 @@ const ChromeStableStack = (specInput) => {
     offerToReceiveAudio: true,
   };
 
-  that.enableSimulcast = (sdpInput) => {
-    let result;
-    let sdp = sdpInput;
-    if (!that.simulcast) {
-      return sdp;
-    }
-    const hasAlreadySetSimulcast = sdp.match(new RegExp('a=ssrc-group:SIM', 'g')) !== null;
-    if (hasAlreadySetSimulcast) {
-      return sdp;
-    }
-    // TODO(javier): Improve the way we check for current video ssrcs
-    const matchGroup = sdp.match(/a=ssrc-group:FID ([0-9]*) ([0-9]*)\r?\n/);
-    if (!matchGroup || (matchGroup.length <= 0)) {
-      return sdp;
-    }
-    // TODO (pedro): Consider adding these to SdpHelpers
-    const numSpatialLayers = that.simulcast.numSpatialLayers || defaultSimulcastSpatialLayers;
-    const baseSsrc = parseInt(matchGroup[1], 10);
-    const baseSsrcRtx = parseInt(matchGroup[2], 10);
-    const cname = sdp.match(new RegExp(`a=ssrc:${matchGroup[1]} cname:(.*)\r?\n`))[1];
-    const msid = sdp.match(new RegExp(`a=ssrc:${matchGroup[1]} msid:(.*)\r?\n`))[1];
-    const mslabel = sdp.match(new RegExp(`a=ssrc:${matchGroup[1]} mslabel:(.*)\r?\n`))[1];
-    const label = sdp.match(new RegExp(`a=ssrc:${matchGroup[1]} label:(.*)\r?\n`))[1];
-
-    sdp.match(new RegExp(`a=ssrc:${matchGroup[1]}.*\r?\n`, 'g')).forEach((line) => {
-      sdp = sdp.replace(line, '');
-    });
-    sdp.match(new RegExp(`a=ssrc:${matchGroup[2]}.*\r?\n`, 'g')).forEach((line) => {
-      sdp = sdp.replace(line, '');
-    });
-
-    const spatialLayers = [baseSsrc];
-    const spatialLayersRtx = [baseSsrcRtx];
-
-    for (let i = 1; i < numSpatialLayers; i += 1) {
-      spatialLayers.push(baseSsrc + (i * 1000));
-      spatialLayersRtx.push(baseSsrcRtx + (i * 1000));
-    }
-
-    result = SdpHelpers.addSim(spatialLayers);
-    let spatialLayerId;
-    let spatialLayerIdRtx;
-    for (let i = 0; i < spatialLayers.length; i += 1) {
-      spatialLayerId = spatialLayers[i];
-      spatialLayerIdRtx = spatialLayersRtx[i];
-      result += SdpHelpers.addGroup(spatialLayerId, spatialLayerIdRtx);
-    }
-
-    for (let i = 0; i < spatialLayers.length; i += 1) {
-      spatialLayerId = spatialLayers[i];
-      spatialLayerIdRtx = spatialLayersRtx[i];
-      result += SdpHelpers.addSpatialLayer(cname,
-        msid, mslabel, label, spatialLayerId, spatialLayerIdRtx);
-    }
-    result += 'a=x-google-flag:conference\r\n';
-    return sdp.replace(matchGroup[0], result);
-  };
-
   const configureParameter = (parameters, config, layerId) => {
     if (parameters.encodings[layerId] === undefined ||
         config[layerId] === undefined) {
@@ -85,16 +27,17 @@ const ChromeStableStack = (specInput) => {
     return newParameters;
   };
 
-  const setBitrateForVideoLayers = (sender) => {
+  const setBitrateForVideoLayers = (sender, streamInput) => {
     if (typeof sender.getParameters !== 'function' || typeof sender.setParameters !== 'function') {
       log.warning('message: Cannot set simulcast layers bitrate, reason: get/setParameters not available');
       return;
     }
     let parameters = sender.getParameters();
-    Object.keys(that.simulcast.spatialLayerConfigs).forEach((layerId) => {
+    const spatialLayerConfigs = streamInput.getSimulcastConfig().spatialLayerConfigs;
+    Object.keys(spatialLayerConfigs).forEach((layerId) => {
       if (parameters.encodings[layerId] !== undefined) {
-        log.debug(`message: Configure parameters for layer, layer: ${layerId}, config: ${that.simulcast.spatialLayerConfigs[layerId]}`);
-        parameters = configureParameter(parameters, that.simulcast.spatialLayerConfigs, layerId);
+        log.warning(`message: Configure parameters for layer, layer: ${layerId}, config: ${spatialLayerConfigs[layerId]}`);
+        parameters = configureParameter(parameters, spatialLayerConfigs, layerId);
       }
     });
     sender.setParameters(parameters)
@@ -108,12 +51,12 @@ const ChromeStableStack = (specInput) => {
 
   that.prepareCreateOffer = () => Promise.resolve();
 
-  that.setSimulcastLayersConfig = () => {
+  that.setSimulcastLayersConfig = (streamInput) => {
     log.debug(`message: Maybe set simulcast Layers config, simulcast: ${JSON.stringify(that.simulcast)}`);
-    if (that.simulcast && that.simulcast.spatialLayerConfigs) {
-      that.peerConnection.getSenders().forEach((sender) => {
-        if (sender.track.kind === 'video') {
-          setBitrateForVideoLayers(sender);
+    if (streamInput.getSimulcastConfig()) {
+      streamInput.stream.transceivers.forEach((transceiver) => {
+        if (transceiver.sender.track.kind === 'video') {
+          setBitrateForVideoLayers(transceiver.sender, streamInput);
         }
       });
     }

--- a/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/ChromeStableStack.js
@@ -8,59 +8,12 @@ const ChromeStableStack = (specInput) => {
   log.debug(`message: Starting Chrome stable stack, spec: ${JSON.stringify(specInput)}`);
   const spec = specInput;
   const that = BaseStack(specInput);
-  const defaultSimulcastSpatialLayers = 2;
   that.mediaConstraints = {
     offerToReceiveVideo: true,
     offerToReceiveAudio: true,
   };
 
-  const configureParameter = (parameters, config, layerId) => {
-    if (parameters.encodings[layerId] === undefined ||
-        config[layerId] === undefined) {
-      return parameters;
-    }
-    const newParameters = parameters;
-    newParameters.encodings[layerId].maxBitrate = config[layerId].maxBitrate;
-    if (config[layerId].active !== undefined) {
-      newParameters.encodings[layerId].active = config[layerId].active;
-    }
-    return newParameters;
-  };
-
-  const setBitrateForVideoLayers = (sender, streamInput) => {
-    if (typeof sender.getParameters !== 'function' || typeof sender.setParameters !== 'function') {
-      log.warning('message: Cannot set simulcast layers bitrate, reason: get/setParameters not available');
-      return;
-    }
-    let parameters = sender.getParameters();
-    const spatialLayerConfigs = streamInput.getSimulcastConfig().spatialLayerConfigs;
-    Object.keys(spatialLayerConfigs).forEach((layerId) => {
-      if (parameters.encodings[layerId] !== undefined) {
-        log.warning(`message: Configure parameters for layer, layer: ${layerId}, config: ${spatialLayerConfigs[layerId]}`);
-        parameters = configureParameter(parameters, spatialLayerConfigs, layerId);
-      }
-    });
-    sender.setParameters(parameters)
-      .then((result) => {
-        log.debug(`message: Success setting simulcast layer configs, result: ${result}`);
-      })
-      .catch((e) => {
-        log.warning(`message: Error setting simulcast layer configs, error: ${e}`);
-      });
-  };
-
   that.prepareCreateOffer = () => Promise.resolve();
-
-  that.setSimulcastLayersConfig = (streamInput) => {
-    log.debug(`message: Maybe set simulcast Layers config, simulcast: ${JSON.stringify(that.simulcast)}`);
-    if (streamInput.getSimulcastConfig()) {
-      streamInput.stream.transceivers.forEach((transceiver) => {
-        if (transceiver.sender.track.kind === 'video') {
-          setBitrateForVideoLayers(transceiver.sender, streamInput);
-        }
-      });
-    }
-  };
 
   that.setStartVideoBW = (sdpInfo) => {
     if (that.video && spec.startVideoBW) {


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR moves simulcast configuration from the Stacks to Streams. That allows for publishing multiple simulcast streams with different configurations in the same connection.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.