### PR TITLE
Add packet stats and improve padding bitrate assignment

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -395,6 +395,7 @@ void MediaStream::printStats() {
   if (audio_enabled_) {
     audio_ssrc = std::to_string(is_publisher_ ? getAudioSourceSSRC() : getAudioSinkSSRC());
     transferMediaStats("audioBitrate", audio_ssrc, "bitrateCalculated");
+    transferMediaStats("audioPackets", audio_ssrc, "packetsCalculated");
     transferMediaStats("audioPL",      audio_ssrc, "packetsLost");
     transferMediaStats("audioFL",      audio_ssrc, "fractionLost");
     transferMediaStats("audioJitter",  audio_ssrc, "jitter");
@@ -407,6 +408,9 @@ void MediaStream::printStats() {
   if (video_enabled_) {
     video_ssrc = std::to_string(is_publisher_ ? getVideoSourceSSRC() : getVideoSinkSSRC());
     transferMediaStats("videoBitrate", video_ssrc, "bitrateCalculated");
+    transferMediaStats("videoBitrateWithoutPadding", video_ssrc, "mediaBitrateCalculated");
+    transferMediaStats("videoPackets", video_ssrc, "packetsCalculated");
+    transferMediaStats("videoPacketsWithoutPadding", video_ssrc, "mediaPacketsCalculated");
     transferMediaStats("videoPL",      video_ssrc, "packetsLost");
     transferMediaStats("videoFL",      video_ssrc, "fractionLost");
     transferMediaStats("videoJitter",  video_ssrc, "jitter");
@@ -434,6 +438,7 @@ void MediaStream::printStats() {
   transferMediaStats("selectedTL", "qualityLayers", "selectedTemporalLayer");
   transferMediaStats("qualityLevel", "qualityLayers", "currentQualityLevel");
   transferMediaStats("totalBitrate", "total", "bitrateCalculated");
+  transferMediaStats("totalPackets", "total", "packetsCalculated");
   transferMediaStats("paddingBitrate", "total", "paddingBitrate");
   transferMediaStats("rtxBitrate", "total", "rtxBitrate");
   transferMediaStats("bwe", "total", "senderBitrateEstimation");

--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -157,6 +157,8 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   bool isAudioMuted() { return audio_muted_; }
   bool isVideoMuted() { return video_muted_; }
 
+  bool canSendPadding() { return !isPublisher() && hasVideo() && !isVideoMuted(); }
+
   std::shared_ptr<SdpInfo> getRemoteSdpInfo() { return remote_sdp_; }
 
   virtual bool isSlideShowModeEnabled() { return slide_show_mode_; }

--- a/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
@@ -167,7 +167,7 @@ void RtpPaddingManagerHandler::distributeTotalTargetPaddingBitrate(int64_t bitra
   size_t num_streams = 0;
   connection_->forEachMediaStream([&num_streams]
     (std::shared_ptr<MediaStream> media_stream) {
-      if (!media_stream->isPublisher()) {
+      if (media_stream->canSendPadding()) {
         num_streams++;
       }
     });
@@ -179,7 +179,7 @@ void RtpPaddingManagerHandler::distributeTotalTargetPaddingBitrate(int64_t bitra
   int64_t bitrate_per_stream = bitrate / num_streams;
   connection_->forEachMediaStreamAsync([bitrate_per_stream]
     (std::shared_ptr<MediaStream> media_stream) {
-      if (media_stream->isPublisher()) {
+      if (!media_stream->canSendPadding()) {
         return;
       }
       media_stream->setTargetPaddingBitrate(bitrate_per_stream);
@@ -190,7 +190,7 @@ int64_t RtpPaddingManagerHandler::getTotalTargetBitrate() {
   int64_t target_bitrate = 0;
   connection_->forEachMediaStream([&target_bitrate]
     (std::shared_ptr<MediaStream> media_stream) {
-      if (media_stream->isPublisher()) {
+      if (!media_stream->canSendPadding()) {
         return;
       }
       target_bitrate += media_stream->getTargetVideoBitrate();

--- a/erizo/src/erizo/rtp/StatsHandler.cpp
+++ b/erizo/src/erizo/rtp/StatsHandler.cpp
@@ -20,6 +20,8 @@ void StatsCalculator::update(MediaStream *stream, std::shared_ptr<Stats> stats) 
     if (!getStatsInfo().hasChild("total")) {
       getStatsInfo()["total"].insertStat("bitrateCalculated", MovingIntervalRateStat{kRateStatIntervalSize,
         kRateStatIntervals, 8.});
+      getStatsInfo()["total"].insertStat("packetsCalculated", MovingIntervalRateStat{kRateStatIntervalSize,
+        kRateStatIntervals, 1.});
     }
   }
 }
@@ -52,11 +54,18 @@ void StatsCalculator::processRtpPacket(std::shared_ptr<DataPacket> packet) {
         kRateStatIntervals, 8.});
     getStatsInfo()[ssrc].insertStat("mediaBitrateCalculated", MovingIntervalRateStat{kRateStatIntervalSize,
         kRateStatIntervals, 8.});
+    getStatsInfo()[ssrc].insertStat("packetsCalculated", MovingIntervalRateStat{kRateStatIntervalSize,
+        kRateStatIntervals, 1.});
+    getStatsInfo()[ssrc].insertStat("mediaPacketsCalculated", MovingIntervalRateStat{kRateStatIntervalSize,
+        kRateStatIntervals, 1.});
   }
   getStatsInfo()[ssrc]["bitrateCalculated"] += len;
+  getStatsInfo()[ssrc]["packetsCalculated"] += 1;
   getStatsInfo()["total"]["bitrateCalculated"] += len;
+  getStatsInfo()["total"]["packetsCalculated"] += 1;
   if (!packet->is_padding) {
     getStatsInfo()[ssrc]["mediaBitrateCalculated"] += len;
+    getStatsInfo()[ssrc]["mediaPacketsCalculated"] += 1;
   }
   if (packet->type == VIDEO_PACKET) {
     stream_->setVideoBitrate(getStatsInfo()[ssrc]["mediaBitrateCalculated"].value());


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR solves a potential issue when deciding which streams will send padding. The PaddingManager now filters and only assigns bitrate to those subscribed streams that have video that is not muted.

This PR also adds logs to keep track of packets received and sent per SSRC while also accounting for the video bitrate with or without padding.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.