### PR TITLE
Take into account passing "undefined" in updatesimulcastlayersbitrate

### DIFF
--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -619,9 +619,10 @@ const Stream = (altConnectionHelpers, specInput) => {
       // limit with maxVideoBW
       const limitedBitrates = bitrates;
       Object.keys(limitedBitrates).forEach((key) => {
-        if (limitedBitrates[key] > that.maxVideoBW) {
-          log.warning(`Trying to set bitrate ${limitedBitrates[key]} higher that max ${that.maxVideoBW}`
-            + `in Layer ${key}`);
+        // explicitly passing undefined means assigning the max for that layer
+        if (limitedBitrates[key] > that.maxVideoBW || limitedBitrates[key] === undefined) {
+          log.info('message: updateSimulcastLayersBitrate defaulting to max bitrate,' +
+          `, layer :${key}, requested: ${limitedBitrates[key]}, max: ${that.maxVideoBW}`);
           limitedBitrates[key] = that.maxVideoBW;
         }
         limitedBitrates[key] =


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This addresses an unintended change in behaviour in updatesimulcastlayersbitrate. If we explicitly pass `undefined`, now the `maxVideoBW` will be assigned, which is the closest to what it meant before the maxVideoBW changes.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.