### PR TITLE
Fix stream republishing

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -739,9 +739,9 @@ void WebRtcConnection::detectNewTransceiversInRemoteSdp() {
       if (!media_info.sender_id.empty()) {
         auto media_stream = getMediaStreamFromLabel(media_info.sender_id);
         if (media_stream) {
-          ELOG_DEBUG("%s message: Associating MediaStream to transceiver, label: %s, mid: %s",
+          ELOG_DEBUG("%s message: Associating MediaStream to reused transceiver, label: %s, mid: %s",
             toLog(), media_stream->getLabel(), transceiver->getId());
-          transceiver->setReceiver(media_stream);
+          associateMediaStreamToTransceiver(media_stream, transceiver);
         } else {
           ELOG_DEBUG("%s message: We received a transceiver with an unknown remote stream, streamId: %s, mid: %d",
             toLog(), media_info.sender_id, index);

--- a/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
+++ b/erizo_controller/erizoClient/src/webrtc-stacks/BaseStack.js
@@ -219,7 +219,7 @@ const BaseStack = (specInput) => {
 
   that.removeStream = (stream) => {
     stream.transceivers.forEach((transceiver) => {
-      log.error('Stopping transceiver', transceiver);
+      log.debug('Stopping transceiver', transceiver);
       // Don't remove the tagged m section, which is the first one (mid=0).
       if (transceiver.mid === '0') {
         that.peerConnection.removeTrack(transceiver.sender);

--- a/erizo_controller/erizoJS/models/Client.js
+++ b/erizo_controller/erizoJS/models/Client.js
@@ -125,8 +125,6 @@ class Client extends EventEmitter {
         log.error(`message: Error adding ICE candidate, clientId: ${this.id}, message> ${e.message}`,
           logger.objectToLog(this.options), logger.objectToLog(this.options.metadata));
       }
-    } else if (description.type === 'offer-error') {
-      this.emit('status_event', this.erizoControllerId, this.id, connection.id, { type: 'offer', sdp: connection.localDescription }, CONN_SDP);
     } else {
       // If we have a setRemoteDescription() answer operation pending, then
       // we will be "stable" by the time the next setRemoteDescription() is


### PR DESCRIPTION
**Description**

We were not handling MIDs properly when the media section was reused. And that affected cases where clients republished their streams.

I also removed a couple of annoying things related to logs and repeated negotiation attempts that were always failing.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.