### PR TITLE
Notify about low conn quality levels if bw is not enough for first layers

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -1139,7 +1139,7 @@ uint64_t MediaStream::getBitrateForHigherTemporalInSpatialLayer(int spatial_laye
 
 uint64_t MediaStream::getBitrateForLowerTemporalInSpatialLayer(int spatial_layer) {
   boost::mutex::scoped_lock lock(layer_bitrates_mutex_);
-  if ((int)layer_bitrates_.size() > spatial_layer && layer_bitrates_[spatial_layer].size() > 0) {
+  if (static_cast<int>(layer_bitrates_.size()) > spatial_layer && layer_bitrates_[spatial_layer].size() > 0) {
     return layer_bitrates_[spatial_layer][0];
   }
   return 0;

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -1139,7 +1139,11 @@ uint64_t MediaStream::getBitrateForHigherTemporalInSpatialLayer(int spatial_laye
 
 uint64_t MediaStream::getBitrateForLowerTemporalInSpatialLayer(int spatial_layer) {
   boost::mutex::scoped_lock lock(layer_bitrates_mutex_);
-  if (static_cast<int>(layer_bitrates_.size()) > spatial_layer && layer_bitrates_[spatial_layer].size() > 0) {
+  if (spatial_layer < 0) {
+    return 0;
+  }
+  if (static_cast<int>(layer_bitrates_.size()) > spatial_layer &&
+      layer_bitrates_[spatial_layer].size() > 0) {
     return layer_bitrates_[spatial_layer][0];
   }
   return 0;

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -1137,4 +1137,12 @@ uint64_t MediaStream::getBitrateForHigherTemporalInSpatialLayer(int spatial_laye
   return 0;
 }
 
+uint64_t MediaStream::getBitrateForLowerTemporalInSpatialLayer(int spatial_layer) {
+  boost::mutex::scoped_lock lock(layer_bitrates_mutex_);
+  if (layer_bitrates_.size() > spatial_layer && layer_bitrates_[spatial_layer].size() > 0) {
+    return layer_bitrates_[spatial_layer][0];
+  }
+  return 0;
+}
+
 }  // namespace erizo

--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -1139,7 +1139,7 @@ uint64_t MediaStream::getBitrateForHigherTemporalInSpatialLayer(int spatial_laye
 
 uint64_t MediaStream::getBitrateForLowerTemporalInSpatialLayer(int spatial_layer) {
   boost::mutex::scoped_lock lock(layer_bitrates_mutex_);
-  if (layer_bitrates_.size() > spatial_layer && layer_bitrates_[spatial_layer].size() > 0) {
+  if ((int)layer_bitrates_.size() > spatial_layer && layer_bitrates_[spatial_layer].size() > 0) {
     return layer_bitrates_[spatial_layer][0];
   }
   return 0;

--- a/erizo/src/erizo/MediaStream.h
+++ b/erizo/src/erizo/MediaStream.h
@@ -195,6 +195,7 @@ class MediaStream: public MediaSink, public MediaSource, public FeedbackSink,
   void setBitrateForLayer(int temporal_layer, int spatial_layer, uint64_t bitrate);
   uint64_t getBitrateForLayer(int spatial_layer, int temporal_layer);
   uint64_t getBitrateForHigherTemporalInSpatialLayer(int spatial_layer);
+  uint64_t getBitrateForLowerTemporalInSpatialLayer(int spatial_layer);
 
   inline std::string toLog() {
     return "id: " + stream_id_ + ", role:" + (is_publisher_ ? "publisher" : "subscriber")

--- a/erizo/src/test/bandwidth/StreamPriorityBWDistributor.cpp
+++ b/erizo/src/test/bandwidth/StreamPriorityBWDistributor.cpp
@@ -461,6 +461,21 @@ INSTANTIATE_TEST_CASE_P(
       StreamPriorityStep("20", "2")
       },
       100, EnabledList{1, 1, 1, 1},    ExpectedList{50, 50, 0, 0},
+      true),
+    make_tuple(StreamConfigList{
+      {1000, 0, 450, "20", std::vector<std::vector<uint64_t>>({ { 50, 150, 300 }, { 250, 300, 450} }), false, true},
+      {1000, 0, 450, "20", std::vector<std::vector<uint64_t>>({ { 50, 150, 300 }, { 250, 300, 450} }), false, true},
+      {1000, 0, 450, "0", std::vector<std::vector<uint64_t>>({ { 50, 150, 300 }, { 250, 300, 450} }), false, true},
+      {1000, 0, 450, "0", std::vector<std::vector<uint64_t>>({ { 50, 150, 300 }, { 250, 300, 450} }), false, true}
+      },
+      StrategyVector{
+      StreamPriorityStep("20", "0"),
+      StreamPriorityStep("10", "0"),
+      StreamPriorityStep("0", "0"),
+      StreamPriorityStep("20", "1"),
+      StreamPriorityStep("20", "2")
+      },
+      100, EnabledList{1, 1, 1, 1},    ExpectedList{50, 50, 0, 0},
       false),
     make_tuple(StreamConfigList{
       {1000, 0, 450, "0", std::vector<std::vector<uint64_t>>({ { 100, 150, 200 }, { 250, 300, 450} }), false, true},

--- a/erizo/src/test/log4cxx.properties
+++ b/erizo/src/test/log4cxx.properties
@@ -62,3 +62,5 @@ log4j.logger.rtp.SRPacketHandler=ERROR
 log4j.logger.rtp.SenderBandwidthEstimationHandler=ERROR
 log4j.logger.rtp.StatsCalculator=ERROR
 log4j.logger.rtp.RtpPaddingGeneratorHandler=ERROR
+
+log4j.logger.bandwidth.StreamPriorityBWDistributor=ERROR


### PR DESCRIPTION
**Description**

I was not taken into account if we distributed BW into layers but with not enough bandwidth to send the very first temporal layer.

- [x] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

Not needed.

[] It includes documentation for these changes in `/doc`.