### PR TITLE
Close all connections before exiting erizoJS

### DIFF
--- a/erizo_controller/erizoJS/erizoJSController.js
+++ b/erizo_controller/erizoJS/erizoJSController.js
@@ -151,13 +151,14 @@ exports.ErizoJSController = (erizoJSId, threadPool, ioThreadPool) => {
 
     Promise.all(removePromises).then(() => {
       log.info(`message: removeClient - closing all connections on, clientId: ${clientId}`);
-      client.closeAllConnections();
-      clients.delete(client.id);
-      callback('callback', true);
-      if (clients.size === 0) {
-        log.info('message: Removed all clients. Process will exit');
-        process.exit(0);
-      }
+      client.closeAllConnections().then(() => {
+        clients.delete(client.id);
+        callback('callback', true);
+        if (clients.size === 0) {
+          log.info('message: Removed all clients. Process will exit');
+          process.exit(0);
+        }
+      });
     });
   };
 

--- a/erizo_controller/erizoJS/models/Client.js
+++ b/erizo_controller/erizoJS/models/Client.js
@@ -218,10 +218,13 @@ class Client extends EventEmitter {
   closeAllConnections() {
     log.debug(`message: client closing all connections, clientId: ${this.id},`,
       logger.objectToLog(this.options), logger.objectToLog(this.options.metadata));
+    const promises = [];
     this.connections.forEach((connection) => {
-      connection.close();
+      promises.push(connection.close());
     });
-    this.connections.clear();
+    return Promise.all(promises).then(() => {
+      this.connections.clear();
+    });
   }
 
   maybeCloseConnection(id) {


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR aims to fix a crash when exiting ErizoJS after all clients leave.
The crash is caused by a race condition when connections are not closed properly.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.