### PR TITLE
Add Backoff and ramp up periods in padding manager

### DIFF
--- a/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
@@ -134,7 +134,7 @@ void RtpPaddingManagerHandler::recalculatePaddingRate() {
   } else if (time_since_bwe_decreased_ < kMinDurationToSendPaddingAfterBweDecrease) {
     ELOG_DEBUG("%s Backoff Period", connection_->toLog());
     target_padding_bitrate = 0;
-  } else if (time_since_bwe_decreased_ > kMinDurationToSendPaddingAfterBweDecrease) {
+  } else if (time_since_bwe_decreased_ >= kMinDurationToSendPaddingAfterBweDecrease) {
     step = static_cast<double>(time_since_bwe_decreased_.count()) / kMaxDurationInRecoveryFromBwe.count();
     ELOG_DEBUG("%s Ramping up period time since %d, max %d, calculated step %f",
     connection_->toLog(),

--- a/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
@@ -128,15 +128,16 @@ void RtpPaddingManagerHandler::recalculatePaddingRate() {
   double step = 1.0;
   duration time_since_bwe_decreased_ = clock_->now() - last_time_bwe_decreased_;
   if (remb_is_decreasing) {
-    ELOG_DEBUG("remb is decreasing");
+    ELOG_DEBUG("%s Remb is decreasing", connection_->toLog());
     target_padding_bitrate = 0;
     last_time_bwe_decreased_ = clock_->now();
   } else if (time_since_bwe_decreased_ < kMinDurationToSendPaddingAfterBweDecrease) {
-    ELOG_DEBUG("backoff period");
+    ELOG_DEBUG("%s Backoff Period", connection_->toLog());
     target_padding_bitrate = 0;
   } else if (time_since_bwe_decreased_ > kMinDurationToSendPaddingAfterBweDecrease) {
     step = static_cast<double>(time_since_bwe_decreased_.count()) / kMaxDurationInRecoveryFromBwe.count();
-    ELOG_DEBUG("ramping up period time since %d, max %d, calculated step %f",
+    ELOG_DEBUG("%s Ramping up period time since %d, max %d, calculated step %f",
+    connection_->toLog(),
     std::chrono::duration_cast<std::chrono::milliseconds>(time_since_bwe_decreased_).count(),
     std::chrono::duration_cast<std::chrono::milliseconds>(kMaxDurationInRecoveryFromBwe).count(),
     step);

--- a/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
@@ -16,7 +16,7 @@ DEFINE_LOGGER(RtpPaddingManagerHandler, "rtp.RtpPaddingManagerHandler");
 static constexpr duration kStatsPeriod = std::chrono::milliseconds(100);
 constexpr duration RtpPaddingManagerHandler::kMinDurationToSendPaddingAfterBweDecrease;
 constexpr duration RtpPaddingManagerHandler::kMaxDurationInRecoveryFromBwe;
-static constexpr double kBitrateComparisonMargin = 1.3;
+static constexpr double kBitrateComparisonMargin = 1.1;
 static constexpr uint64_t kInitialBitrate = 300000;
 static constexpr uint64_t kUnnasignedBitrateMargin = 50000;
 

--- a/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
@@ -132,13 +132,17 @@ void RtpPaddingManagerHandler::recalculatePaddingRate() {
     target_padding_bitrate = 0;
     last_time_bwe_decreased_ = clock_->now();
   } else if (time_since_bwe_decreased_ < kMinDurationToSendPaddingAfterBweDecrease) {
-    ELOG_DEBUG("%s Backoff Period", connection_->toLog());
+    ELOG_DEBUG("%s Backoff up period time since %d, min %d",
+    connection_->toLog(),
+    std::chrono::duration_cast<std::chrono::milliseconds>(time_since_bwe_decreased_).count(),
+    std::chrono::duration_cast<std::chrono::milliseconds>(kMinDurationToSendPaddingAfterBweDecrease).count());
     target_padding_bitrate = 0;
   } else if (time_since_bwe_decreased_ >= kMinDurationToSendPaddingAfterBweDecrease) {
     step = static_cast<double>(time_since_bwe_decreased_.count()) / kMaxDurationInRecoveryFromBwe.count();
-    ELOG_DEBUG("%s Ramping up period time since %d, max %d, calculated step %f",
+    ELOG_DEBUG("%s Ramping up period time since %d, min %d, max %d, calculated step %f",
     connection_->toLog(),
     std::chrono::duration_cast<std::chrono::milliseconds>(time_since_bwe_decreased_).count(),
+    std::chrono::duration_cast<std::chrono::milliseconds>(kMinDurationToSendPaddingAfterBweDecrease).count(),
     std::chrono::duration_cast<std::chrono::milliseconds>(kMaxDurationInRecoveryFromBwe).count(),
     step);
     step = std::min(step, 1.0);

--- a/erizo/src/erizo/rtp/RtpPaddingManagerHandler.h
+++ b/erizo/src/erizo/rtp/RtpPaddingManagerHandler.h
@@ -42,7 +42,7 @@ class RtpPaddingManagerHandler: public Handler, public std::enable_shared_from_t
   bool initialized_;
   std::shared_ptr<erizo::Clock> clock_;
   time_point last_rate_calculation_time_;
-  time_point last_time_with_packet_losses_;
+  time_point last_time_bwe_decreased_;
   WebRtcConnection* connection_;
   std::shared_ptr<Stats> stats_;
   int64_t last_estimated_bandwidth_;

--- a/erizo/src/erizo/rtp/RtpPaddingManagerHandler.h
+++ b/erizo/src/erizo/rtp/RtpPaddingManagerHandler.h
@@ -19,6 +19,8 @@ class RtpPaddingManagerHandler: public Handler, public std::enable_shared_from_t
   DECLARE_LOGGER();
 
  public:
+  static constexpr duration kMinDurationToSendPaddingAfterBweDecrease = std::chrono::seconds(5);
+  static constexpr duration kMaxDurationInRecoveryFromBwe = std::chrono::seconds(30);
   explicit RtpPaddingManagerHandler(std::shared_ptr<erizo::Clock> the_clock = std::make_shared<erizo::SteadyClock>());
 
   void enable() override;

--- a/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
@@ -211,7 +211,8 @@ TEST_F(RtpPaddingManagerHandlerTest, shouldNotSendPaddingInTheBackoffPeriod) {
   whenCurrentTotalVideoBitrateIs(100);
 
   expectPaddingBitrate(0, 2);
-  clock->advanceTime(RtpPaddingManagerHandler::kMinDurationToSendPaddingAfterBweDecrease - std::chrono::milliseconds(1));
+  clock->advanceTime(
+    RtpPaddingManagerHandler::kMinDurationToSendPaddingAfterBweDecrease - std::chrono::milliseconds(1));
   pipeline->write(packet);
 }
 

--- a/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
@@ -211,7 +211,7 @@ TEST_F(RtpPaddingManagerHandlerTest, shouldNotSendPaddingInTheBackoffPeriod) {
   whenCurrentTotalVideoBitrateIs(100);
 
   expectPaddingBitrate(0, 2);
-  clock->advanceTime(std::chrono::milliseconds(200));
+  clock->advanceTime(RtpPaddingManagerHandler::kMinDurationToSendPaddingAfterBweDecrease - std::chrono::milliseconds(1));
   pipeline->write(packet);
 }
 

--- a/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
@@ -169,6 +169,53 @@ TEST_F(RtpPaddingManagerHandlerTest, shouldDistributePaddingEvenlyAmongStreamsWi
   pipeline->write(packet);
 }
 
+TEST_F(RtpPaddingManagerHandlerTest, shouldStopPaddingIfRembGoesDown) {
+  auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+  whenSubscribersWithTargetBitrate({500});
+  whenPublishers(0);
+  whenBandwidthEstimationIs(300);
+  whenCurrentTotalVideoBitrateIs(100);
+
+  expectPaddingBitrate(200);
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+
+  whenBandwidthEstimationIs(200);
+  whenCurrentTotalVideoBitrateIs(100);
+
+  expectPaddingBitrate(0);
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+}
+
+TEST_F(RtpPaddingManagerHandlerTest, shouldNotSendPaddingInTheBackoffPeriod) {
+  auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+  whenSubscribersWithTargetBitrate({500});
+  whenPublishers(0);
+  whenBandwidthEstimationIs(300);
+  whenCurrentTotalVideoBitrateIs(100);
+
+  expectPaddingBitrate(200);
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+
+  whenBandwidthEstimationIs(200);
+  whenCurrentTotalVideoBitrateIs(100);
+
+  expectPaddingBitrate(0);
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+
+  whenBandwidthEstimationIs(200);
+  whenCurrentTotalVideoBitrateIs(100);
+
+  expectPaddingBitrate(0);
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+}
+
 typedef std::vector<uint32_t> SubscriberBitratesList;
 
 class RtpPaddingManagerHandlerTestWithParam : public RtpPaddingManagerHandlerBaseTest,

--- a/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
@@ -103,10 +103,10 @@ class RtpPaddingManagerHandlerBaseTest : public erizo::BaseHandlerTest {
     return media_stream;
   }
 
-  void expectPaddingBitrate(uint64_t bitrate) {
+  void expectPaddingBitrate(uint64_t bitrate, int times = 1) {
     std::for_each(subscribers.begin(), subscribers.end(),
-      [bitrate](const std::shared_ptr<erizo::MockMediaStream> &stream) {
-        EXPECT_CALL(*stream.get(), setTargetPaddingBitrate(testing::Eq(bitrate))).Times(1);
+      [bitrate, times](const std::shared_ptr<erizo::MockMediaStream> &stream) {
+        EXPECT_CALL(*stream.get(), setTargetPaddingBitrate(testing::Eq(bitrate))).Times(times);
       });
 
     std::for_each(publishers.begin(), publishers.end(),
@@ -204,7 +204,26 @@ TEST_F(RtpPaddingManagerHandlerTest, shouldNotSendPaddingInTheBackoffPeriod) {
   whenBandwidthEstimationIs(200);
   whenCurrentTotalVideoBitrateIs(100);
 
-  expectPaddingBitrate(0);
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+
+  whenBandwidthEstimationIs(200);
+  whenCurrentTotalVideoBitrateIs(100);
+
+  expectPaddingBitrate(0, 2);
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+}
+
+TEST_F(RtpPaddingManagerHandlerTest, shouldRampUpAfterBackoff) {
+  auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+  whenSubscribersWithTargetBitrate({500});
+  whenPublishers(0);
+  whenBandwidthEstimationIs(300);
+  whenCurrentTotalVideoBitrateIs(100);
+
+  expectPaddingBitrate(200);
   clock->advanceTime(std::chrono::milliseconds(200));
   pipeline->write(packet);
 
@@ -213,6 +232,43 @@ TEST_F(RtpPaddingManagerHandlerTest, shouldNotSendPaddingInTheBackoffPeriod) {
 
   expectPaddingBitrate(0);
   clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+
+  whenBandwidthEstimationIs(200);
+  whenCurrentTotalVideoBitrateIs(100);
+  std::chrono::steady_clock::duration kDurationLowerThanMaxDurationInRecovery =
+    RtpPaddingManagerHandler::kMaxDurationInRecoveryFromBwe - std::chrono::seconds(1);
+  double correcting_factor = static_cast<double>(kDurationLowerThanMaxDurationInRecovery.count())/
+    RtpPaddingManagerHandler::kMaxDurationInRecoveryFromBwe.count();
+  expectPaddingBitrate(100 * correcting_factor);
+  clock->advanceTime(kDurationLowerThanMaxDurationInRecovery);
+  pipeline->write(packet);
+}
+
+TEST_F(RtpPaddingManagerHandlerTest, shouldRecoverPaddingBitrateCompletely) {
+  auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+  whenSubscribersWithTargetBitrate({500});
+  whenPublishers(0);
+  whenBandwidthEstimationIs(300);
+  whenCurrentTotalVideoBitrateIs(100);
+
+  expectPaddingBitrate(200);
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+
+  whenBandwidthEstimationIs(200);
+  whenCurrentTotalVideoBitrateIs(100);
+
+  expectPaddingBitrate(0);
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+
+  whenBandwidthEstimationIs(500);
+  whenCurrentTotalVideoBitrateIs(100);
+
+  expectPaddingBitrate(400);
+  clock->advanceTime(RtpPaddingManagerHandler::kMaxDurationInRecoveryFromBwe + std::chrono::milliseconds(100));
   pipeline->write(packet);
 }
 

--- a/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
@@ -340,4 +340,4 @@ INSTANTIATE_TEST_CASE_P(
     std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200},   99,     100,                      0),
     std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200},  600,     600,                      0),
     std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200},    0,     100,                      0),
-    std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200}, 1200,       0,                    200)));
+    std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200}, 1000,       0,                    200)));


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR introduces improved backoff and ramp up periods for `RtpPaddingMangerHandler`, the goal is for the manager to avoid congesting the network whenever possible.

It only takes into account differences in bandwidth estimation. If the estimation decreases, it is detected as potential network problems and padding will stop for some time. After that backoff period, it will gradually ramp up (if the estimation does not decrease again) until it sends the calculated `target_padding_bitrate`.



- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.