### PR TITLE
Enable padding when in slideshow below_min_layer

### DIFF
--- a/erizo/src/erizo/MediaStream.cpp
+++ b/erizo/src/erizo/MediaStream.cpp
@@ -790,7 +790,7 @@ uint32_t MediaStream::getTargetVideoBitrate() {
   if (is_simulcast) {
     target_bitrate = std::min(bitrate_from_max_quality_layer, max_bitrate);
   }
-  if (slide_show_mode || !is_simulcast) {
+  if ((slide_show_mode && !quality_manager_->isEnableSlideshowBelowSpatialLayer()) || !is_simulcast) {
     target_bitrate = std::min(bitrate_sent, max_bitrate);
   }
   if (target_bitrate == 0) {

--- a/erizo/src/erizo/rtp/QualityManager.h
+++ b/erizo/src/erizo/rtp/QualityManager.h
@@ -33,6 +33,8 @@ class QualityManager: public Service, public std::enable_shared_from_this<Qualit
   void forceLayers(int spatial_layer, int temporal_layer);
   void enableSlideShowBelowSpatialLayer(bool enabled, int spatial_layer);
   void enableFallbackBelowMinLayer(bool enabled);
+  bool isEnableSlideshowBelowSpatialLayer() { return enable_slideshow_below_spatial_layer_; }
+  bool isEnableFallbackBelowMinLayer() { return enable_fallback_below_min_layer_; }
   void setVideoConstraints(int max_video_width, int max_video_height, int max_video_frame_rate);
   void notifyEvent(MediaEventPtr event) override;
   void notifyQualityUpdate();


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

We were disabling padding (the target bitrate is the bitrate sent) when in slideshow below_min_layer. That can cause streams to be locked in that state without having a chance to recover and actually receive the spatial layer.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.