### PR TITLE
Give the option to reuse rooms with the same name

### DIFF
--- a/nuve/nuveAPI/resource/roomsResource.js
+++ b/nuve/nuveAPI/resource/roomsResource.js
@@ -55,6 +55,21 @@ exports.createRoom = (req, res) => {
     if (typeof req.body.options.mediaConfiguration === 'string') {
       room.mediaConfiguration = req.body.options.mediaConfiguration;
     }
+
+    if (req.body.options.getOrCreate) {
+      let existingRoom;
+      currentService.rooms.forEach((r) => {
+        if (r.name === room.name) {
+          existingRoom = r;
+        }
+      });
+      if (existingRoom) {
+        log.info(`message: createRoom success with existing room, roomName:${req.body.name}, ` +
+          `serviceId: ${currentService.name}, p2p: ${existingRoom.p2p}`);
+        res.send(existingRoom);
+        return;
+      }
+    }
     roomRegistry.addRoom(room, (result) => {
       currentService.rooms.push(result);
       serviceRegistry.addRoomToService(currentService, result);

--- a/nuve/nuveAPI/test/resource/roomsResource.js
+++ b/nuve/nuveAPI/test/resource/roomsResource.js
@@ -152,5 +152,86 @@ describe('Rooms Resource', () => {
           done();
         });
     });
+
+    it('should not reuse normal rooms if getOrCreate is not passed', (done) => {
+      kArbitraryRoom = { _id: '1', name: 'arbitraryName', options: { p2p: true, data: '' } };
+      kArbitraryService.rooms = [kArbitraryRoom];
+      roomRegistryMock.addRoom.callsArgWith(1, kArbitraryRoom);
+      setServiceStub.returns(kArbitraryService);
+      request(app)
+        .post('/rooms')
+        .send(kArbitraryRoom)
+        .expect(200, JSON.stringify(kArbitraryRoom))
+        .end((err) => {
+          if (err) throw err;
+          // eslint-disable-next-line no-unused-expressions
+          expect(roomRegistryMock.addRoom.called).to.be.true;
+          expect(kArbitraryService.rooms.length).to.be.equals(2);
+          // eslint-disable-next-line no-unused-expressions
+          expect(serviceRegistryMock.addRoomToService.called).to.be.true;
+          done();
+        });
+    });
+
+    it('should not reuse normal rooms if getOrCreate is false', (done) => {
+      kArbitraryRoom = { _id: '1', name: 'arbitraryName', options: { p2p: true, data: '', getOrCreate: false } };
+      kArbitraryService.rooms = [kArbitraryRoom];
+      roomRegistryMock.addRoom.callsArgWith(1, kArbitraryRoom);
+      setServiceStub.returns(kArbitraryService);
+      request(app)
+        .post('/rooms')
+        .send(kArbitraryRoom)
+        .expect(200, JSON.stringify(kArbitraryRoom))
+        .end((err) => {
+          if (err) throw err;
+          // eslint-disable-next-line no-unused-expressions
+          expect(roomRegistryMock.addRoom.called).to.be.true;
+          expect(kArbitraryService.rooms.length).to.be.equals(2);
+          // eslint-disable-next-line no-unused-expressions
+          expect(serviceRegistryMock.addRoomToService.called).to.be.true;
+          done();
+        });
+    });
+
+    it('should not reuse normal rooms if getOrCreate is true but names are different', (done) => {
+      kArbitraryRoom = { _id: '1', name: 'arbitraryName', options: { p2p: true, data: '', getOrCreate: false } };
+      const kArbitraryRoom2 = { name: 'differentArbitraryName', options: { p2p: true, data: '', getOrCreate: false } };
+      kArbitraryService.rooms = [kArbitraryRoom];
+      roomRegistryMock.addRoom.callsArgWith(1, kArbitraryRoom2);
+      setServiceStub.returns(kArbitraryService);
+      request(app)
+        .post('/rooms')
+        .send(kArbitraryRoom2)
+        .expect(200, JSON.stringify(kArbitraryRoom2))
+        .end((err) => {
+          if (err) throw err;
+          // eslint-disable-next-line no-unused-expressions
+          expect(roomRegistryMock.addRoom.called).to.be.true;
+          expect(kArbitraryService.rooms.length).to.be.equals(2);
+          // eslint-disable-next-line no-unused-expressions
+          expect(serviceRegistryMock.addRoomToService.called).to.be.true;
+          done();
+        });
+    });
+
+    it('should reuse normal rooms if getOrCreate is true', (done) => {
+      kArbitraryRoom = { _id: '1', name: 'arbitraryName', options: { p2p: true, data: '', getOrCreate: true } };
+      kArbitraryService.rooms = [kArbitraryRoom];
+      roomRegistryMock.addRoom.callsArgWith(1, kArbitraryRoom);
+      setServiceStub.returns(kArbitraryService);
+      request(app)
+        .post('/rooms')
+        .send(kArbitraryRoom)
+        .expect(200, JSON.stringify(kArbitraryRoom))
+        .end((err) => {
+          if (err) throw err;
+          // eslint-disable-next-line no-unused-expressions
+          expect(roomRegistryMock.addRoom.called).to.be.false;
+          expect(kArbitraryService.rooms.length).to.be.equals(1);
+          // eslint-disable-next-line no-unused-expressions
+          expect(serviceRegistryMock.addRoomToService.called).to.be.false;
+          done();
+        });
+    });
   });
 });


### PR DESCRIPTION
**Description**

We were having race conditions when creating a room from two different endpoints at the same time. This PR gives the option to reuse rooms with the same name when we call createRoom() to simplify other's codebases.

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

N/A

[] It includes documentation for these changes in `/doc`.