### PR TITLE
Bump markupsafe 2.1.0 to 2.0.1

### DIFF
--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -117,6 +117,7 @@ install_mongodb(){
 
 install_conan(){
   sudo pip3 install conan==1.43
+  sudo pip3 install markupsafe==2.0.1
 }
 
 install_cpplint(){


### PR DESCRIPTION
**Description**

When licode docker build, there is some error with markupsafe version. 
(ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/local/lib/python3.8/dist-packages/markupsafe/__init__.py))

markupsafe installed automatically this logic. so,  i added pip install.


ref : https://github.com/aws/aws-sam-cli/issues/3661
