### PR TITLE
Fix issues with setMaxVideoBW and updateSimulcastLayersBitrate

### DIFF
--- a/erizo_controller/erizoClient/src/Stream.js
+++ b/erizo_controller/erizoClient/src/Stream.js
@@ -84,6 +84,14 @@ const Stream = (altConnectionHelpers, specInput) => {
       const translated = (maxVideoBW * 1000 * 0.90) - (50 * 40 * 8);
       log.info(`message: Setting maxVideoBW, streamId: ${that.getID()}, maxVideoBW: ${maxVideoBW}, translated: ${translated}`);
       that.maxVideoBW = translated;
+      // Make sure all the current parameters respect the new limit
+      if (videoSenderLicodeParameters) {
+        Object.keys(videoSenderLicodeParameters).forEach((key) => {
+          const senderParam = videoSenderLicodeParameters[key];
+          senderParam.maxBitrate = senderParam.maxBitrate > that.maxVideoBW ?
+            that.maxVideoBW : senderParam.maxBitrate;
+        });
+      }
     } else {
       that.maxVideoBW = maxVideoBW;
     }
@@ -617,7 +625,7 @@ const Stream = (altConnectionHelpers, specInput) => {
   that.updateSimulcastLayersBitrate = (bitrates) => {
     if (that.pc && that.local) {
       // limit with maxVideoBW
-      const limitedBitrates = bitrates;
+      const limitedBitrates = Object.assign({}, bitrates);
       Object.keys(limitedBitrates).forEach((key) => {
         // explicitly passing undefined means assigning the max for that layer
         if (limitedBitrates[key] > that.maxVideoBW || limitedBitrates[key] === undefined) {
@@ -625,8 +633,6 @@ const Stream = (altConnectionHelpers, specInput) => {
           `, layer :${key}, requested: ${limitedBitrates[key]}, max: ${that.maxVideoBW}`);
           limitedBitrates[key] = that.maxVideoBW;
         }
-        limitedBitrates[key] =
-          limitedBitrates[key] > that.maxVideoBW ? that.maxVideoBW : limitedBitrates[key];
       });
       setEncodingConfig('maxBitrate', limitedBitrates);
       that.applySenderEncoderParameters();


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR fixes 2 issues:
1. `updateSimulcastLayersBitrate` could update the structure passed as parameters if the bitrate specified was over the max. This could cause problems in the application if it happened to repeatedly use the same structure.
2. We were not updating the layers properly when setting MaxVideoBW. That could lead to a case where some of the layers did not comply with the maxVideoBW. 

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.