### PR TITLE
Update circleCi image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.0
 jobs:
   build:
     docker:
-      - image: circleci/buildpack-deps:trusty-curl-browsers
+      - image: cimg/base:current 
 
     working_directory: /tmp/licode
 
@@ -65,7 +65,7 @@ jobs:
 
   prerelease:
     docker:
-      - image: circleci/buildpack-deps:trusty-curl-browsers
+      - image: cimg/base:current
 
     working_directory: /tmp/licode
 
@@ -87,7 +87,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/buildpack-deps:trusty-curl-browsers
+      - image: cimg/base:current
 
     working_directory: /tmp/licode
 


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

The images we were using for building in circleCI were deprecated. 
Updated them according to [this thread](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034#deprecated-images-3)

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.