### PR TITLE
Implement target connection bandwidth

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -40,6 +40,7 @@ WebRtcConnection::WebRtcConnection(std::shared_ptr<Worker> worker, std::shared_p
     remote_sdp_{std::make_shared<SdpInfo>(rtp_mappings)}, local_sdp_{std::make_shared<SdpInfo>(rtp_mappings)},
     audio_muted_{false}, video_muted_{false}, first_remote_sdp_processed_{false},
     enable_connection_quality_check_{enable_connection_quality_check}, encrypt_transport_{encrypt_transport},
+    connection_target_bw_{0},
     pipeline_{Pipeline::create()},
     pipeline_initialized_{false}, latest_mid_{0} {
   stats_ = std::make_shared<Stats>();

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -161,8 +161,8 @@ class WebRtcConnection: public TransportListener, public LogContext, public Hand
   void setBwDistributionConfigSync(BwDistributionConfig distribution_config);
 
   uint32_t getConnectionTargetBw() { return connection_target_bw_.load(); }
-  void setConnectionTargetBw(uint32_t target_bw) { 
-    connection_target_bw_ = target_bw; 
+  void setConnectionTargetBw(uint32_t target_bw) {
+    connection_target_bw_ = target_bw;
     }
 
   inline std::string toLog() {

--- a/erizo/src/erizo/WebRtcConnection.h
+++ b/erizo/src/erizo/WebRtcConnection.h
@@ -160,6 +160,11 @@ class WebRtcConnection: public TransportListener, public LogContext, public Hand
 
   void setBwDistributionConfigSync(BwDistributionConfig distribution_config);
 
+  uint32_t getConnectionTargetBw() { return connection_target_bw_.load(); }
+  void setConnectionTargetBw(uint32_t target_bw) { 
+    connection_target_bw_ = target_bw; 
+    }
+
   inline std::string toLog() {
     return "id: " + connection_id_ + ", distributor: "
       + std::to_string(bw_distribution_config_.selected_distributor)
@@ -237,6 +242,7 @@ class WebRtcConnection: public TransportListener, public LogContext, public Hand
   ConnectionQualityCheck connection_quality_check_;
   bool enable_connection_quality_check_;
   bool encrypt_transport_;
+  std::atomic <uint32_t> connection_target_bw_;
   Pipeline::Ptr pipeline_;
   bool pipeline_initialized_;
   std::shared_ptr<HandlerManager> handler_manager_;

--- a/erizoAPI/WebRtcConnection.cc
+++ b/erizoAPI/WebRtcConnection.cc
@@ -169,6 +169,7 @@ NAN_MODULE_INIT(WebRtcConnection::Init) {
   Nan::SetPrototypeMethod(tpl, "removeMediaStream", removeMediaStream);
   Nan::SetPrototypeMethod(tpl, "copySdpToLocalDescription", copySdpToLocalDescription);
   Nan::SetPrototypeMethod(tpl, "setBwDistributionConfig", setBwDistributionConfig);
+  Nan::SetPrototypeMethod(tpl, "setConnectionTargetBw", setConnectionTargetBw);
   Nan::SetPrototypeMethod(tpl, "getStats", getStats);
   Nan::SetPrototypeMethod(tpl, "maybeRestartIce", maybeRestartIce);
   Nan::SetPrototypeMethod(tpl, "getDurationDistribution", getDurationDistribution);
@@ -481,6 +482,16 @@ NAN_METHOD(WebRtcConnection::setBwDistributionConfig) {
   std::string distribution_config_string = std::string(*json_param_distribution);
   erizo::BwDistributionConfig distrib_config = obj->parseDistribConfig(distribution_config_string);
   me->setBwDistributionConfig(distrib_config);
+}
+
+NAN_METHOD(WebRtcConnection::setConnectionTargetBw) {
+  WebRtcConnection* obj = Nan::ObjectWrap::Unwrap<WebRtcConnection>(info.Holder());
+  std::shared_ptr<erizo::WebRtcConnection> me = obj->me;
+  if (!me) {
+    return;
+  }
+  int connection_target_bw = Nan::To<int>(info[0]).FromJust();
+  me->setConnectionTargetBw(connection_target_bw);
 }
 
 NAN_METHOD(WebRtcConnection::addRemoteCandidate) {

--- a/erizoAPI/WebRtcConnection.h
+++ b/erizoAPI/WebRtcConnection.h
@@ -135,6 +135,7 @@ class WebRtcConnection : public erizo::WebRtcConnectionEventListener,
     static NAN_METHOD(copySdpToLocalDescription);
 
     static NAN_METHOD(setBwDistributionConfig);
+    static NAN_METHOD(setConnectionTargetBw);
 
     static NAN_METHOD(getStats);
 

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -752,6 +752,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
       spec.defaultVideoBW = response.defaultVideoBW;
       spec.maxVideoBW = response.maxVideoBW;
       that.streamPriorityStrategy = response.streamPriorityStrategy;
+      that.connectionTargetBw = response.connectionTargetBw;
 
       // 2- Retrieve list of streams
       const streamIndices = Object.keys(streams);
@@ -1057,6 +1058,16 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
 
   that.setStreamPriorityStrategy = (strategyId, callback = () => { }) => {
     socket.sendMessage('setStreamPriorityStrategy', strategyId, (result) => {
+      that.streamPriorityStrategy = strategyId;
+      if (result) {
+        callback(result);
+      }
+    });
+  };
+
+  that.setConnectionTargetBandwidth = (connectionTargetBw, callback = () => { }) => {
+    socket.sendMessage('setConnectionTargetBandwidth', connectionTargetBw, (result) => {
+      that.connectionTargetBw = connectionTargetBw;
       if (result) {
         callback(result);
       }

--- a/erizo_controller/erizoController/erizoController.js
+++ b/erizo_controller/erizoController/erizoController.js
@@ -353,6 +353,7 @@ const listen = () => {
           clientId: client.id,
           singlePC: options.singlePC,
           streamPriorityStrategy: options.streamPriorityStrategy,
+          connectionTargetBw: options.connectionTargetBw,
           p2p: room.p2p,
           defaultVideoBW: global.config.erizoController.defaultVideoBW,
           maxVideoBW: global.config.erizoController.maxVideoBW,

--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -473,6 +473,13 @@ exports.ErizoJSController = (erizoJSId, threadPool, ioThreadPool) => {
     }
   };
 
+  that.setClientConnectionTargetBandwidth = (clientId, connectionTargetBw) => {
+    if (clients.has(clientId)) {
+      log.info(`message: updating connectionTargetBandwidth in client ${clientId} to ${connectionTargetBw}`);
+      clients.get(clientId).setConnectionTargetBw(connectionTargetBw);
+    }
+  };
+
   that.getStreamStats = (streamId, callbackRpc) => {
     const stats = {};
     let publisher;

--- a/erizo_controller/erizoJS/models/Client.js
+++ b/erizo_controller/erizoJS/models/Client.js
@@ -23,7 +23,9 @@ class Client extends EventEmitter {
     this.ioThreadPool = ioThreadPool;
     this.singlePc = singlePc;
     this.streamPriorityStrategy = Client._getStreamPriorityStrategy(streamPriorityStrategy);
-    this.connectionTargetBw = options.connectionTargetBw || 0;
+    // The strategy connectionTargetBw is prioritized over connectionTargetBw
+    this.connectionTargetBw =
+     this.streamPriorityStrategy.connectionTargetBw || options.connectionTargetBw || 0;
     this.connectionClientId = 0;
     this.options = options;
   }

--- a/erizo_controller/erizoJS/models/Client.js
+++ b/erizo_controller/erizoJS/models/Client.js
@@ -24,8 +24,7 @@ class Client extends EventEmitter {
     this.singlePc = singlePc;
     this.streamPriorityStrategy = Client._getStreamPriorityStrategy(streamPriorityStrategy);
     // The strategy connectionTargetBw is prioritized over connectionTargetBw
-    this.connectionTargetBw =
-     this.streamPriorityStrategy.connectionTargetBw || options.connectionTargetBw || 0;
+    this.connectionTargetBw = options.connectionTargetBw || 0;
     this.connectionClientId = 0;
     this.options = options;
   }

--- a/erizo_controller/erizoJS/models/Client.js
+++ b/erizo_controller/erizoJS/models/Client.js
@@ -23,6 +23,7 @@ class Client extends EventEmitter {
     this.ioThreadPool = ioThreadPool;
     this.singlePc = singlePc;
     this.streamPriorityStrategy = Client._getStreamPriorityStrategy(streamPriorityStrategy);
+    this.connectionTargetBw = options.connectionTargetBw || 0;
     this.connectionClientId = 0;
     this.options = options;
   }
@@ -61,6 +62,7 @@ class Client extends EventEmitter {
     configuration.isRemote = options.isRemote;
     configuration.encryptTransport = options.encryptTransport;
     configuration.streamPriorityStrategy = this.streamPriorityStrategy;
+    configuration.connectionTargetBw = this.connectionTargetBw;
     const connection = new RtcPeerConnection(configuration);
     connection.on('status_event', (...args) => {
       this.emit('status_event', ...args);
@@ -189,8 +191,16 @@ class Client extends EventEmitter {
     return Array.from(this.connections.values());
   }
 
+  setConnectionTargetBw(connectionTargetBw) {
+    this.connectionTargetBw = connectionTargetBw;
+    this.connections.forEach((connection) => {
+      connection.setConnectionTargetBw(connectionTargetBw);
+    });
+  }
+
   setStreamPriorityStrategy(streamPriorityStrategy) {
     this.streamPriorityStrategy = Client._getStreamPriorityStrategy(streamPriorityStrategy);
+    this.connectionTargetBw = this.streamPriorityStrategy.connectionTargetBw;
     this.connections.forEach((connection) => {
       connection.setStreamPriorityStrategy(this.streamPriorityStrategy);
     });

--- a/erizo_controller/erizoJS/models/RTCPeerConnection.js
+++ b/erizo_controller/erizoJS/models/RTCPeerConnection.js
@@ -626,6 +626,10 @@ class RTCPeerConnection extends EventEmitter {
     this.internalConnection.resetStats();
   }
 
+  setConnectionTargetBw(connectionTargetBw) {
+    this.internalConnection.setConnectionTargetBw(connectionTargetBw);
+  }
+
   setStreamPriorityStrategy(streamPriorityStrategy) {
     this.internalConnection.setStreamPriorityStrategy(streamPriorityStrategy);
   }

--- a/erizo_controller/test/utils.js
+++ b/erizo_controller/test/utils.js
@@ -202,6 +202,7 @@ module.exports.reset = () => {
     addRemoteCandidate: sinon.stub(),
     addMediaStream: sinon.stub().returns(Promise.resolve(true)),
     removeMediaStream: sinon.stub().returns(Promise.resolve()),
+    setConnectionTargetBw: sinon.stub(),
     getConnectionQualityLevel: sinon.stub().returns(2),
     setMetadata: sinon.stub(),
     linkSendersToSdp: sinon.stub().returns(Promise.resolve()),


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR implements a way to set a `target bandwidth` for connections in Licode. This target can be set with as part of a strategy as `connectionTargetBw` or by calling  `room.setConnectionTargetBandwidth` in the client.
The main use of target bitrate is to provide a goal or a target for the bandwidth estimation. Licode will generate padding to try to reach the target bitrate.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.