### PR TITLE
Fix initializing connection target bw

### DIFF
--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -731,7 +731,8 @@ class Client extends events.EventEmitter {
   onSetStreamPriorityStrategy(strategyId, callback = () => {}) {
     this.options.streamPriorityStrategy =
       Client.getStreamPriorityStrategy(strategyId);
-    this.options.connectionTargetBw = this.getStreamPriorityStrategyDefinition().connectionTargetBw || 0;
+    this.options.connectionTargetBw =
+      this.getStreamPriorityStrategyDefinition().connectionTargetBw || 0;
     this.room.amqper.broadcast('ErizoJS', { method: 'setClientStreamPriorityStrategy', args: [this.id, strategyId] });
     callback();
   }

--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -20,8 +20,8 @@ class Client extends events.EventEmitter {
     this.options = options;
     this.options.streamPriorityStrategy =
       Client.getStreamPriorityStrategy(options.streamPriorityStrategy);
-    this.options.connectionTargetBw = Number.isInteger(options.connectionTargetBw) ?
-      options.connectionTargetBw : this.options.streamPriorityStrategy.connectionTargetBw;
+    this.options.connectionTargetBw = this.getStreamPriorityStrategyDefinition().bwDistributorConfig
+      || 0;
     this.socketEventListeners = new Map();
     this.listenToSocketEvents();
     this.user = { name: token.userName, role: token.role, permissions: {} };
@@ -60,6 +60,15 @@ class Client extends events.EventEmitter {
       this.channel.socketRemoveListener(key, value);
     });
   }
+
+  getStreamPriorityStrategyDefinition() {
+    if (this.options.streamPriorityStrategy) {
+      return global.bwDistributorConfig
+        .strategyDefinitions[this.options.streamPriorityStrategy];
+    }
+    return false;
+  }
+
   static getStreamPriorityStrategy(streamPriorityStrategy) {
     log.debug(`message: getting streamPriorityStrategy configuration, streamPriorityStrategy: ${streamPriorityStrategy}`);
     const isStrategyIsDefined = streamPriorityStrategy
@@ -720,7 +729,7 @@ class Client extends events.EventEmitter {
   onSetStreamPriorityStrategy(strategyId, callback = () => {}) {
     this.options.streamPriorityStrategy =
       Client.getStreamPriorityStrategy(strategyId);
-    this.options.connectionTargetBw = this.options.streamPriorityStrategy.connectionTargetBw;
+    this.options.connectionTargetBw = this.getStreamPriorityStrategyDefinition().connectionTargetBw || 0;
     this.room.amqper.broadcast('ErizoJS', { method: 'setClientStreamPriorityStrategy', args: [this.id, strategyId] });
     callback();
   }

--- a/erizo_controller/erizoController/models/Client.js
+++ b/erizo_controller/erizoController/models/Client.js
@@ -20,7 +20,9 @@ class Client extends events.EventEmitter {
     this.options = options;
     this.options.streamPriorityStrategy =
       Client.getStreamPriorityStrategy(options.streamPriorityStrategy);
-    this.options.connectionTargetBw = this.getStreamPriorityStrategyDefinition().bwDistributorConfig
+    this.options.connectionTargetBw =
+      (this.getStreamPriorityStrategyDefinition() &&
+      this.getStreamPriorityStrategyDefinition().connectionTargetBw)
       || 0;
     this.socketEventListeners = new Map();
     this.listenToSocketEvents();


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR fixes cases where the connectionTargetBw was not being properly taken from the strategy definition

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.