### PR TITLE
Fix race condition in task scheduler

### DIFF
--- a/erizo/src/erizo/thread/Scheduler.cpp
+++ b/erizo/src/erizo/thread/Scheduler.cpp
@@ -20,8 +20,8 @@ Scheduler::~Scheduler() {
   assert(n_threads_servicing_queue_ == 0);
 }
 
-std::chrono::system_clock::time_point Scheduler::getFirstTime() {
-  return task_queue_.empty() ? std::chrono::system_clock::now() : task_queue_.begin()->first;
+std::chrono::steady_clock::time_point Scheduler::getFirstTime() {
+  return task_queue_.empty() ? std::chrono::steady_clock::now() : task_queue_.begin()->first;
 }
 
 void Scheduler::serviceQueue() {
@@ -33,10 +33,15 @@ void Scheduler::serviceQueue() {
         new_task_scheduled_.wait(lock);
       }
 
-      std::chrono::system_clock::time_point time = getFirstTime();
+      std::chrono::steady_clock::time_point time = getFirstTime();
       while (!stop_requested_ && !task_queue_.empty() &&
              new_task_scheduled_.wait_until(lock, time) != std::cv_status::timeout) {
         time = getFirstTime();
+      }
+      // check time again after acquiring lock to ensure the first task is due
+      time = getFirstTime();
+      if (std::chrono::steady_clock::now() < time) {
+        continue;
       }
       if (stop_requested_) {
         break;
@@ -73,7 +78,7 @@ void Scheduler::stop(bool drain) {
   group_.join_all();
 }
 
-void Scheduler::schedule(Scheduler::Function f, std::chrono::system_clock::time_point t) {
+void Scheduler::schedule(Scheduler::Function f, std::chrono::steady_clock::time_point t) {
   {
     std::unique_lock<std::mutex> lock(new_task_mutex_);
     // Pairs in this multimap are sorted by the Key value, so begin() will always point to the
@@ -84,7 +89,7 @@ void Scheduler::schedule(Scheduler::Function f, std::chrono::system_clock::time_
 }
 
 void Scheduler::scheduleFromNow(Scheduler::Function f, std::chrono::milliseconds delta_ms) {
-  schedule(f, std::chrono::system_clock::now() + delta_ms);
+  schedule(f, std::chrono::steady_clock::now() + delta_ms);
 }
 
 // TODO(javier): Make it possible to unschedule repeated tasks before enable this code

--- a/erizo/src/erizo/thread/Scheduler.h
+++ b/erizo/src/erizo/thread/Scheduler.h
@@ -21,7 +21,7 @@ class Scheduler {
 
   typedef boost::function<void(void)> Function;
 
-  void schedule(Function f, std::chrono::system_clock::time_point t);
+  void schedule(Function f, std::chrono::steady_clock::time_point t);
 
   void scheduleFromNow(Function f, std::chrono::milliseconds delta_ms);
 
@@ -34,10 +34,10 @@ class Scheduler {
 
  private:
   void serviceQueue();
-  std::chrono::system_clock::time_point getFirstTime();
+  std::chrono::steady_clock::time_point getFirstTime();
 
  private:
-  std::multimap<std::chrono::system_clock::time_point, Function> task_queue_;
+  std::multimap<std::chrono::steady_clock::time_point, Function> task_queue_;
   std::condition_variable new_task_scheduled_;
   mutable std::mutex new_task_mutex_;
   std::atomic<int> n_threads_servicing_queue_;

--- a/erizo/src/test/thread/SchedulerTest.cpp
+++ b/erizo/src/test/thread/SchedulerTest.cpp
@@ -70,12 +70,38 @@ TEST_P(SchedulerTest, execute_multiple_concurrent_tasks) {
   EXPECT_THAT(counter, Eq(counter_limit));
 }
 
+TEST_P(SchedulerTest, timely_execute_multiple_concurrent_tasks) {
+  counter_limit = 2;
+  scheduleCounterIncrement(20);
+  scheduleCounterIncrement(20);
+  scheduleCounterIncrement(10000);
+  scheduleCounterIncrement(20000);
+
+  auto reason = wait_until(300);
+
+  EXPECT_THAT(reason, Not(Eq(std::cv_status::timeout)));
+  EXPECT_THAT(counter, Eq(counter_limit));
+}
+
 TEST_P(SchedulerTest, execute_tasks_on_different_times) {
   counter_limit = 4;
   scheduleCounterIncrement(20);
   scheduleCounterIncrement(40);
   scheduleCounterIncrement(60);
   scheduleCounterIncrement(80);
+
+  auto reason = wait_until(500);
+
+  EXPECT_THAT(reason, Not(Eq(std::cv_status::timeout)));
+  EXPECT_THAT(counter, Eq(counter_limit));
+}
+
+TEST_P(SchedulerTest, timely_execute_tasks_on_different_times) {
+  counter_limit = 3;
+  scheduleCounterIncrement(20);
+  scheduleCounterIncrement(40);
+  scheduleCounterIncrement(100);
+  scheduleCounterIncrement(600);
 
   auto reason = wait_until(500);
 

--- a/scripts/installMacDeps.sh
+++ b/scripts/installMacDeps.sh
@@ -92,7 +92,7 @@ install_homebrew(){
 }
 
 install_brew_deps(){
-  brew install pkg-config cmake yasm gettext coreutils conan
+  brew install pkg-config glib cmake yasm gettext coreutils conan
   install_nvm_node
   nvm use
   npm install


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
This PR fixes a concurrency issue that could cause scheduled tasks to be executed before their time.
This problem would occur whenever two threads were waiting for the same task (same timeout) at the same time.
As a bonus, I've replaced the `system_clock` for a `steady_clock` which is better in this case since we're always calculating time differences.


- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.