### PR TITLE
Adjust min bitrate with the number of streams

### DIFF
--- a/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
@@ -90,7 +90,7 @@ void SenderBandwidthEstimationHandler::updateNumberOfStreams() {
   // if there are streams update bitrate limits
   if (num_streams > 0) {
     uint32_t min_send_bitrate = std::min(kMinSendBitrate * static_cast<uint32_t>(num_streams), kMinSendBitrateLimit);
-    ELOG_WARN("SetBitrates, estimated: %u, min: %u, max: %u", estimated_bitrate_, min_send_bitrate, kMaxSendBitrate);
+    ELOG_DEBUG("SetBitrates, estimated: %u, min: %u, max: %u", estimated_bitrate_, min_send_bitrate, kMaxSendBitrate);
 
     sender_bwe_->SetBitrates(
       absl::optional<webrtc::DataRate>(),

--- a/erizo/src/erizo/rtp/SenderBandwidthEstimationHandler.h
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimationHandler.h
@@ -28,6 +28,7 @@ class SenderBandwidthEstimationHandler : public Handler,
   static const uint16_t kMaxSrListSize = 20;
   static const uint32_t kStartSendBitrate = 300000;
   static const uint32_t kMinSendBitrate = 30000;
+  static const uint32_t kMinSendBitrateLimit = 1000000;
   static const uint32_t kMaxSendBitrate = 1000000000;
   static constexpr duration kMinUpdateEstimateInterval = std::chrono::milliseconds(25);
 
@@ -53,7 +54,7 @@ class SenderBandwidthEstimationHandler : public Handler,
     bwe_listener_ = listener;
   }
  private:
-  void updateMaxListSizes();
+  void updateNumberOfStreams();
   void updateReceiverBlockFromList();
   webrtc::Timestamp getNowTimestamp();
 


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
When in SinglePC we usually have multiple streams in one connection. This simple PR updates the min sending bitrate according to the number of streams.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.