### PR TITLE
Fix connection failed event 

### DIFF
--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -42,7 +42,7 @@ class ErizoConnection extends EventEmitterConst {
 
     log.debug(`message: Building a new Connection, ${this.toLog()}`);
     spec.onEnqueueingTimeout = (step) => {
-      const message = `reason: Timeout in ${step}`;
+      const message = `Timeout in ${step}`;
       this._onConnectionFailed(message);
     };
 


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

Properly capture the `failed` message from the connection and emit a `connection-failed` event.
[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**


[] It includes documentation for these changes in `/doc`.