### PR TITLE
Fix crash when calling enableFallback/Slideshow below min layer

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -1086,7 +1086,9 @@ void MediaStream::setQualityLayer(int spatial_layer, int temporal_layer) {
 
 void MediaStream::enableSlideShowBelowSpatialLayer(bool enabled, int spatial_layer) {
   asyncTask([enabled, spatial_layer] (std::shared_ptr<MediaStream> media_stream) {
-    media_stream->quality_manager_->enableSlideShowBelowSpatialLayer(enabled, spatial_layer);
+    if (media_stream->isRunning()) {
+      media_stream->quality_manager_->enableSlideShowBelowSpatialLayer(enabled, spatial_layer);
+    }
   });
 }
 
@@ -1104,7 +1106,9 @@ void MediaStream::addHandlerInPosition(Positions position,
 
 void MediaStream::enableFallbackBelowMinLayer(bool enabled) {
   asyncTask([enabled] (std::shared_ptr<MediaStream> media_stream) {
-    media_stream->quality_manager_->enableFallbackBelowMinLayer(enabled);
+    if (media_stream->isRunning()) {
+      media_stream->quality_manager_->enableFallbackBelowMinLayer(enabled);
+    }
   });
 }
 

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -116,7 +116,7 @@ install_mongodb(){
 }
 
 install_conan(){
-  sudo pip3 install conan==1.34
+  sudo pip3 install conan==1.37
   conan remote update conan-center https://center.conan.io False
 }
 

--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -117,7 +117,7 @@ install_mongodb(){
 
 install_conan(){
   sudo pip3 install conan==1.34
-  conan remote update conan-center https://conan.bintray.com False
+  conan remote update conan-center https://center.conan.io False
 }
 
 install_cpplint(){


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

`enableFallbackBelowMinLayer` and `enableSlideshowBelowMinLayer` are called from `StreamPriorityBWDistributor` in the `WebRtcConnection` thread. It is possible for the asyncTask in `MediaStream` to make those calls when the pipeline is already close but the `MediaStream` has not been destroyed yet. This results in a crash since it will end up calling `selectLayer` in `QualityManager` that tries to access the already removed pipeline directly.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.