### PR TITLE
Add/stream switch handler

### DIFF
--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -31,6 +31,21 @@
 
 namespace erizo {
 
+class MediaStreamSwitchEvent : public MediaEvent {
+ public:
+  explicit MediaStreamSwitchEvent(bool has_audio, bool has_video) : has_audio_{has_audio}, has_video_{has_video} {}
+
+  std::string getType() const override {
+    return "MediaStreamSwitchEvent";
+  }
+  bool hasAudio() { return has_audio_; }
+  bool hasVideo() { return has_video_; }
+
+ private:
+  bool has_audio_;
+  bool has_video_;
+};
+
 class MediaStreamStatsListener {
  public:
     virtual ~MediaStreamStatsListener() {

--- a/erizo/src/erizo/OneToManyProcessor.cpp
+++ b/erizo/src/erizo/OneToManyProcessor.cpp
@@ -166,6 +166,7 @@ namespace erizo {
         subscribers_.erase(peer_id);
     }
     subscribers_[peer_id] = subscriber_stream;
+    subscriber_stream->deliverEvent(std::make_shared<MediaStreamSwitchEvent>(true, true));
   }
 
   std::shared_ptr<MediaSink> OneToManyProcessor::getSubscriber(const std::string& peer_id) {

--- a/erizo/src/erizo/SdpInfo.cpp
+++ b/erizo/src/erizo/SdpInfo.cpp
@@ -105,7 +105,17 @@ namespace erizo {
     return nullptr;
   }
 
-  RtpMap *SdpInfo::getCodecByName(const std::string codecName, const unsigned int clockRate) {
+  RtpMap *SdpInfo::getCodecByName(const std::string codecName) {
+    for (unsigned int it = 0; it < internalPayloadVector_.size(); it++) {
+      RtpMap& rtp = internalPayloadVector_[it];
+      if (rtp.encoding_name == codecName) {
+        return &rtp;
+      }
+    }
+    return NULL;
+  }
+
+  RtpMap *SdpInfo::getCodecByNameAndClockRate(const std::string codecName, const unsigned int clockRate) {
     for (unsigned int it = 0; it < internalPayloadVector_.size(); it++) {
       RtpMap& rtp = internalPayloadVector_[it];
       if (rtp.encoding_name == codecName && rtp.clock_rate == clockRate) {
@@ -116,7 +126,7 @@ namespace erizo {
   }
 
   bool SdpInfo::supportCodecByName(const std::string codecName, const unsigned int clockRate) {
-    RtpMap *rtp = getCodecByName(codecName, clockRate);
+    RtpMap *rtp = getCodecByNameAndClockRate(codecName, clockRate);
     if (rtp != NULL) {
       return supportPayloadType(rtp->payload_type);
     }

--- a/erizo/src/erizo/SdpInfo.h
+++ b/erizo/src/erizo/SdpInfo.h
@@ -271,7 +271,9 @@ class SdpInfo {
 
   std::string getPassword(MediaType media) const;
 
-  RtpMap* getCodecByName(const std::string codecName, const unsigned int clockRate);
+  RtpMap* getCodecByName(const std::string codecName);
+
+  RtpMap* getCodecByNameAndClockRate(const std::string codecName, const unsigned int clockRate);
 
   bool supportCodecByName(const std::string codecName, const unsigned int clockRate);
 

--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
@@ -111,6 +111,9 @@ void BandwidthEstimationHandler::updateExtensionMap(bool is_video, std::array<RT
     switch (extension) {
       case RTP_ID:
       case MID:
+      case VIDEO_CONTENT_TYPE:
+      case VIDEO_TIMING:
+      case COLOR_SPACE:
       case UNKNOWN:
         continue;
         break;

--- a/erizo/src/erizo/rtp/FakeKeyframeGeneratorHandler.cpp
+++ b/erizo/src/erizo/rtp/FakeKeyframeGeneratorHandler.cpp
@@ -26,6 +26,14 @@ void FakeKeyframeGeneratorHandler::disable() {
   enabled_ = false;
 }
 
+void FakeKeyframeGeneratorHandler::notifyEvent(MediaEventPtr event) {
+  if (event->getType() == "MediaStreamSwitchEvent") {
+    ELOG_WARN("Swithing streams in BlackKeyframe generator");
+    first_keyframe_received_ = false;
+    plis_scheduled_ = false;
+  }
+}
+
 void FakeKeyframeGeneratorHandler::notifyUpdate() {
   auto pipeline = getContext()->getPipelineShared();
   if (pipeline && !stream_) {

--- a/erizo/src/erizo/rtp/FakeKeyframeGeneratorHandler.cpp
+++ b/erizo/src/erizo/rtp/FakeKeyframeGeneratorHandler.cpp
@@ -26,14 +26,6 @@ void FakeKeyframeGeneratorHandler::disable() {
   enabled_ = false;
 }
 
-void FakeKeyframeGeneratorHandler::notifyEvent(MediaEventPtr event) {
-  if (event->getType() == "MediaStreamSwitchEvent") {
-    ELOG_WARN("Swithing streams in BlackKeyframe generator");
-    first_keyframe_received_ = false;
-    plis_scheduled_ = false;
-  }
-}
-
 void FakeKeyframeGeneratorHandler::notifyUpdate() {
   auto pipeline = getContext()->getPipelineShared();
   if (pipeline && !stream_) {

--- a/erizo/src/erizo/rtp/FakeKeyframeGeneratorHandler.h
+++ b/erizo/src/erizo/rtp/FakeKeyframeGeneratorHandler.h
@@ -31,7 +31,6 @@ class FakeKeyframeGeneratorHandler: public Handler, public std::enable_shared_fr
   void read(Context *ctx, std::shared_ptr<DataPacket> packet) override;
   void write(Context *ctx, std::shared_ptr<DataPacket> packet) override;
   void notifyUpdate() override;
-  void notifyEvent(MediaEventPtr event) override;
 
  private:
   std::shared_ptr<DataPacket> transformIntoKeyframePacket(std::shared_ptr<DataPacket> packet);

--- a/erizo/src/erizo/rtp/FakeKeyframeGeneratorHandler.h
+++ b/erizo/src/erizo/rtp/FakeKeyframeGeneratorHandler.h
@@ -31,6 +31,7 @@ class FakeKeyframeGeneratorHandler: public Handler, public std::enable_shared_fr
   void read(Context *ctx, std::shared_ptr<DataPacket> packet) override;
   void write(Context *ctx, std::shared_ptr<DataPacket> packet) override;
   void notifyUpdate() override;
+  void notifyEvent(MediaEventPtr event) override;
 
  private:
   std::shared_ptr<DataPacket> transformIntoKeyframePacket(std::shared_ptr<DataPacket> packet);

--- a/erizo/src/erizo/rtp/QualityFilterHandler.cpp
+++ b/erizo/src/erizo/rtp/QualityFilterHandler.cpp
@@ -122,6 +122,7 @@ void QualityFilterHandler::updatePictureID(const std::shared_ptr<DataPacket> &pa
     RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
     unsigned char* start_buffer = reinterpret_cast<unsigned char*> (packet->data);
     start_buffer = start_buffer + rtp_header->getHeaderLength();
+    packet->picture_id = new_picture_id;
     RtpVP8Parser::setVP8PictureID(start_buffer, packet->length - rtp_header->getHeaderLength(), new_picture_id);
   }
 }
@@ -131,6 +132,7 @@ void QualityFilterHandler::updateTL0PicIdx(const std::shared_ptr<DataPacket> &pa
     RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
     unsigned char* start_buffer = reinterpret_cast<unsigned char*> (packet->data);
     start_buffer = start_buffer + rtp_header->getHeaderLength();
+    packet->tl0_pic_idx = new_tl0_pic_idx;
     RtpVP8Parser::setVP8TL0PicIdx(start_buffer, packet->length - rtp_header->getHeaderLength(), new_tl0_pic_idx);
   }
 }
@@ -233,8 +235,9 @@ void QualityFilterHandler::write(Context *ctx, std::shared_ptr<DataPacket> packe
       chead->setTimestamp(sr_timestamp + timestamp_offset_);
     }
     */
+   ELOG_DEBUG("         packet, ssrc: %u, sn: %u, ts: %u, pid: %d, tl0pic: %d, keyframe: %d",
+        ssrc, sequence_number_info.output, last_timestamp_sent_, picture_id_info.output, tl0_pic_idx_sent, packet->is_keyframe);
   }
-
   ctx->fireWrite(packet);
 }
 

--- a/erizo/src/erizo/rtp/RtpExtensionProcessor.h
+++ b/erizo/src/erizo/rtp/RtpExtensionProcessor.h
@@ -21,7 +21,10 @@ enum RTPExtensions {
   TRANSPORT_CC,         // http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
   PLAYBACK_TIME,        // http:// www.webrtc.org/experiments/rtp-hdrext/playout-delay
   RTP_ID,               // urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
-  MID                   // urn:ietf:params:rtp-hdrext:sdes:mid
+  MID,                  // urn:ietf:params:rtp-hdrext:sdes:mid
+  VIDEO_CONTENT_TYPE,   // http://www.webrtc.org/experiments/rtp-hdrext/video-content-type
+  VIDEO_TIMING,         // http://www.webrtc.org/experiments/rtp-hdrext/video-timing
+  COLOR_SPACE           // http://www.webrtc.org/experiments/rtp-hdrext/color-space
 };
 
 class RtpExtensionProcessor{

--- a/erizo/src/erizo/rtp/RtpUtils.cpp
+++ b/erizo/src/erizo/rtp/RtpUtils.cpp
@@ -242,8 +242,8 @@ std::shared_ptr<DataPacket> RtpUtils::makeVP8BlackKeyframePacket(std::shared_ptr
   keyframe_packet->priority = packet->priority;
   keyframe_packet->received_time_ms = packet->received_time_ms;
   keyframe_packet->compatible_spatial_layers = packet->compatible_spatial_layers;
-  keyframe_packet->compatible_temporal_layers = packet->compatible_temporal_layers;
-  keyframe_packet->ending_of_layer_frame = packet->ending_of_layer_frame;
+  keyframe_packet->compatible_temporal_layers = packet->compatible_spatial_layers;
+  keyframe_packet->ending_of_layer_frame = true;
   keyframe_packet->codec = packet->codec;
   keyframe_packet->clock_rate = packet->clock_rate;
   keyframe_packet->is_padding = packet->is_padding;

--- a/erizo/src/erizo/rtp/RtpUtils.h
+++ b/erizo/src/erizo/rtp/RtpUtils.h
@@ -38,6 +38,15 @@ class RtpUtils {
 
   static std::shared_ptr<DataPacket> makePaddingPacket(std::shared_ptr<DataPacket> packet, uint8_t padding_size);
   static std::shared_ptr<DataPacket> makeVP8BlackKeyframePacket(std::shared_ptr<DataPacket> packet);
+  std::shared_ptr<DataPacket> createVP8BlackKeyframePacket(
+    unsigned int pt,
+    uint16_t seq_number,
+    uint32_t wall_clock_timestamp,
+    uint32_t ssrc,
+    std::string codec_name,
+    unsigned int clock_rate,
+    std::string rid,
+    std::string mid);
 };
 
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/RtpVP8Parser.cpp
+++ b/erizo/src/erizo/rtp/RtpVP8Parser.cpp
@@ -390,11 +390,6 @@ RTPPayloadVP8* RtpVP8Parser::parseVP8(unsigned char* data, int dataLength) {
   } else {
     vp8->frameType = kVP8PFrame;
   }
-  if (0 == ParseVP8FrameSize(vp8, dataPtr, dataLength)) {
-    if (vp8->frameWidth != 640) {
-      ELOG_WARN("VP8 Frame width changed! = %d need postprocessing", vp8->frameWidth);
-    }
-  }
   vp8->data = dataPtr;
   vp8->dataLength = (unsigned int) dataLength;
 

--- a/erizo/src/erizo/rtp/StreamSwitchHandler.cpp
+++ b/erizo/src/erizo/rtp/StreamSwitchHandler.cpp
@@ -1,0 +1,176 @@
+#include "rtp/StreamSwitchHandler.h"
+
+#include <string>
+
+#include "./MediaDefinitions.h"
+#include "./MediaStream.h"
+#include "rtp/RtpUtils.h"
+#include "rtp/RtpVP8Parser.h"
+
+namespace erizo {
+
+constexpr uint64_t kKeyframePeriodMs = 3000;
+
+DEFINE_LOGGER(StreamSwitchHandler, "rtp.StreamSwitchHandler");
+
+StreamSwitchHandler::StreamSwitchHandler(std::shared_ptr<erizo::Clock> the_clock)
+  : stream_{nullptr}, video_ssrc_{0}, generate_video_{false}, generated_seq_number_{0}, clock_{the_clock} {}
+
+void StreamSwitchHandler::enable() {}
+
+void StreamSwitchHandler::disable() {}
+
+void StreamSwitchHandler::notifyUpdate() {
+  if (stream_) {
+    return;
+  }
+  auto pipeline = getContext()->getPipelineShared();
+  stream_ = pipeline->getService<MediaStream>().get();
+  video_ssrc_ = stream_->getVideoSourceSSRC();
+  std::shared_ptr<SdpInfo> remote_sdp = stream_->getRemoteSdpInfo();
+  RtpMap *pt = remote_sdp->getCodecByName("VP8");
+  if (!pt) {
+    pt = remote_sdp->getCodecByName("VP9");
+  }
+  if (!pt) {
+    pt = remote_sdp->getCodecByName("H264");
+  }
+  if (pt) {
+    video_pt_ = pt->payload_type;
+    video_codec_name_ = pt->encoding_name;
+    video_clock_rate_ = pt->clock_rate;
+  }
+}
+
+void StreamSwitchHandler::notifyEvent(MediaEventPtr event) {
+  if (event->getType() == "MediaStreamSwitchEvent") {
+    auto media_stream_switch_event = std::static_pointer_cast<MediaStreamSwitchEvent>(event);
+    std::for_each(state_map_.begin(), state_map_.end(),
+      [this] (std::pair<const unsigned int, std::shared_ptr<TrackState>> state_pair) {
+        ELOG_DEBUG("Mark as switched SSRC %u", state_pair.first);
+        if (state_pair.second->last_packet) {
+          sendBlackKeyframe(state_pair.second->last_packet);
+          state_pair.second->last_packet.reset();
+        }
+        state_pair.second->switched = true;
+      });
+    // DeliverEvent to show bitrate per layer.
+  }
+}
+
+void StreamSwitchHandler::sendBlackKeyframe(std::shared_ptr<DataPacket> incoming_packet) {
+  if (incoming_packet->codec == "VP8") {
+    auto packet = RtpUtils::makeVP8BlackKeyframePacket(incoming_packet);
+    // packet->is_keyframe = false;
+    packet->picture_id++;
+    packet->tl0_pic_idx++;
+    RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
+    uint16_t sequence_number = rtp_header->getSeqNumber();
+    uint32_t new_timestamp = rtp_header->getTimestamp();
+    rtp_header->setSeqNumber(sequence_number + 1);
+    rtp_header->setTimestamp(new_timestamp + 1);
+    ELOG_WARN("Sending keyframe before switch");
+    // write(getContext(), packet);
+  }
+}
+
+void StreamSwitchHandler::read(Context *ctx, std::shared_ptr<DataPacket> packet) {
+  ctx->fireRead(std::move(packet));
+}
+
+uint32_t StreamSwitchHandler::getNow() {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+          clock_->now().time_since_epoch())
+          .count();
+}
+
+void StreamSwitchHandler::write(Context *ctx, std::shared_ptr<DataPacket> packet) {
+  RtcpHeader *chead = reinterpret_cast<RtcpHeader*>(packet->data);
+  if (!chead->isRtcp()) {
+    uint32_t now = getNow();
+    RtpHeader *rtp_header = reinterpret_cast<RtpHeader*>(packet->data);
+    uint32_t ssrc = rtp_header->getSSRC();
+    uint16_t sequence_number = rtp_header->getSeqNumber();
+    uint32_t new_timestamp = rtp_header->getTimestamp();
+    int picture_id = 0;
+    uint8_t tl0_pic_idx = 0;
+    packetType type = packet->type;
+    if (type == VIDEO_PACKET) {
+      picture_id = packet->picture_id;
+      tl0_pic_idx = packet->tl0_pic_idx;
+    }
+    std::shared_ptr<TrackState> state = getStateForSsrc(ssrc, true);
+    if (state->switched) {
+      ELOG_DEBUG("Switching SSRC %u", ssrc);
+      state->switched = false;
+      state->sequence_number_translator.reset();
+      state->picture_id_translator.reset();
+      if (state->last_timestamp_sent > 0) {
+        uint32_t time_with_silence = now - state->last_timestamp_sent_at;
+        ELOG_WARN("Adding silence of %d, %d", time_with_silence, state->clock_rate);
+        if (state->clock_rate > 0) {
+          time_with_silence = time_with_silence * state->clock_rate / 1000;
+        }
+        state->timestamp_offset = state->last_timestamp_sent - new_timestamp + 1 + time_with_silence;
+      }
+      if (state->last_tl0_pic_idx_sent > 0) {
+        state->tl0_pic_idx_offset = state->last_tl0_pic_idx_sent - tl0_pic_idx + 1;
+      }
+    }
+    // ELOG_DEBUG("Incoming packet, ssrc: %u, sn: %u, ts: %u, pid: %d, tl0pic: %d",
+    //   ssrc, sequence_number, new_timestamp, picture_id, tl0_pic_idx);
+
+    SequenceNumber sequence_number_info = state->sequence_number_translator.get(sequence_number, false);
+    if (sequence_number_info.type != SequenceNumberType::Valid) {
+      return;
+    }
+
+    if (type == VIDEO_PACKET) {
+      state->last_packet = std::make_shared<DataPacket>(*packet);
+      state->last_packet->picture_id = packet->picture_id;
+      state->last_packet->tl0_pic_idx = packet->tl0_pic_idx;
+    }
+
+    rtp_header->setSeqNumber(sequence_number_info.output);
+
+    state->last_timestamp_sent = new_timestamp + state->timestamp_offset;
+    state->last_timestamp_sent_at = now;
+    state->clock_rate = packet->clock_rate;
+    rtp_header->setTimestamp(state->last_timestamp_sent);
+
+    if (type == VIDEO_PACKET) {
+      SequenceNumber picture_id_info = state->picture_id_translator.get(picture_id, false);
+      if (picture_id_info.type != SequenceNumberType::Valid) {
+        return;
+      }
+
+      packet->picture_id = picture_id_info.output & 0x7FFF;
+
+      uint8_t tl0_pic_idx_sent = tl0_pic_idx + state->tl0_pic_idx_offset;
+      state->last_tl0_pic_idx_sent = RtpUtils::numberLessThan(state->last_tl0_pic_idx_sent, tl0_pic_idx_sent, 8) ?
+        tl0_pic_idx_sent : state->last_tl0_pic_idx_sent;
+      packet->tl0_pic_idx = tl0_pic_idx_sent;
+      tl0_pic_idx = tl0_pic_idx_sent;
+      picture_id = picture_id_info.output;
+    }
+    ELOG_DEBUG("         packet, ssrc: %u, sn: %u, ts: %u, pid: %d, tl0pic: %d, keyframe: %d",
+        ssrc, sequence_number_info.output, state->last_timestamp_sent, picture_id, tl0_pic_idx, packet->is_keyframe);
+  }
+  ctx->fireWrite(std::move(packet));
+}
+
+std::shared_ptr<TrackState> StreamSwitchHandler::getStateForSsrc(uint32_t ssrc,
+    bool should_create) {
+  auto state_it = state_map_.find(ssrc);
+  std::shared_ptr<TrackState> state;
+  if (state_it != state_map_.end()) {
+      // ELOG_DEBUG("Found Translator for %u, %s", ssrc, stream_->toLog());
+      state = state_it->second;
+  } else if (should_create) {
+      ELOG_DEBUG("message: no Translator found creating a new one, ssrc: %u, %s", ssrc, stream_->toLog());
+      state = std::make_shared<TrackState>();
+      state_map_[ssrc] = state;
+  }
+  return state;
+}
+}  // namespace erizo

--- a/erizo/src/erizo/rtp/StreamSwitchHandler.h
+++ b/erizo/src/erizo/rtp/StreamSwitchHandler.h
@@ -1,0 +1,75 @@
+#ifndef ERIZO_SRC_ERIZO_RTP_STREAMSWITCHHANDLER_H_
+#define ERIZO_SRC_ERIZO_RTP_STREAMSWITCHHANDLER_H_
+
+#include <string>
+
+#include "./logger.h"
+#include "pipeline/Handler.h"
+#include "rtp/SequenceNumberTranslator.h"
+#include "lib/ClockUtils.h"
+
+namespace erizo {
+
+class MediaStream;
+
+class TrackState {
+ public:
+  TrackState() :
+    switched{false},
+    timestamp_offset{0},
+    last_timestamp_sent{0},
+    last_timestamp_sent_at{0},
+    tl0_pic_idx_offset{0},
+    last_tl0_pic_idx_sent{0},
+    clock_rate{1} {}
+ public:
+  SequenceNumberTranslator sequence_number_translator;
+  SequenceNumberTranslator picture_id_translator;
+  bool switched;
+  uint32_t timestamp_offset;
+  uint32_t last_timestamp_sent;
+  uint32_t last_timestamp_sent_at;
+  uint8_t tl0_pic_idx_offset;
+  uint8_t last_tl0_pic_idx_sent;
+  uint32_t clock_rate;
+  std::shared_ptr<DataPacket> last_packet;
+};
+
+class StreamSwitchHandler: public Handler, public std::enable_shared_from_this<StreamSwitchHandler> {
+  DECLARE_LOGGER();
+
+ public:
+  StreamSwitchHandler(std::shared_ptr<erizo::Clock> the_clock = std::make_shared<SteadyClock>());
+
+  void enable() override;
+  void disable() override;
+
+  std::string getName() override {
+    return "stream-switch-handler";
+  }
+
+  void read(Context *ctx, std::shared_ptr<DataPacket> packet) override;
+  void write(Context *ctx, std::shared_ptr<DataPacket> packet) override;
+  void notifyUpdate() override;
+  void notifyEvent(MediaEventPtr event) override;
+
+ private:
+  std::shared_ptr<TrackState> getStateForSsrc(uint32_t ssrc, bool should_create);
+  void sendBlackKeyframe(std::shared_ptr<DataPacket> packet);
+  uint32_t getNow();
+
+ private:
+  MediaStream* stream_;
+  std::map<uint32_t, std::shared_ptr<TrackState>> state_map_;
+  uint32_t video_ssrc_;
+  bool generate_video_;
+  unsigned int video_pt_;
+  std::string video_codec_name_;
+  unsigned int video_clock_rate_;
+  uint16_t generated_seq_number_;
+  std::shared_ptr<erizo::Clock> clock_;
+};
+
+}  // namespace erizo
+
+#endif  // ERIZO_SRC_ERIZO_RTP_STREAMSWITCHHANDLER_H_

--- a/erizo/src/erizo/rtp/StreamSwitchHandler.h
+++ b/erizo/src/erizo/rtp/StreamSwitchHandler.h
@@ -21,7 +21,9 @@ class TrackState {
     last_timestamp_sent_at{0},
     tl0_pic_idx_offset{0},
     last_tl0_pic_idx_sent{0},
-    clock_rate{1} {}
+    clock_rate{1},
+    keyframe_received{false},
+    frame_received{false} {}
  public:
   SequenceNumberTranslator sequence_number_translator;
   SequenceNumberTranslator picture_id_translator;
@@ -33,6 +35,8 @@ class TrackState {
   uint8_t last_tl0_pic_idx_sent;
   uint32_t clock_rate;
   std::shared_ptr<DataPacket> last_packet;
+  bool keyframe_received;
+  bool frame_received;
 };
 
 class StreamSwitchHandler: public Handler, public std::enable_shared_from_this<StreamSwitchHandler> {
@@ -55,7 +59,10 @@ class StreamSwitchHandler: public Handler, public std::enable_shared_from_this<S
 
  private:
   std::shared_ptr<TrackState> getStateForSsrc(uint32_t ssrc, bool should_create);
+  void storeLastPacket(const std::shared_ptr<TrackState> &state, const std::shared_ptr<DataPacket> &packet);
   void sendBlackKeyframe(std::shared_ptr<DataPacket> packet);
+  void sendPLI();
+  void schedulePLI();
   uint32_t getNow();
 
  private:

--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -288,7 +288,8 @@ const Stream = (altConnectionHelpers, specInput) => {
         that.player = player;
         that.showing = true;
       }
-    } else if (nativeStreamContainsAudio && that.hasAudio()) {
+    }
+    if (nativeStreamContainsAudio && that.hasAudio()) {
       player = AudioPlayer({ id: that.getID(),
         stream: that,
         elementID,

--- a/erizo_controller/erizoClient/src/views/AudioPlayer.js
+++ b/erizo_controller/erizoClient/src/views/AudioPlayer.js
@@ -1,7 +1,7 @@
-/* global document */
+/* global window, MediaStream */
 
 import View from './View';
-import Bar from './Bar';
+// import Bar from './Bar';
 
 /*
  * AudioPlayer represents a Licode Audio component that shows either a local or a remote Audio.
@@ -9,10 +9,13 @@ import Bar from './Bar';
  * A AudioPlayer is also a View component.
  */
 
+const AudioContext = window.AudioContext || window.webkitAudioContext;
+const context = new AudioContext();
+
 const AudioPlayer = (spec) => {
   const that = View({});
-  let onmouseover;
-  let onmouseout;
+  // let onmouseover;
+  // let onmouseout;
 
   // Variables
 
@@ -26,76 +29,81 @@ const AudioPlayer = (spec) => {
   that.elementID = spec.elementID;
 
 
-  // Audio tag
-  that.audio = document.createElement('audio');
-  that.audio.setAttribute('id', `stream${that.id}`);
-  that.audio.setAttribute('class', 'licode_stream');
-  that.audio.setAttribute('style', 'width: 100%; height: 100%; position: absolute');
-  that.audio.setAttribute('autoplay', 'autoplay');
+  // // Audio tag
+  // that.audio = document.createElement('audio');
+  // that.audio.setAttribute('id', `stream${that.id}`);
+  // that.audio.setAttribute('class', 'licode_stream');
+  // that.audio.setAttribute('style', 'width: 100%; height: 100%; position: absolute');
+  // that.audio.setAttribute('autoplay', 'autoplay');
 
-  if (spec.stream.local) { that.audio.volume = 0; }
+  // if (spec.stream.local) { that.audio.volume = 0; }
 
-  if (that.elementID !== undefined) {
-    // It will stop the AudioPlayer and remove it from the HTML
-    that.destroy = () => {
-      that.audio.pause();
-      that.parentNode.removeChild(that.div);
-    };
+  // if (that.elementID !== undefined) {
+  //   // It will stop the AudioPlayer and remove it from the HTML
+  //   that.destroy = () => {
+  //     that.audio.pause();
+  //     that.parentNode.removeChild(that.div);
+  //   };
 
-    onmouseover = () => {
-      that.bar.display();
-    };
+  //   onmouseover = () => {
+  //     that.bar.display();
+  //   };
 
-    onmouseout = () => {
-      that.bar.hide();
-    };
+  //   onmouseout = () => {
+  //     that.bar.hide();
+  //   };
 
-    // Container
-    that.div = document.createElement('div');
-    that.div.setAttribute('id', `player_${that.id}`);
-    that.div.setAttribute('class', 'licode_player');
-    that.div.setAttribute('style', 'width: 100%; height: 100%; position: relative; ' +
-                              'overflow: hidden;');
+  //   // Container
+  //   that.div = document.createElement('div');
+  //   that.div.setAttribute('id', `player_${that.id}`);
+  //   that.div.setAttribute('class', 'licode_player');
+  //   that.div.setAttribute('style', 'width: 100%; height: 100%; position: relative; ' +
+  //                             'overflow: hidden;');
 
-    // Check for a passed DOM node.
-    if (typeof that.elementID === 'object' &&
-          typeof that.elementID.appendChild === 'function') {
-      that.container = that.elementID;
-    } else {
-      that.container = document.getElementById(that.elementID);
-    }
-    that.container.appendChild(that.div);
+  //   // Check for a passed DOM node.
+  //   if (typeof that.elementID === 'object' &&
+  //         typeof that.elementID.appendChild === 'function') {
+  //     that.container = that.elementID;
+  //   } else {
+  //     that.container = document.getElementById(that.elementID);
+  //   }
+  //   that.container.appendChild(that.div);
 
-    that.parentNode = that.div.parentNode;
+  //   that.parentNode = that.div.parentNode;
 
-    that.div.appendChild(that.audio);
+  //   that.div.appendChild(that.audio);
 
-    // Bottom Bar
-    if (spec.options.bar !== false) {
-      that.bar = Bar({ elementID: `player_${that.id}`,
-        id: that.id,
-        stream: spec.stream,
-        media: that.audio,
-        options: spec.options });
+  //   // Bottom Bar
+  //   if (spec.options.bar !== false) {
+  //     that.bar = Bar({ elementID: `player_${that.id}`,
+  //       id: that.id,
+  //       stream: spec.stream,
+  //       media: that.audio,
+  //       options: spec.options });
 
-      that.div.onmouseover = onmouseover;
-      that.div.onmouseout = onmouseout;
-    } else {
-      // Expose a consistent object to manipulate the media.
-      that.media = that.audio;
-    }
-  } else {
-    // It will stop the AudioPlayer and remove it from the HTML
-    that.destroy = () => {
-      that.audio.pause();
-      that.parentNode.removeChild(that.audio);
-    };
+  //     that.div.onmouseover = onmouseover;
+  //     that.div.onmouseout = onmouseout;
+  //   } else {
+  //     // Expose a consistent object to manipulate the media.
+  //     that.media = that.audio;
+  //   }
+  // } else {
+  //   // It will stop the AudioPlayer and remove it from the HTML
+  //   that.destroy = () => {
+  //     that.audio.pause();
+  //     that.parentNode.removeChild(that.audio);
+  //   };
 
-    document.body.appendChild(that.audio);
-    that.parentNode = document.body;
-  }
+  //   document.body.appendChild(that.audio);
+  //   that.parentNode = document.body;
+  // }
 
-  that.audio.srcObject = that.stream;
+  // that.audio.srcObject = that.stream;
+  const peerInput = context.createMediaStreamSource(new MediaStream(that.stream.getAudioTracks()));
+  const panner = context.createPanner();
+  panner.setPosition(0, 0, 0);
+  peerInput.connect(panner);
+  panner.connect(context.destination);
 
   return that;
 };

--- a/erizo_controller/erizoClient/src/views/VideoPlayer.js
+++ b/erizo_controller/erizoClient/src/views/VideoPlayer.js
@@ -1,4 +1,4 @@
-/* global document */
+/* global document, MediaStream */
 
 import View from './View';
 import Bar from './Bar';
@@ -108,6 +108,7 @@ const VideoPlayer = (spec) => {
     that.media = that.video;
   }
 
+  that.video.srcObject = new MediaStream(that.stream.getVideoTracks());
   that.video.srcObject = that.stream;
 
   return that;

--- a/test/negotiation/index.js
+++ b/test/negotiation/index.js
@@ -1,4 +1,5 @@
 const describeNegotiationTest = require('./utils/NegotiationTest');
+const describeStreamSwitchTest = require('./utils/StreamSwitchTest');
 
 describeNegotiationTest('SDP negotiations started by client', function(ctx) {
   ctx.publishToErizoStreamStep();
@@ -14,39 +15,24 @@ describeNegotiationTest('SDP negotiations started by Erizo', function(ctx) {
   ctx.subscribeToErizoStreamStep();
 });
 
-describeNegotiationTest('Conflicting SDP negotiation started by Erizo and Client', function(ctx) {
-  ctx.publishAndSubscribeStreamsStep([
-    'client-add-stream',
-                              'erizo-publish-stream',
-                              'erizo-subscribe-stream',
-                              'erizo-get-offer',
-    'client-get-offer',
-                              // Erizo is not polite 'erizo-process-offer',
-    'client-process-offer',
-    'client-get-answer',
-                              'erizo-process-answer',
-    'get-and-process-candidates',
-    'client-get-offer',
-                              'erizo-process-offer',
-                              'erizo-get-answer',
-    'client-process-answer',
-    'wait-for-being-connected',
-  ]);
-  ctx.publishAndSubscribeStreamsStep([
-    'client-add-stream',
-                              'erizo-publish-stream',
-    'client-get-offer',
-                              // Erizo is not polite 'erizo-process-offer',
-                              'erizo-subscribe-stream',
-                              'erizo-get-offer',
-    'client-process-offer',
-    'client-get-answer',
-                              'erizo-process-answer',
-    'client-get-offer',
-                              'erizo-process-offer',
-                              'erizo-get-answer',
-    'client-process-answer',
-    'get-and-process-candidates',
-    'wait-for-being-connected',
-  ]);
-});
+describeStreamSwitchTest('Basic Stream Switch Test', async function(ctx) {
+  let publisherA, publisherB, subscriberA, subscriberB;
+  before(async function() {
+    publisherA = await ctx.createClientStream('streamA', undefined, 400);
+    publisherB = await ctx.createClientStream('streamB', "#ff0000", 1000);
+
+    subscriberA = await ctx.createErizoStream('erizoStreamA', publisherA.label, true, false);
+    subscriberB = await ctx.createErizoStream('erizoStreamB', publisherB.label, true, true);
+  });
+
+  ctx.publishStream('pub', 'pub', 'streamA');
+  ctx.publishStream('pub', 'pub', 'streamB');
+  ctx.subscribeToStream('sub', 'sub', 'erizoStreamA', 'pub');
+
+  for (let i = 0; i < 20; i++) {
+    ctx.linkSubToPub('sub', 'pub', 'sub', 'streamA', 'erizoStreamA');
+    ctx.unlinkSubToPub('sub', 'pub', 'sub', 'streamA', 'erizoStreamA');
+    ctx.linkSubToPub('sub', 'pub', 'sub', 'streamB', 'erizoStreamA');
+    ctx.unlinkSubToPub('sub', 'pub', 'sub', 'streamB', 'erizoStreamA');
+  }
+}, true);

--- a/test/negotiation/utils/BrowserInstaller.js
+++ b/test/negotiation/utils/BrowserInstaller.js
@@ -33,7 +33,7 @@ const BrowserInstaller = {
       format: `Downloading Chromium r${chromeRevision}  [{bar}] {percentage}% | {value}MB/{total}MB`
     }, cliProgress.Presets.legacy);
     let barStarted = false;
-    chromeRevision = '801937';
+    chromeRevision = '869685';
     BrowserInstaller.revisionInfo = await browserFetcher.download(chromeRevision, (downloadedBytes, totalBytes) => {
       const totalMB = parseInt(totalBytes / 1000000);
       const downloadedMB = parseInt(downloadedBytes / 1000000);

--- a/test/negotiation/utils/ClientConnection.js
+++ b/test/negotiation/utils/ClientConnection.js
@@ -38,6 +38,14 @@ class ClientConnection {
     }, this.connectionId, this.sessionId, this.erizoId, this.options);
   }
 
+  registerFrameProcessingFunctions() {
+    return this.page.evaluate(() => {
+      navigator.getImageData = function (canvas, img) {
+        return canvas.getContext('2d').getImageData(0, 0, img.width, img.height);
+      }
+    });
+  }
+
   addStream(stream) {
     stream.addedToConnection = true;
     return this.page.evaluate((streamId, connectionId) => navigator.connections[connectionId].addStream(navigator.streams[streamId]), stream.id, this.connectionId);
@@ -46,6 +54,73 @@ class ClientConnection {
   removeStream(stream) {
     stream.addedToConnection = false;
     return this.page.evaluate((streamId, connectionId) => navigator.connections[connectionId].removeStream(navigator.streams[streamId]), stream.id, this.connectionId);
+  }
+
+  showStream(erizoStream) {
+    return this.page.evaluate((streamId, connectionId) => {
+      const stream = navigator.connections[connectionId]
+        .stack.peerConnection.getRemoteStreams().find(s => s.label = streamId);
+      if (!stream) {
+        return;
+      }
+      const div = document.createElement('div');
+      div.setAttribute('id', `player_${streamId}`);
+      div.setAttribute('class', 'licode_player');
+      div.setAttribute('style', 'width: 100%; height: 100%; position: relative; ' +
+                                'background-color: black; overflow: hidden;');
+      video = document.createElement('video');
+      video.setAttribute('id', `stream${streamId}`);
+      video.setAttribute('class', 'licode_stream');
+      video.setAttribute('style', 'width: 100%; height: 100%; position: absolute; object-fit: cover');
+      video.setAttribute('autoplay', 'autoplay');
+      video.setAttribute('playsinline', 'playsinline');
+      const container = document.createElement('div');
+      container.setAttribute('style', 'width: 320px; height: 240px;float:left;');
+      container.setAttribute('id', `test${streamId}`);
+
+      document.getElementById('videoContainer').appendChild(container);
+      container.appendChild(div);
+      div.appendChild(video);
+      video.srcObject = stream;
+      video.muted = true;
+
+      // const context = new AudioContext();
+      // const peerInput = context.createMediaStreamSource(stream);
+      // const panner = document.context.createPanner();
+      // panner.setPosition(0, 0, 0);
+      // peerInput.connect(panner);
+      // peerInput.connect(context.destination);
+      const audioStream = new MediaStream(stream.getAudioTracks());
+      // const recvAudio = new Audio();
+      // recvAudio.srcObject = audioStream;
+      // recvAudio.autoplay = true;
+      // recvAudio.muted = true;
+      const audioCtx = new AudioContext();
+      const source = audioCtx.createMediaStreamSource(audioStream);
+      source.connect(audioCtx.destination);
+      console.log("OK");
+
+    }, erizoStream.label, this.connectionId);
+  }
+
+  async getImageData(erizoStream) {
+    return await this.page.evaluate(async (streamId, connectionId) => {
+      const stream = navigator.connections[connectionId]
+        .stack.peerConnection.getRemoteStreams().find(s => s.label = streamId);
+      if (!stream) {
+        return;
+      }
+
+      const imageCapture = new ImageCapture(stream.getVideoTracks()[0]);
+      const imageBitmap = await imageCapture.grabFrame();
+      const width = imageBitmap.width;
+      const height = imageBitmap.height;
+      const canvas = Object.assign(document.createElement('canvas'), {width, height});
+      canvas.getContext('2d').drawImage(imageBitmap, 0, 0, width, height);
+      const image = canvas.getContext('2d').getImageData(0, 0, width, height);
+
+      return image.data;
+    }, erizoStream.label, this.connectionId);
   }
 
   setLocalDescription() {

--- a/test/negotiation/utils/ClientStream.js
+++ b/test/negotiation/utils/ClientStream.js
@@ -1,6 +1,6 @@
 let currentClientStreamId = 0;
 class ClientStream {
-  constructor(page) {
+  constructor(page, color, frequency) {
     this.page = page;
     this.id = currentClientStreamId++;
     this.audio = true;
@@ -8,22 +8,82 @@ class ClientStream {
     this.data = true;
     this.label = this.id;
     this.addedToConnection = false;
+    this.color = color;
+    this.frequency = frequency;
+    this.backgroundColor = color ? "#ffffff" : undefined;
   }
 
   init() {
-    return this.page.evaluate((streamId, audio, video, data) => {
+    return this.page.evaluate((streamId, audio, video, data, background, color, frequency) => {
       if (!navigator.streamsAccepted) {
         navigator.streamsAccepted = {};
         navigator.streams = {};
       }
       const stream = Erizo.Stream({ audio, video, data, attributes: {} });
+      stream.stream = navigator.startLocalVideo(background, color, frequency);
       navigator.streamsAccepted[streamId] = false;
       stream.on('access-accepted', () => {
         navigator.streamsAccepted[streamId] = true;
       });
-      stream.init();
+      // stream.init();
+      navigator.streamsAccepted[streamId] = true;
       navigator.streams[streamId] = stream;
-    }, this.id, this.audio, this.video, this.data);
+    }, this.id, this.audio, this.video, this.data, this.backgroundColor, this.color, this.frequency);
+  }
+
+  registerLocalVideoCreator() {
+    return this.page.evaluate(() => {
+      navigator.startLocalVideo = (fill = undefined, background = undefined, frequency = undefined) => {
+        let tone = (frequency) => {
+          let ctx = new AudioContext(), oscillator = ctx.createOscillator();
+          const gainNode = ctx.createGain();
+          const dst = ctx.createMediaStreamDestination();
+          oscillator.type = 'sine';
+          oscillator.frequency.setValueAtTime(frequency, ctx.currentTime); // value in hertz
+
+          oscillator.connect(gainNode);
+          gainNode.connect(dst);
+
+          gainNode.gain.setValueAtTime(1, ctx.currentTime);
+
+          oscillator.start();
+          setInterval(function() {
+            gainNode.gain.setValueAtTime(1, ctx.currentTime);
+            setTimeout(function () {
+              gainNode.gain.setValueAtTime(0, ctx.currentTime);
+            }, 100);
+          }, 500);
+
+          return dst.stream.getAudioTracks()[0];
+        }
+        function whiteNoise(width, height, fill, background) {
+          const canvas = Object.assign(document.createElement('canvas'), {width, height});
+          const ctx = canvas.getContext('2d');
+          var start = new Date().getTime();
+          requestAnimationFrame(function draw () {
+            ctx.clearRect(0,0,width,height);
+            ctx.fillStyle = background;
+            ctx.fillRect(0, 0, width, height);
+            ctx.textBaseline = "top";
+            ctx.font = '48px serif';
+            ctx.fillStyle = fill;
+            var now = new Date().getTime();
+            ctx.fillText(now - start, 50, 50);
+            requestAnimationFrame(draw);
+          });
+          let stream = canvas.captureStream();
+          return stream.getVideoTracks()[0];
+        }
+        const tracks = [];
+        if (fill && background) {
+          tracks.push(whiteNoise(640, 480, fill, background));
+        }
+        if (frequency) {
+          tracks.push(tone(frequency));
+        }
+        return new MediaStream(tracks);
+      };
+    });
   }
 
   async getLabel() {
@@ -35,6 +95,18 @@ class ClientStream {
 
   waitForAccepted() {
     return this.page.waitForFunction((streamId) => navigator.streamsAccepted[streamId], {}, this.id);
+  }
+
+  async show() {
+    await this.page.evaluate((streamId) => {
+      const stream = navigator.streams[streamId];
+      const div = document.createElement('div');
+      div.setAttribute('style', 'width: 320px; height: 240px;float:left;');
+      div.setAttribute('id', `test${streamId}`);
+
+      document.getElementById('videoContainer').appendChild(div);
+      stream.show(`test${streamId}`);
+    }, this.id);
   }
 
   async remove() {

--- a/test/negotiation/utils/ErizoConnection.js
+++ b/test/negotiation/utils/ErizoConnection.js
@@ -9,6 +9,7 @@ global.config = {
     useConnectionQualityCheck: true,
     networkinterface: 'en0',
     addon: 'addonDebug',
+    handlerProfiles: [[], [{"name":"Logger"}]],
   },
 };
 global.mediaConfig = mediaConfig;
@@ -25,7 +26,7 @@ const ioThreadPool = new erizo.IOThreadPool(1);
 ioThreadPool.start();
 
 class ErizoConnection {
-  constructor(connectionId) {
+  constructor(connectionId, isRemote) {
     this.webRtcConnectionConfiguration = {
       threadPool,
       ioThreadPool,
@@ -36,6 +37,7 @@ class ErizoConnection {
       erizoControllerId: 'erizoControllerTest1',
       clientId: 'clientTest1',
       encryptTransport: true,
+      isRemote,
       options: {},
     };
     this.connectionId = connectionId;
@@ -60,6 +62,10 @@ class ErizoConnection {
     if (threadPool.counter === 0) {
       threadPool.close();
     }
+  }
+
+  createOneToManyProcessor() {
+    return new erizo.OneToManyProcessor();
   }
 
   onceNegotiationIsNeeded() {
@@ -105,7 +111,12 @@ class ErizoConnection {
       label: stream.label,
       audio: true,
       video: true,
+      handlerProfile: 1,
     }, isPublisher);
+  }
+
+  async getStream(stream) {
+    return this.connection.getStream(stream.id);
   }
 
   async removeStream(stream) {

--- a/test/negotiation/utils/NegotiationTest.js
+++ b/test/negotiation/utils/NegotiationTest.js
@@ -45,6 +45,9 @@ const describeNegotiationTest = function(title, test, only = false) {
       erizoStreams: {},
       expectedClientSdpVersion: 2,
       expectedErizoSdpVersion: 0,
+      erizo: {},
+      client: {},
+      candidates: {},
     };
 
     let page;
@@ -91,25 +94,25 @@ const describeNegotiationTest = function(title, test, only = false) {
       delete ctx.erizoStreams[erizoStream.id];
     };
 
-    ctx.createClientConnection = async function() {
+    ctx.createClientConnection = async function(idx) {
       const connectionId = parseInt(Math.random() * 1000, 0);
       const conn = new ClientConnection(page, connectionId);
-      ctx.client = conn;
+      ctx.client[idx] = conn;
       await conn.init();
       return conn;
     };
 
-    ctx.createErizoConnection = async function() {
+    ctx.createErizoConnection = async function(idx) {
       const connectionId = parseInt(Math.random() * 1000, 0);
       const conn = new ErizoConnection(connectionId);
-      ctx.erizo = conn;
+      ctx.erizo[idx] = conn;
       return conn;
     };
 
     after(async function() {
       await page.close();
-      await ctx.erizo.removeAllStreams();
-      ctx.erizo.close();
+      await ctx.erizo['pub'].removeAllStreams();
+      ctx.erizo['pub'].close();
     });
 
     before(async function() {
@@ -122,69 +125,73 @@ const describeNegotiationTest = function(title, test, only = false) {
     });
 
     before(async function() {
-      await ctx.createClientConnection();
-      await ctx.createErizoConnection();
+      await ctx.createClientConnection('pub');
+      await ctx.createErizoConnection('pub');
+      await ctx.createClientConnection('sub');
+      await ctx.createErizoConnection('sub');
     });
 
-    ctx.checkClientSentCorrectOffer = (getOffer) => {
+    ctx.checkClientSentCorrectOffer = (getOffer, isPubConnection) => {
       it('Client should send the correct offer', function() {
         const sdp = new SdpChecker(getOffer());
         sdp.expectType('offer');
-        sdp.expectToHaveStreams(ctx.clientStreams);
+        if (isPubConnection) {
+          sdp.expectToHaveStreams(ctx.clientStreams);
+        }
       });
     };
 
-    ctx.checkErizoSentCorrectOffer = (getOffer) => {
+    ctx.checkErizoSentCorrectOffer = (getOffer, isPubConnection) => {
       it('Erizo should send the correct offer', function() {
         const sdp = new SdpChecker(getOffer());
         sdp.expectType('offer');
         sdp.expectToIncludeCandidates();
-        sdp.expectToHaveStreams(ctx.erizoStreams);
+        if (!isPubConnection) {
+          sdp.expectToHaveStreams(ctx.erizoStreams);
+        }
       });
     };
 
-    ctx.checkClientSentCorrectAnswer = (getAnswer) => {
+    ctx.checkClientSentCorrectAnswer = (getAnswer, isPubConnection) => {
       it('Client should send the correct answer', function() {
         const sdp = new SdpChecker(getAnswer());
         sdp.expectType('answer');
-        sdp.expectToHaveStreams(ctx.clientStreams);
+        if (isPubConnection) {
+          sdp.expectToHaveStreams(ctx.clientStreams);
+        }
       });
     };
 
-    ctx.checkErizoSentCorrectAnswer = (getAnswer) => {
+    ctx.checkErizoSentCorrectAnswer = (getAnswer, isPubConnection) => {
       it('Erizo should send an answer', function() {
         const sdp = new SdpChecker(getAnswer());
         sdp.expectType('answer');
         sdp.expectToIncludeCandidates();
-        sdp.expectToHaveStreams(ctx.erizoStreams);
+        if (!isPubConnection) {
+          sdp.expectToHaveStreams(ctx.erizoStreams);
+        }
       });
     };
 
-    ctx.checkClientSentCandidates = () => {
+    ctx.checkClientSentCandidates = (idx) => {
       it('Client should send candidates', function() {
-        for (const candidate of ctx.candidates) {
+        for (const candidate of ctx.candidates[idx]) {
           const sdp = new SdpChecker(candidate);
           sdp.expectType('candidate');
         }
       });
     };
 
-    ctx.checkErizoFinishedSuccessfully = () => {
+    ctx.checkErizoFinishedSuccessfully = (idx) => {
       it('Erizo should finish successfully', function() {
-        expect(ctx.erizo.isReady).to.be.true;
+        expect(ctx.erizo[idx].isReady).to.be.true;
+        // expect(ctx.erizo['sub'].isReady).to.be.true;
       });
     };
 
-    ctx.checkClientFSMStateIsStable = () => {
-      it('Client FSM state should be stable', async function() {
-        const state = await ctx.client.getFSMState();
-        expect(state).to.be.equals('stable');
-      });
-    };
-
-    ctx.checkClientHasNotFailed = () => {
+    ctx.checkClientHasNotFailed = (idx) => {
       it('Client should not be failed', async function() {
-        const connectionFailed = await ctx.client.isConnectionFailed();
+        const connectionFailed = await ctx.client[idx].isConnectionFailed();
         expect(connectionFailed).to.be.false;
       });
     };
@@ -201,31 +208,31 @@ const describeNegotiationTest = function(title, test, only = false) {
         before(async function() {
           clientStream = await ctx.createClientStream();
 
-          await ctx.client.addStream(clientStream);
-          await ctx.erizo.publishStream(clientStream);
+          await ctx.client['pub'].addStream(clientStream);
+          await ctx.erizo['pub'].publishStream(clientStream);
 
-          await ctx.client.setLocalDescription();
-          offer = { type: 'offer', sdp: await ctx.client.getLocalDescription() };
-          await ctx.erizo.setRemoteDescription(offer);
-          await ctx.erizo.setLocalDescription();
-          answer = { type: 'answer', sdp:  await ctx.erizo.getLocalDescription()};
-          await ctx.client.setRemoteDescription(answer);
-          if (!ctx.candidates) {
-            await ctx.client.waitForCandidates();
-            ctx.candidates = await ctx.client.getAllCandidates();
-            for (const candidate of ctx.candidates) {
-              await ctx.erizo.addIceCandidate(candidate);
+          await ctx.client['pub'].setLocalDescription();
+          offer = { type: 'offer', sdp: await ctx.client['pub'].getLocalDescription() };
+          await ctx.erizo['pub'].setRemoteDescription(offer);
+          await ctx.erizo['pub'].createAnswer();
+          answer = { type: 'answer', sdp:  await ctx.erizo['pub'].getLocalDescription()};
+          await ctx.client['pub'].setRemoteDescription(answer);
+          if (!ctx.candidates['pub']) {
+            await ctx.client['pub'].waitForCandidates();
+            ctx.candidates['pub'] = await ctx.client['pub'].getAllCandidates();
+            for (const candidate of ctx.candidates['pub']) {
+              await ctx.erizo['pub'].addIceCandidate(candidate);
             }
           }
-          await ctx.client.waitForConnected();
-          await ctx.erizo.waitForReadyMessage();
+          await ctx.client['pub'].waitForConnected();
+          await ctx.erizo['pub'].waitForReadyMessage();
         });
 
-        ctx.checkClientSentCorrectOffer(() => offer);
-        ctx.checkErizoSentCorrectAnswer(() => answer);
-        ctx.checkClientSentCandidates();
-        ctx.checkErizoFinishedSuccessfully();
-        ctx.checkClientHasNotFailed();
+        ctx.checkClientSentCorrectOffer(() => offer, true);
+        ctx.checkErizoSentCorrectAnswer(() => answer, true);
+        ctx.checkClientSentCandidates('pub');
+        ctx.checkErizoFinishedSuccessfully('pub');
+        ctx.checkClientHasNotFailed('pub');
       });
     };
 
@@ -235,36 +242,35 @@ const describeNegotiationTest = function(title, test, only = false) {
         before(async function() {
           clientStream = ctx.getFirstClientStream();
 
-          await ctx.client.removeStream(clientStream);
-          await ctx.erizo.unpublishStream(clientStream);
+          await ctx.client['pub'].removeStream(clientStream);
+          await ctx.erizo['pub'].unpublishStream(clientStream);
 
-          await ctx.client.setLocalDescription();
-          offer = { type: 'offer', sdp: await ctx.client.getLocalDescription() };
+          await ctx.client['pub'].setLocalDescription();
+          offer = { type: 'offer', sdp: await ctx.client['pub'].getLocalDescription() };
+          await ctx.erizo['pub'].setRemoteDescription(offer);
+          await ctx.erizo['pub'].createAnswer();
+          answer = { type: 'answer', sdp: await ctx.erizo['pub'].getLocalDescription() };
+          await ctx.client['pub'].setRemoteDescription(answer);
 
-          await ctx.erizo.setRemoteDescription(offer);
-          answer = { type: 'answer', sdp: await ctx.erizo.getLocalDescription() };
-
-          await ctx.client.setRemoteDescription(answer);
-
-          if (!ctx.candidates) {
-            await ctx.client.waitForCandidates();
-            ctx.candidates = await ctx.client.getAllCandidates();
-            for (const candidate of ctx.candidates) {
-              await ctx.erizo.addIceCandidate(candidate);
+          if (!ctx.candidates['pub']) {
+            await ctx.client['pub'].waitForCandidates();
+            ctx.candidates['pub'] = await ctx.client['pub'].getAllCandidates();
+            for (const candidate of ctx.candidates['pub']) {
+              await ctx.erizo['pub'].addIceCandidate(candidate);
             }
           }
 
-          await ctx.client.waitForConnected();
-          await ctx.erizo.waitForReadyMessage();
+          await ctx.client['pub'].waitForConnected();
+          await ctx.erizo['pub'].waitForReadyMessage();
 
          await ctx.deleteClientStream(clientStream);
         });
 
-        ctx.checkClientSentCorrectOffer(() => offer);
-        ctx.checkErizoSentCorrectAnswer(() => answer);
-        ctx.checkClientSentCandidates();
-        ctx.checkErizoFinishedSuccessfully();
-        ctx.checkClientHasNotFailed();
+        ctx.checkClientSentCorrectOffer(() => offer, true);
+        ctx.checkErizoSentCorrectAnswer(() => answer, true);
+        ctx.checkClientSentCandidates('pub');
+        ctx.checkErizoFinishedSuccessfully('pub');
+        ctx.checkClientHasNotFailed('pub');
       });
     };
 
@@ -275,34 +281,34 @@ const describeNegotiationTest = function(title, test, only = false) {
         before(async function() {
           erizoStream = await ctx.createErizoStream();
 
-          const negotiationNeeded = ctx.erizo.onceNegotiationIsNeeded();
-          await ctx.erizo.subscribeStream(erizoStream);
+          const negotiationNeeded = ctx.erizo['sub'].onceNegotiationIsNeeded();
+          await ctx.erizo['sub'].subscribeStream(erizoStream);
           await negotiationNeeded;
 
-          await ctx.erizo.setLocalDescription();
-          offer = { type: 'offer', sdp: await ctx.erizo.getLocalDescription() };
-          await ctx.client.setRemoteDescription(offer);
-          await ctx.client.setLocalDescription();
-          answer = { type: 'answer', sdp: await ctx.client.getLocalDescription() };
-          await ctx.erizo.setRemoteDescription(answer);
-          if (!ctx.candidates) {
-            await ctx.client.waitForCandidates();
-            ctx.candidates = await ctx.client.getAllCandidates();
-            for (const candidate of ctx.candidates) {
-              await ctx.erizo.addIceCandidate(candidate);
+          await ctx.erizo['sub'].setLocalDescription();
+          offer = { type: 'offer', sdp: await ctx.erizo['sub'].getLocalDescription() };
+          await ctx.client['sub'].setRemoteDescription(offer);
+          await ctx.client['sub'].setLocalDescription();
+          answer = { type: 'answer', sdp: await ctx.client['sub'].getLocalDescription() };
+          await ctx.erizo['sub'].setRemoteDescription(answer);
+          if (!ctx.candidates['sub']) {
+            await ctx.client['sub'].waitForCandidates();
+            ctx.candidates['sub'] = await ctx.client['sub'].getAllCandidates();
+            for (const candidate of ctx.candidates['sub']) {
+              await ctx.erizo['sub'].addIceCandidate(candidate);
             }
           }
 
-          await ctx.client.waitForConnected();
-          await ctx.erizo.waitForReadyMessage();
-          // await ctx.erizo.sleep(1000 * 60 * 5);
+          await ctx.client['sub'].waitForConnected();
+          await ctx.erizo['sub'].waitForReadyMessage();
+          // await ctx.erizo['sub'].sleep(1000 * 60 * 5);
         });
 
-        ctx.checkErizoSentCorrectOffer(() => offer);
-        ctx.checkClientSentCorrectAnswer(() => answer);
-        ctx.checkClientSentCandidates();
-        ctx.checkErizoFinishedSuccessfully();
-        ctx.checkClientHasNotFailed();
+        ctx.checkErizoSentCorrectOffer(() => offer, false);
+        ctx.checkClientSentCorrectAnswer(() => answer, false);
+        ctx.checkClientSentCandidates('sub');
+        ctx.checkErizoFinishedSuccessfully('sub');
+        ctx.checkClientHasNotFailed('sub');
       });
     };
 
@@ -313,34 +319,34 @@ const describeNegotiationTest = function(title, test, only = false) {
         before(async function() {
           erizoStream = ctx.getFirstErizoStream();
 
-          const negotiationNeeded = ctx.erizo.onceNegotiationIsNeeded();
-          await ctx.erizo.unsubscribeStream(erizoStream);
+          const negotiationNeeded = ctx.erizo['sub'].onceNegotiationIsNeeded();
+          await ctx.erizo['sub'].unsubscribeStream(erizoStream);
           await negotiationNeeded;
-          await ctx.erizo.setLocalDescription();
-          offer = { type: 'offer', sdp: await ctx.erizo.getLocalDescription() };
+          await ctx.erizo['sub'].setLocalDescription();
+          offer = { type: 'offer', sdp: await ctx.erizo['sub'].getLocalDescription() };
 
-          await ctx.client.setRemoteDescription(offer);
-          answer = { type: 'answer', sdp: await ctx.client.getLocalDescription() };
+          await ctx.client['sub'].setRemoteDescription(offer);
+          answer = { type: 'answer', sdp: await ctx.client['sub'].getLocalDescription() };
 
-          await ctx.erizo.setRemoteDescription(answer);
-          if (!ctx.candidates) {
-            await ctx.client.waitForCandidates();
-            ctx.candidates = await ctx.client.getAllCandidates();
-            for (const candidate of ctx.candidates) {
-              await ctx.erizo.addIceCandidate(candidate);
+          await ctx.erizo['sub'].setRemoteDescription(answer);
+          if (!ctx.candidates['sub']) {
+            await ctx.client['sub'].waitForCandidates();
+            ctx.candidates['sub'] = await ctx.client['sub'].getAllCandidates();
+            for (const candidate of ctx.candidates['sub']) {
+              await ctx.erizo['sub'].addIceCandidate(candidate);
             }
           }
 
-          await ctx.client.waitForConnected();
-          await ctx.erizo.waitForReadyMessage();
+          await ctx.client['sub'].waitForConnected();
+          await ctx.erizo['sub'].waitForReadyMessage();
           await ctx.deleteErizoStream(erizoStream);
         });
 
-        ctx.checkErizoSentCorrectOffer(() => offer);
-        ctx.checkClientSentCorrectAnswer(() => answer);
-        ctx.checkClientSentCandidates();
-        ctx.checkErizoFinishedSuccessfully();
-        ctx.checkClientHasNotFailed();
+        ctx.checkErizoSentCorrectOffer(() => offer, false);
+        ctx.checkClientSentCorrectAnswer(() => answer, false);
+        ctx.checkClientSentCandidates('sub');
+        ctx.checkErizoFinishedSuccessfully('sub');
+        ctx.checkClientHasNotFailed('sub');
       });
     };
 
@@ -356,70 +362,80 @@ const describeNegotiationTest = function(title, test, only = false) {
           for (const step of steps) {
             switch (step) {
               case 'client-add-stream':
-                await ctx.client.addStream(clientStream);
+                await ctx.client['pub'].addStream(clientStream);
                 break;
               case 'client-add-stream-and-process-erizo-offer':
-                addStreamPromise = ctx.client.addStream(clientStream);
-                processOfferPromise = ctx.client.setRemoteDescription(erizoOffer);
+                addStreamPromise = ctx.client['pub'].addStream(clientStream);
+                processOfferPromise = ctx.client['sub'].setRemoteDescription(erizoOffer);
                 await addStreamPromise;
                 await processOfferPromise;
                 break;
               case 'client-get-offer-and-process-erizo-offer':
-                processOfferPromise = ctx.client.setRemoteDescription(erizoOffer);
-                clientOfferPromise = ctx.client.setLocalDescription();
+                processOfferPromise = ctx.client['sub'].setRemoteDescription(erizoOffer);
+                clientOfferPromise = ctx.client['pub'].setLocalDescription();
                 await clientOfferPromise;
-                clientOffer = { type: 'offer', sdp: await ctx.client.getLocalDescription() };
+                clientOffer = { type: 'offer', sdp: await ctx.client['pub'].getLocalDescription() };
                 break;
               case 'erizo-publish-stream':
-                await ctx.erizo.publishStream(clientStream);
+                await ctx.erizo['pub'].publishStream(clientStream);
                 break;
               case 'erizo-subscribe-stream':
-                await ctx.erizo.subscribeStream(erizoStream);
+                await ctx.erizo['sub'].subscribeStream(erizoStream);
                 break;
               case 'erizo-get-offer':
-                await ctx.erizo.setLocalDescription();
-                erizoOffer = { type: 'offer', sdp: await ctx.erizo.getLocalDescription() };
+                await ctx.erizo['sub'].setLocalDescription();
+                erizoOffer = { type: 'offer', sdp: await ctx.erizo['sub'].getLocalDescription() };
                 break;
               case 'erizo-get-answer':
-                await ctx.erizo.setLocalDescription();
-                erizoAnswer = { type: 'answer', sdp: await ctx.erizo.getLocalDescription() };
+                await ctx.erizo['pub'].setLocalDescription();
+                erizoAnswer = { type: 'answer', sdp: await ctx.erizo['pub'].getLocalDescription() };
                 break;
               case 'client-get-offer':
-                await ctx.client.setLocalDescription();
-                clientOffer = { type: 'offer', sdp: await ctx.client.getLocalDescription() };
+                await ctx.client['pub'].setLocalDescription();
+                clientOffer = { type: 'offer', sdp: await ctx.client['pub'].getLocalDescription() };
                 break;
               case 'client-get-answer':
-                await ctx.client.setLocalDescription();
-                clientAnswer = { type: 'answer', sdp: await ctx.client.getLocalDescription() };
+                await ctx.client['sub'].setLocalDescription();
+                clientAnswer = { type: 'answer', sdp: await ctx.client['sub'].getLocalDescription() };
                 break;
               case 'erizo-process-offer':
-                await ctx.erizo.setRemoteDescription(clientOffer);
+                await ctx.erizo['pub'].setRemoteDescription(clientOffer);
                 break;
               case 'erizo-process-answer':
-                await ctx.erizo.setRemoteDescription(clientAnswer);
+                await ctx.erizo['sub'].setRemoteDescription(clientAnswer);
                 break;
               case 'client-process-offer':
-                await ctx.client.setRemoteDescription(erizoOffer);
+                await ctx.client['sub'].setRemoteDescription(erizoOffer);
                 break;
 
               case 'client-process-answer':
-                await ctx.client.setRemoteDescription(erizoAnswer);
+                await ctx.client['pub'].setRemoteDescription(erizoAnswer);
                 break;
               case 'get-and-process-candidates':
-                if (!ctx.candidates) {
-                  await ctx.client.waitForCandidates();
-                  ctx.candidates = await ctx.client.getAllCandidates();
-                  for (const candidate of ctx.candidates) {
-                    await ctx.erizo.addIceCandidate(candidate);
+                if (!ctx.candidates['pub'] && ctx.client['pub']) {
+                  await ctx.client['pub'].waitForCandidates();
+                  ctx.candidates['pub'] = await ctx.client['pub'].getAllCandidates();
+                  for (const candidate of ctx.candidates['pub']) {
+                    await ctx.erizo['pub'].addIceCandidate(candidate);
+                  }
+                }
+
+                if (!ctx.candidates['sub'] && ctx.client['sub']) {
+                  await ctx.client['sub'].waitForCandidates();
+                  ctx.candidates['sub'] = await ctx.client['sub'].getAllCandidates();
+                  for (const candidate of ctx.candidates['sub']) {
+                    await ctx.erizo['sub'].addIceCandidate(candidate);
                   }
                 }
                 break;
               case 'wait-for-being-connected':
-                await ctx.erizo.waitForStartedMessage();
-                await ctx.client.waitForConnected();
+                await ctx.erizo['pub'].waitForStartedMessage();
+                await ctx.client['pub'].waitForConnected();
+                await ctx.erizo['sub'].waitForStartedMessage();
+                await ctx.client['sub'].waitForConnected();
                 break;
               case '':
-                await ctx.erizo.subscribeStream(erizoStream);
+                await ctx.erizo['sub'].subscribeStream(erizoStream);
                 break;
               default:
                 break;

--- a/test/negotiation/utils/SdpUtils.js
+++ b/test/negotiation/utils/SdpUtils.js
@@ -41,6 +41,9 @@ class SdpChecker {
   }
 
   expectToHaveStreams(streams) {
+    if (!streams) {
+      return;
+    }
     const streamIds = Object.keys(streams);
     for (const streamId of streamIds) {
       this.expectToHaveStream(streams[streamId]);

--- a/test/negotiation/utils/StreamSwitchTest.js
+++ b/test/negotiation/utils/StreamSwitchTest.js
@@ -18,7 +18,7 @@ before(async function() {
     await BrowserInstaller.install('canary');
   }
   browser = await puppeteer.launch({
-    headless: false,
+    headless: true,
     dumpio: false,
     executablePath: BrowserInstaller.revisionInfo.executablePath,
     args: [
@@ -26,13 +26,13 @@ before(async function() {
       '--use-fake-device-for-media-stream',
       '-enable-logging',
       '--v=1',
-      '--vmodule=*/webrtc/*=2,*=-1',
+      '--vmodule=*/webrtc/*=2,*=2',
       '--enable-logging=stderr',
     ]
   });
 
   browser2 = await puppeteer.launch({
-    headless: false,
+    headless: true,
     dumpio: false,
     executablePath: BrowserInstaller.revisionInfo.executablePath,
     args: [
@@ -40,7 +40,7 @@ before(async function() {
       '--use-fake-device-for-media-stream',
       '-enable-logging',
       '--v=1',
-      '--vmodule=*/webrtc/*=2,*=-1',
+      '--vmodule=*/webrtc/*=2,*=2',
       '--enable-logging=stderr',
     ]
   });

--- a/test/negotiation/utils/StreamSwitchTest.js
+++ b/test/negotiation/utils/StreamSwitchTest.js
@@ -1,0 +1,476 @@
+const path = require('path');
+const puppeteer = require('puppeteer-core');
+const expect = require('chai').expect;
+
+const BrowserInstaller = require('./BrowserInstaller');
+const ClientStream = require('./ClientStream');
+const ClientConnection = require('./ClientConnection');
+const ErizoConnection = require('./ErizoConnection');
+const SdpChecker = require('./SdpUtils');
+
+let browser, browser2;
+let currentErizoStreamId = 10;
+
+before(async function() {
+  this.timeout(30000);
+  if (!BrowserInstaller.installed) {
+    this.timeout(300000);
+    await BrowserInstaller.install('canary');
+  }
+  browser = await puppeteer.launch({
+    headless: false,
+    dumpio: false,
+    executablePath: BrowserInstaller.revisionInfo.executablePath,
+    args: [
+      '--use-fake-ui-for-media-stream',
+      '--use-fake-device-for-media-stream',
+      '-enable-logging',
+      '--v=1',
+      '--vmodule=*/webrtc/*=2,*=-1',
+      '--enable-logging=stderr',
+    ]
+  });
+
+  browser2 = await puppeteer.launch({
+    headless: false,
+    dumpio: false,
+    executablePath: BrowserInstaller.revisionInfo.executablePath,
+    args: [
+      '--use-fake-ui-for-media-stream',
+      '--use-fake-device-for-media-stream',
+      '-enable-logging',
+      '--v=1',
+      '--vmodule=*/webrtc/*=2,*=-1',
+      '--enable-logging=stderr',
+    ]
+  });
+
+  const internalPage = await browser.newPage();
+  await internalPage.goto(`chrome://webrtc-internals`);
+
+  const internalPage2 = await browser2.newPage();
+  await internalPage2.goto(`chrome://webrtc-internals`);
+});
+
+after(async function() {
+  await browser.close();
+  await browser2.close();
+});
+
+const describeStreamSwitchTest = function(title, test, only = false) {
+  const describeImpl = only ? describe.only : describe;
+  describeImpl(title, function() {
+    this.timeout(500000);
+
+    const ctx = {
+      clientStreams: {},
+      erizoStreams: {},
+      expectedClientSdpVersion: 2,
+      expectedErizoSdpVersion: 0,
+      erizo: {},
+      client: {},
+    };
+
+    let page, page2;
+    const erizoConns = {};
+
+    ctx.createClientStream = async function(idx, color, frequency) {
+      const stream = new ClientStream(page2, color, frequency);
+      ctx.clientStreams[idx] = stream;
+      await stream.registerLocalVideoCreator();
+      await stream.init();
+      await stream.waitForAccepted();
+      await stream.getLabel();
+      return stream;
+    };
+
+    ctx.deleteClientStream = async function(idx) {
+      if (ctx.clientStreams[idx]) {
+        ctx.clientStreams[idx].remove();
+        delete ctx.clientStreams[idx];
+      }
+    };
+
+    ctx.createErizoStream = async function(idx, label, audio, video) {
+      const id = parseInt(currentErizoStreamId++, 0);
+      const stream = { id, label: label || id, audio, video, addedToConnection: false };
+      ctx.erizoStreams[idx] = stream;
+      return stream;
+    };
+
+    ctx.deleteErizoStream = async function(idx) {
+      delete ctx.erizoStreams[idx];
+    };
+
+    ctx.createClientConnection = async function(idx) {
+      const connectionId = parseInt(Math.random() * 1000, 0);
+      const conn = new ClientConnection(idx === 'pub' ? page2 : page, connectionId);
+      ctx.client[idx] = conn;
+      await conn.init();
+      await conn.registerFrameProcessingFunctions();
+      return conn;
+    };
+
+    ctx.createErizoConnection = async function(idx) {
+      const connectionId = parseInt(Math.random() * 1000, 0);
+      const conn = new ErizoConnection(connectionId, idx === 'pub');
+      ctx.erizo[idx] = conn;
+      return conn;
+    };
+
+    after(async function() {
+      await page.close();
+      await page2.close();
+      await ctx.erizo['pub'].removeAllStreams();
+      ctx.erizo['pub'].close();
+    });
+
+    before(async function() {
+      const currentProcessPath = process.cwd();
+      const htmlPath = path.join(currentProcessPath, '../../extras/basic_example/public/index.html');
+      page = await browser.newPage();
+
+      // page.on('console', msg => console.log('PAGE LOG:', msg.text()));
+      await page.goto(`file://${htmlPath}?forceStart=1`);
+
+      page2 = await browser2.newPage();
+
+      // page.on('console', msg => console.log('PAGE LOG:', msg.text()));
+      await page2.goto(`file://${htmlPath}?forceStart=1`);
+    });
+
+    before(async function() {
+      await ctx.createClientConnection('pub');
+      await ctx.createErizoConnection('pub');
+      await ctx.createClientConnection('sub');
+      await ctx.createErizoConnection('sub');
+    });
+
+    ctx.checkClientSentCorrectOffer = (getOffer, clientId) => {
+      it('Client should send the correct offer', function() {
+        const sdp = new SdpChecker(getOffer());
+        sdp.expectType('offer');
+        sdp.expectToHaveStreams(ctx.client[clientId].streams);
+      });
+    };
+
+    ctx.checkErizoSentCorrectOffer = (getOffer, erizoId) => {
+      it('Erizo should send the correct offer', function() {
+        const sdp = new SdpChecker(getOffer());
+        sdp.expectType('offer');
+        sdp.expectToIncludeCandidates();
+        sdp.expectToHaveStreams(ctx.erizo[erizoId].streams);
+      });
+    };
+
+    ctx.checkClientSentCorrectAnswer = (getAnswer, clientId) => {
+      it('Client should send the correct answer', function() {
+        const sdp = new SdpChecker(getAnswer());
+        sdp.expectType('answer');
+        sdp.expectToHaveStreams(ctx.client[clientId].streams);
+      });
+    };
+
+    ctx.checkErizoSentCorrectAnswer = (getAnswer, erizoId) => {
+      it('Erizo should send an answer', function() {
+        const sdp = new SdpChecker(getAnswer());
+        sdp.expectType('answer');
+        sdp.expectToIncludeCandidates();
+        sdp.expectToHaveStreams(ctx.erizo[erizoId].streams);
+      });
+    };
+
+    ctx.checkClientSentCandidates = (clientId) => {
+      it('Client should send candidates', function() {
+        for (const candidate of ctx.client[clientId].candidates) {
+          const sdp = new SdpChecker(candidate);
+          sdp.expectType('candidate');
+        }
+      });
+    };
+
+    ctx.checkErizoFinishedSuccessfully = (idx) => {
+      it('Erizo should finish successfully', function() {
+        expect(ctx.erizo[idx].isReady).to.be.true;
+        // expect(erizo.isReady).to.be.true;
+      });
+    };
+
+    ctx.checkClientHasNotFailed = (idx) => {
+      it('Client should not be failed', async function() {
+        const connectionFailed = await ctx.client[idx].isConnectionFailed();
+        expect(connectionFailed).to.be.false;
+      });
+    };
+
+    ctx.checkClientDroppedOffer = (getOffer) => {
+      it('Client should drop erizo offer', function() {
+        expect(getOffer()).to.have.property('type', 'offer-dropped');
+      });
+    };
+
+    ctx.publishStream = async function(clientId, erizoId, clientStreamId) {
+      describe('Publish One Client Stream', function() {
+        let offer, answer, client, erizo, clientStream;
+
+        before(async function() {
+          client = ctx.client[clientId];
+          erizo = ctx.erizo[erizoId];
+          clientStream = ctx.clientStreams[clientStreamId];
+          await client.addStream(clientStream);
+          await erizo.publishStream(clientStream);
+
+          await client.setLocalDescription();
+          offer = { type: 'offer', sdp: await client.getLocalDescription() };
+          await erizo.setRemoteDescription(offer);
+          await erizo.createAnswer();
+          answer = { type: 'answer', sdp:  await erizo.getLocalDescription()};
+          console.log(offer,answer);
+          await client.setRemoteDescription(answer);
+          if (!client.candidates) {
+            await client.waitForCandidates();
+            client.candidates = await client.getAllCandidates();
+            for (const candidate of client.candidates) {
+              await erizo.addIceCandidate(candidate);
+            }
+          }
+          await client.waitForConnected();
+          await erizo.waitForReadyMessage();
+          await clientStream.show();
+        });
+
+        ctx.checkClientSentCorrectOffer(() => offer, clientId);
+        ctx.checkErizoSentCorrectAnswer(() => answer, erizoId);
+        ctx.checkClientSentCandidates(clientId);
+        ctx.checkErizoFinishedSuccessfully(erizoId);
+        ctx.checkClientHasNotFailed(clientId);
+      });
+    };
+
+    ctx.unpublishStream = async function(client, erizo, clientStream) {
+      describe('Unpublish One Client Stream', function() {
+        let offer, answer;
+        before(async function() {
+          await client.removeStream(clientStream);
+          await erizo.unpublishStream(clientStream);
+
+          await client.setLocalDescription();
+          offer = { type: 'offer', sdp: await client.getLocalDescription() };
+          await erizo.setRemoteDescription(offer);
+          await erizo.createAnswer();
+          answer = { type: 'answer', sdp: await erizo.getLocalDescription() };
+          await client.setRemoteDescription(answer);
+
+          if (!client.candidates) {
+            await client.waitForCandidates();
+            client.candidates = await client.getAllCandidates();
+            for (const candidate of client.candidates) {
+              await erizo.addIceCandidate(candidate);
+            }
+          }
+
+          await client.waitForConnected();
+          await erizo.waitForReadyMessage();
+
+          await ctx.deleteClientStream(clientStream);
+        });
+
+        ctx.checkClientSentCorrectOffer(() => offer, client);
+        ctx.checkErizoSentCorrectAnswer(() => answer, erizo);
+        ctx.checkClientSentCandidates(client);
+        ctx.checkErizoFinishedSuccessfully(erizo);
+        ctx.checkClientHasNotFailed(client);
+      });
+    };
+
+    function RGBToHex(r,g,b) {
+      r = r.toString(16);
+      g = g.toString(16);
+      b = b.toString(16);
+
+      if (r.length == 1)
+        r = "0" + r;
+      if (g.length == 1)
+        g = "0" + g;
+      if (b.length == 1)
+        b = "0" + b;
+
+      return "#" + r + g + b;
+    }
+
+    function hexToRGB(hex) {
+      var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+      return result ? [parseInt(result[1], 16), parseInt(result[2], 16), parseInt(result[3], 16)] : null;
+    }
+
+    function colorDistance(v1, v2){
+      var i,
+          d = 0;
+
+      for (i = 0; i < v1.length; i++) {
+          d += (v1[i] - v2[i])*(v1[i] - v2[i]);
+      }
+      return Math.sqrt(d);
+    };
+
+    ctx.linkSubToPub = function(clientId, erizoPubId, erizoSubId, streamPubId, streamSubId, wait = 5) {
+      describe('Link Subscriber to Publisher', async function() {
+        let erizoPub, erizoSub, publisher, subscriber, client, erizoStream, pubStream;
+        before(async function() {
+          client = ctx.client[clientId];
+          erizoPub = ctx.erizo[erizoPubId];
+          erizoSub = ctx.erizo[erizoSubId];
+          pubStream = ctx.clientStreams[streamPubId];
+          publisher = erizoPub.connection.getStream(pubStream.id);
+          const subStream = ctx.erizoStreams[streamSubId];
+          subscriber = erizoSub.connection.getStream(subStream.id);
+          if (!publisher.muxer) {
+            publisher.muxer = erizoPub.createOneToManyProcessor();
+            publisher.setAudioReceiver(publisher.muxer);
+            publisher.setVideoReceiver(publisher.muxer);
+            publisher.muxer.setPublisher(publisher);
+            publisher.muteStream(false, false);
+            await erizoSub.sleep(300);
+          }
+          publisher.muxer.addSubscriber(subscriber, subscriber.id);
+          subscriber.muteStream(false, false);
+          await erizoSub.sleep(1000 * wait);
+
+          erizoStream = ctx.erizoStreams[streamSubId];
+        });
+
+        it('should have muxer with publisher', async () => {
+          expect(publisher.muxer).to.not.be.null;
+          expect(publisher.muxer.hasPublisher()).to.be.true;
+        });
+
+        // it('should be receiving the right stream', async() => {
+        //   const imageData = await client.getImageData(erizoStream);
+        //   const imagePixel = [imageData[0], imageData[1], imageData[2]];
+        //   const pixelColor = hexToRGB(pubStream.color);
+        //   const distance = colorDistance(imagePixel, pixelColor);
+        //   expect(distance).to.be.lessThan(100);
+        // });
+
+        // it('should be receiving video', async() => {
+        //   const imageData = await client.getImageData(erizoStream);
+        //   await erizoSub.sleep(100);
+        //   const imageData2 = await client.getImageData(erizoStream);
+        //   expect(imageData).to.not.be.deep.equals(imageData2);
+        // });
+      });
+    };
+
+    ctx.unlinkSubToPub = function(clientId, erizoPubId, erizoSubId, streamPubId, streamSubId) {
+      describe('Unlink Subscriber to Publisher', function() {
+        let erizoPub, erizoSub, publisher, subscriber, erizoStream, client;
+        before(async function() {
+          client = ctx.client[clientId];
+          erizoPub = ctx.erizo[erizoPubId];
+          erizoSub = ctx.erizo[erizoSubId];
+          const pubStream = ctx.clientStreams[streamPubId];
+          publisher = erizoPub.connection.getStream(pubStream.id);
+          const subStream = ctx.erizoStreams[streamSubId];
+          subscriber = erizoSub.connection.getStream(subStream.id);
+          if (publisher.muxer) {
+            publisher.muxer.removeSubscriber(subscriber.id);
+          }
+          await erizoSub.sleep(0);
+
+          erizoStream = ctx.erizoStreams[streamSubId];
+        });
+
+        it('should have muxer', () => {
+          expect(publisher.muxer).to.not.be.null;
+          expect(publisher.muxer.hasPublisher()).to.be.true;
+        });
+
+        it('should not be receiving video', async() => {
+        });
+      });
+    };
+
+    ctx.subscribeToStream = function(clientId, erizoId, erizoStreamId, erizoPubId) {
+      describe('Subscribe One Erizo Stream', function() {
+        let offer, answer, client, erizo, erizoPub, erizoStream;
+        before(async function() {
+          client = ctx.client[clientId];
+          erizo = ctx.erizo[erizoId];
+          erizoPub = ctx.erizo[erizoPubId];
+          erizoStream = ctx.erizoStreams[erizoStreamId];
+          const negotiationNeeded = erizo.onceNegotiationIsNeeded();
+          await erizo.subscribeStream(erizoStream);
+          await negotiationNeeded;
+
+          erizo.connection.copySdpInfoFromConnection(erizoPub.connection);
+
+          await erizo.setLocalDescription();
+          offer = { type: 'offer', sdp: await erizo.getLocalDescription() };
+          await client.setRemoteDescription(offer);
+          await client.setLocalDescription();
+          answer = { type: 'answer', sdp: await client.getLocalDescription() };
+          await erizo.setRemoteDescription(answer);
+          if (!client.candidates) {
+            await client.waitForCandidates();
+            client.candidates = await client.getAllCandidates();
+            for (const candidate of client.candidates) {
+              await erizo.addIceCandidate(candidate);
+            }
+          }
+
+          await client.waitForConnected();
+          await erizo.waitForReadyMessage();
+          await client.showStream(erizoStream);
+        });
+
+        ctx.checkErizoSentCorrectOffer(() => offer, erizoId);
+        ctx.checkClientSentCorrectAnswer(() => answer, clientId);
+        ctx.checkClientSentCandidates(clientId);
+        ctx.checkErizoFinishedSuccessfully(erizoId);
+        ctx.checkClientHasNotFailed(clientId);
+      });
+    };
+
+    ctx.unsubscribeStreamStep = function(client, erizo, erizoStream) {
+      describe('Unsubscribe One Erizo Stream', function() {
+        let offer, answer, erizoStream;
+
+        before(async function() {
+          const negotiationNeeded = erizo.onceNegotiationIsNeeded();
+          await erizo.unsubscribeStream(erizoStream);
+          await negotiationNeeded;
+          await erizo.setLocalDescription();
+          offer = { type: 'offer', sdp: await erizo.getLocalDescription() };
+
+          await client.setRemoteDescription(offer);
+          answer = { type: 'answer', sdp: await client.getLocalDescription() };
+
+          await erizo.setRemoteDescription(answer);
+          if (!client.candidates) {
+            await client.waitForCandidates();
+            client.candidates = await client.getAllCandidates();
+            for (const candidate of client.candidates) {
+              await erizo.addIceCandidate(candidate);
+            }
+          }
+
+          await client.waitForConnected();
+          await erizo.waitForReadyMessage();
+          await ctx.deleteErizoStream(erizoStream);
+        });
+
+        ctx.checkErizoSentCorrectOffer(() => offer, false);
+        ctx.checkClientSentCorrectAnswer(() => answer, false);
+        ctx.checkClientSentCandidates('sub');
+        ctx.checkErizoFinishedSuccessfully('sub');
+        ctx.checkClientHasNotFailed('sub');
+      });
+    };
+
+    test.call(this, ctx);
+  });
+};
+
+
+
+module.exports = describeStreamSwitchTest;


### PR DESCRIPTION
**Description**

This PR adds a new feature to quickly switch the streams that are subscribed. The goal is to avoid renegotiations of the SDP, which creates a high load of traffic in the server for large classes.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed yet.

[] It includes documentation for these changes in `/doc`.