### PR TITLE
Fix to recording

### DIFF
--- a/erizo_controller/erizoJS/models/Publisher.js
+++ b/erizo_controller/erizoJS/models/Publisher.js
@@ -392,7 +392,7 @@ class Source extends NodeClass {
 
 class Publisher extends Source {
   constructor(clientId, streamId, connection, options) {
-    super(clientId, streamId, connection.threadPool, options);
+    super(clientId, streamId, connection.internalConnection.threadPool, options);
     this.mediaConfiguration = options.mediaConfiguration;
     this.options = options;
     this.connection = connection;


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

Recording was broken in the latest version of Licode. When trying to record the following error happened:

[erizo-0748cec0-2097-34c0-614a-5c62adf86945] 2022-01-14T10:50:34.332  - INFO: Publisher - message: Adding ExternalOutput, id: /tmp/331516203452821600.mkv_754069268214465700, url: /tmp/331516203452821600.mkv, state: erizo, data: true, audio: true, video: true, label: fpf1k0FCuYrewAYWb5IP07gu3ZPayyeHmvWy, screen: false, attributes: {}, metadata: {type: publisher}, muteStream: {audio: false, video: false}, encryptTransport: true, handlerProfile: {}, minVideoBW: 0, maxVideoBW: 300, mediaConfiguration: default, singlePC: false, streamPriorityStrategy: false, connectionTargetBw: 0, publicIP: 138.4.7.37, privateRegexp: {}, isRemote: true type: publisher
[erizo-0748cec0-2097-34c0-614a-5c62adf86945] FATAL ERROR: v8::ToLocalChecked Empty MaybeLocal.
[erizo-0748cec0-2097-34c0-614a-5c62adf86945]  1: 0x9d8da0 node::Abort() [node]
[erizo-0748cec0-2097-34c0-614a-5c62adf86945]  2: 0x9d9f56 node::OnFatalError(char const*, char const*) [node]
[erizo-0748cec0-2097-34c0-614a-5c62adf86945]  3: 0xb37b8a v8::Utils::ReportApiFailure(char const*, char const*) [node]
[erizo-0748cec0-2097-34c0-614a-5c62adf86945]  4: 0x7f47181e460d ExternalOutput::New(Nan::FunctionCallbackInfo<v8::Value> const&) [/home/licode/erizoAPI/build/Release/addon.node]
 5: 0x7f4718198f5f  [/home/licode/erizoAPI/build/Release/addon.node]
[erizo-0748cec0-2097-34c0-614a-5c62adf86945]  6: 0xba4edb  [node]
[erizo-0748cec0-2097-34c0-614a-5c62adf86945]  7: 0xba5a62 v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) [node]
[erizo-0748cec0-2097-34c0-614a-5c62adf86945]  8: 0x13726d9  [node]
2022-01-14T10:50:34.831  - INFO: ErizoAgent - message: closed, erizoId: 0748cec0-2097-34c0-614a-5c62adf86945
2022-01-14T10:50:34.834  - INFO: ErizoAgent - message: launched new ErizoJS, erizoId: de3b32eb-c783-dc7e-d09b-b560136773b2

The creation of the externalOutput was failing because the threadPool provided in the constructor was undefined. I found a threadPool in the connection object in connection.internalConnection.threadPool instead of connection.threadPool. Passing this threadPool results in recording working again, however resulting files require post-processing for correct visualization. 

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.