### PR TITLE
Fix mediaStream priority initialization

### DIFF
--- a/erizoAPI/MediaStream.cc
+++ b/erizoAPI/MediaStream.cc
@@ -215,7 +215,7 @@ NAN_METHOD(MediaStream::New) {
     if (info.Length() > 8) {
       Nan::Utf8String paramPriority(Nan::To<v8::String>(info[8]).ToLocalChecked());
       priority = std::string(*paramPriority);
-      if (priority == "undefined") {
+      if (priority == "undefined" || priority == "") {
         priority = "default";
       }
     }


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR fixes an issue where a mediaStream would be initialized with an empty string when no priority is passed to erizoAPI constructor

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.