### PR TITLE
Implement new padding manager calculation algorithm

### DIFF
--- a/erizo/src/erizo/WebRtcConnection.cpp
+++ b/erizo/src/erizo/WebRtcConnection.cpp
@@ -149,6 +149,7 @@ void WebRtcConnection::initializeStats() {
   log_stats_->getNode().insertStat("bwe", CumulativeStat{0});
   log_stats_->getNode().insertStat("bwDistributionAlgorithm", StringStat{""});
   log_stats_->getNode().insertStat("bwPriorityStrategy", StringStat{""});
+  log_stats_->getNode().insertStat("paddingMode", CumulativeStat{0});
 
   std::weak_ptr<WebRtcConnection> weak_this = shared_from_this();
   worker_->scheduleEvery([weak_this] () {
@@ -178,6 +179,7 @@ void WebRtcConnection::printStats() {
   log_stats_->getNode().insertStat("connectionQualityLevel",
       CumulativeStat(getConnectionQualityLevel()));
   transferMediaStats("bwe", "total", "senderBitrateEstimation");
+  transferMediaStats("paddingMode", "total", "paddingMode");
 
   ELOG_INFOT(ConnectionStatsLogger, "%s", log_stats_->getStats());
 }

--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
@@ -161,7 +161,7 @@ void BandwidthEstimationHandler::read(Context *ctx, std::shared_ptr<DataPacket> 
       RtpHeader *head = reinterpret_cast<RtpHeader*> (packet->data);
       int64_t arrival_time_ms = packet->received_time_ms;
       arrival_time_ms = clock_->TimeInMilliseconds() - (ClockUtils::timePointToMs(clock::now()) - arrival_time_ms);
-      size_t payload_size = packet->length - head->getHeaderLength();
+      size_t payload_size = packet->length;
       pickEstimatorFromHeader();
       rbe_->IncomingPacket(arrival_time_ms, payload_size, header_);
     } else {

--- a/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
@@ -54,6 +54,8 @@ void RtpPaddingManagerHandler::notifyUpdate() {
         MovingIntervalRateStat{std::chrono::milliseconds(100), 30, 8., clock_});
     stats_->getNode()["total"].insertStat("videoBitrate",
         MovingIntervalRateStat{std::chrono::milliseconds(100), 30, 8., clock_});
+    stats_->getNode()["total"].insertStat("paddingMode",
+        CumulativeStat{current_mode_});
   }
 
   if (!connection_) {
@@ -197,6 +199,8 @@ void RtpPaddingManagerHandler::forceModeSwitch(PaddingManagerMode new_mode) {
       std::chrono::duration_cast<std::chrono::milliseconds>(clock_->now() - last_mode_change_));
   current_mode_ = new_mode;
   last_mode_change_ = clock_->now();
+  stats_->getNode()["total"].insertStat("paddingMode",
+      CumulativeStat{current_mode_});
 }
 
 void RtpPaddingManagerHandler::maybeTriggerTimedModeChanges() {

--- a/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
@@ -14,18 +14,19 @@ namespace erizo {
 DEFINE_LOGGER(RtpPaddingManagerHandler, "rtp.RtpPaddingManagerHandler");
 
 static constexpr duration kStatsPeriod = std::chrono::milliseconds(100);
-constexpr duration RtpPaddingManagerHandler::kMinDurationToSendPaddingAfterBweDecrease;
-constexpr duration RtpPaddingManagerHandler::kMaxDurationInRecoveryFromBwe;
 static constexpr double kBitrateComparisonMargin = 1.1;
 static constexpr uint64_t kInitialBitrate = 300000;
-static constexpr uint64_t kUnnasignedBitrateMargin = 50000;
+static constexpr uint64_t kUnnasignedBitrateMargin = 200000;
 
 RtpPaddingManagerHandler::RtpPaddingManagerHandler(std::shared_ptr<erizo::Clock> the_clock) :
   initialized_{false},
   clock_{the_clock},
   last_rate_calculation_time_{clock_->now()},
+  last_mode_change_{clock_->now()},
   connection_{nullptr},
-  last_estimated_bandwidth_{0} {
+  last_estimated_bandwidth_{0},
+  can_recover_{true},
+  current_mode_{PaddingManagerMode::START} {
 }
 
 void RtpPaddingManagerHandler::enable() {
@@ -83,6 +84,11 @@ void RtpPaddingManagerHandler::write(Context *ctx, std::shared_ptr<DataPacket> p
   ctx->fireWrite(packet);
 }
 
+PaddingManagerMode RtpPaddingManagerHandler::getCurrentPaddingMode() {
+  ELOG_DEBUG("Getting current padding mode - %u", current_mode_);
+  return current_mode_;
+}
+
 void RtpPaddingManagerHandler::recalculatePaddingRate() {
   if (!isTimeToCalculateBitrate()) {
     return;
@@ -107,60 +113,127 @@ void RtpPaddingManagerHandler::recalculatePaddingRate() {
   }
 
   int64_t target_padding_bitrate = std::max(target_bitrate - media_bitrate, int64_t(0));
-  int64_t available_bw = std::max(estimated_bandwidth - media_bitrate, int64_t(0));
-
-  target_padding_bitrate = std::min(target_padding_bitrate, available_bw);
-
-  bool estimated_is_high_enough = estimated_bandwidth > (target_bitrate * kBitrateComparisonMargin);
-  bool has_unnasigned_bitrate = false;
-  bool has_connection_target_bitrate = connection_->getConnectionTargetBw() > 0;
-  if (stats_->getNode()["total"].hasChild("unnasignedBitrate")) {
-    has_unnasigned_bitrate =
-        stats_->getNode()["total"]["unnasignedBitrate"].value() > kUnnasignedBitrateMargin &&
-        !has_connection_target_bitrate;
-  }
-  if (estimated_is_high_enough || has_unnasigned_bitrate) {
-    target_padding_bitrate = 0;
-  }
-
   bool remb_is_decreasing = estimated_bandwidth < last_estimated_bandwidth_;
+  bool remb_sharp_drop = estimated_bandwidth < last_estimated_bandwidth_*kBweSharpDropThreshold;
+  if (current_mode_ == PaddingManagerMode::RECOVER) {  // if in recover mode any drop will stop it
+    remb_sharp_drop = estimated_bandwidth < last_estimated_bandwidth_;
+  }
+  int64_t available_bitrate = std::max(estimated_bandwidth - media_bitrate, int64_t(0));
+
+  ELOG_DEBUG("Is sharp drop? last_estimated*k %f, new_estimated %u", last_estimated_bandwidth_*kBweSharpDropThreshold,
+    estimated_bandwidth);
+  //  Maybe Trigger Hold Mode
+  if (remb_sharp_drop) {
+    estimated_before_drop_ = last_estimated_bandwidth_;
+    ELOG_DEBUG("%s Detected sharp BWE drop, estimated_before_drop_: %lu, estimated_bandwidth: %u",
+        connection_->toLog(), estimated_before_drop_, estimated_bandwidth);
+    if (current_mode_ == PaddingManagerMode::RECOVER) {
+      ELOG_DEBUG("%s, Sharp drop in recover mode", connection_->toLog());
+      can_recover_ = false;
+    }
+    forceModeSwitch(PaddingManagerMode::HOLD);
+  }
   last_estimated_bandwidth_ = estimated_bandwidth;
-  double step = 1.0;
-  duration time_since_bwe_decreased_ = clock_->now() - last_time_bwe_decreased_;
-  if (remb_is_decreasing) {
-    ELOG_DEBUG("%s Remb is decreasing", connection_->toLog());
-    target_padding_bitrate = 0;
-    last_time_bwe_decreased_ = clock_->now();
-  } else if (time_since_bwe_decreased_ < kMinDurationToSendPaddingAfterBweDecrease) {
-    ELOG_DEBUG("%s Backoff up period time since %d, min %d",
-    connection_->toLog(),
-    std::chrono::duration_cast<std::chrono::milliseconds>(time_since_bwe_decreased_).count(),
-    std::chrono::duration_cast<std::chrono::milliseconds>(kMinDurationToSendPaddingAfterBweDecrease).count());
-    target_padding_bitrate = 0;
-  } else if (time_since_bwe_decreased_ >= kMinDurationToSendPaddingAfterBweDecrease) {
-    step = static_cast<double>(time_since_bwe_decreased_.count()) / kMaxDurationInRecoveryFromBwe.count();
-    ELOG_DEBUG("%s Ramping up period time since %d, min %d, max %d, calculated step %f",
-    connection_->toLog(),
-    std::chrono::duration_cast<std::chrono::milliseconds>(time_since_bwe_decreased_).count(),
-    std::chrono::duration_cast<std::chrono::milliseconds>(kMinDurationToSendPaddingAfterBweDecrease).count(),
-    std::chrono::duration_cast<std::chrono::milliseconds>(kMaxDurationInRecoveryFromBwe).count(),
-    step);
-    step = std::min(step, 1.0);
-    target_padding_bitrate = target_padding_bitrate * step;
+
+  //  Check if it's time to change mode
+  maybeTriggerTimedModeChanges();
+
+  switch (current_mode_) {
+    case PaddingManagerMode::START:
+      {
+        available_bitrate = std::max(estimated_bandwidth*kStartModeFactor - media_bitrate, static_cast<double>(0));
+        target_padding_bitrate = std::min(target_padding_bitrate, available_bitrate);  // never send more than max
+        break;
+      }
+    case PaddingManagerMode::STABLE:
+      {
+        can_recover_ = true;
+        target_padding_bitrate = std::min(target_padding_bitrate,
+          static_cast<int64_t>(available_bitrate*kStableModeAvailableFactor));
+        bool has_unnasigned_bitrate = false;
+        bool has_connection_target_bitrate = connection_->getConnectionTargetBw() > 0;
+        bool estimated_is_high_enough = estimated_bandwidth > (target_bitrate * kBitrateComparisonMargin);
+        if (stats_->getNode()["total"].hasChild("unnasignedBitrate")) {
+          has_unnasigned_bitrate =
+            stats_->getNode()["total"]["unnasignedBitrate"].value() > kUnnasignedBitrateMargin &&
+            !has_connection_target_bitrate;
+        }
+        if (estimated_is_high_enough || has_unnasigned_bitrate) {
+          target_padding_bitrate = 0;
+        }
+        break;
+      }
+    case PaddingManagerMode::HOLD:
+      {
+        target_padding_bitrate = 0;
+        break;
+      }
+    case PaddingManagerMode::RECOVER:
+      {
+        available_bitrate = std::max(estimated_before_drop_*kRecoverBweFactor - media_bitrate, static_cast<double>(0));
+        target_padding_bitrate = std::min(available_bitrate, target_bitrate);
+        break;
+      }
   }
 
-  ELOG_DEBUG("%s Calculated: target %d, bwe %d, last_bwe %d, media %d, target %d, bwe enough %d"
-  " step %f, remb_is_decreasing %d",
-    connection_->toLog(),
-    target_padding_bitrate,
-    estimated_bandwidth,
-    last_estimated_bandwidth_,
-    media_bitrate,
+  ELOG_DEBUG("Padding stats: target_bitrate %lu, target_padding_bitrate %lu, current_mode_ %u "
+  "estimated_bitrate %lu, media_bitrate: %lu, available_bw: %lu",
     target_bitrate,
-    estimated_is_high_enough,
-    step,
-    remb_is_decreasing);
+    target_padding_bitrate,
+    current_mode_,
+    estimated_bandwidth,
+    media_bitrate,
+    available_bitrate,
+    current_mode_);
+
   distributeTotalTargetPaddingBitrate(target_padding_bitrate);
+}
+
+void RtpPaddingManagerHandler::forceModeSwitch(PaddingManagerMode new_mode) {
+  ELOG_DEBUG("%s switching mode, current_mode_ %u, new_mode %u, ms since last change %lu",
+      connection_->toLog(),
+      current_mode_,
+      new_mode,
+      std::chrono::duration_cast<std::chrono::milliseconds>(clock_->now() - last_mode_change_));
+  current_mode_ = new_mode;
+  last_mode_change_ = clock_->now();
+}
+
+void RtpPaddingManagerHandler::maybeTriggerTimedModeChanges() {
+  duration time_in_current_mode = clock_->now() - last_mode_change_;
+  switch (current_mode_) {
+    case PaddingManagerMode::START:
+      {
+        if (time_in_current_mode > kMaxDurationInStartMode) {
+          ELOG_DEBUG("%s Start mode is over, switching to stable", connection_->toLog());
+          forceModeSwitch(PaddingManagerMode::STABLE);
+        }
+        break;
+      }
+    case PaddingManagerMode::STABLE:
+      break;
+    case PaddingManagerMode::HOLD:
+      {
+        if (time_in_current_mode > kMaxDurationInHoldMode) {
+          if (can_recover_) {
+            ELOG_DEBUG("%s Hold mode is over, switching to recover", connection_->toLog());
+            forceModeSwitch(PaddingManagerMode::RECOVER);
+          } else {
+            ELOG_DEBUG("%s Hold mode is over, switching to stable", connection_->toLog());
+            forceModeSwitch(PaddingManagerMode::STABLE);
+          }
+        }
+        break;
+      }
+    case PaddingManagerMode::RECOVER:
+      {
+        if (time_in_current_mode > kMaxDurationInRecoverMode) {
+          ELOG_DEBUG("%s Recover is successful, switching to stable", connection_->toLog());
+          forceModeSwitch(PaddingManagerMode::STABLE);
+        }
+        break;
+      }
+  }
 }
 
 void RtpPaddingManagerHandler::distributeTotalTargetPaddingBitrate(int64_t bitrate) {
@@ -182,6 +255,7 @@ void RtpPaddingManagerHandler::distributeTotalTargetPaddingBitrate(int64_t bitra
       if (!media_stream->canSendPadding()) {
         return;
       }
+      ELOG_DEBUG("Setting Target %u", bitrate_per_stream);
       media_stream->setTargetPaddingBitrate(bitrate_per_stream);
   });
 }

--- a/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingManagerHandler.cpp
@@ -115,7 +115,6 @@ void RtpPaddingManagerHandler::recalculatePaddingRate() {
   }
 
   int64_t target_padding_bitrate = std::max(target_bitrate - media_bitrate, int64_t(0));
-  bool remb_is_decreasing = estimated_bandwidth < last_estimated_bandwidth_;
   bool remb_sharp_drop = estimated_bandwidth < last_estimated_bandwidth_*kBweSharpDropThreshold;
   if (current_mode_ == PaddingManagerMode::RECOVER) {  // if in recover mode any drop will stop it
     remb_sharp_drop = estimated_bandwidth < last_estimated_bandwidth_;

--- a/erizo/src/erizo/rtp/RtpPaddingManagerHandler.h
+++ b/erizo/src/erizo/rtp/RtpPaddingManagerHandler.h
@@ -15,12 +15,25 @@ namespace erizo {
 
 class WebRtcConnection;
 
+enum PaddingManagerMode {
+  START = 0,
+  STABLE = 1,
+  HOLD = 2,
+  RECOVER = 3
+};
+
+
 class RtpPaddingManagerHandler: public Handler, public std::enable_shared_from_this<RtpPaddingManagerHandler> {
   DECLARE_LOGGER();
 
  public:
-  static constexpr duration kMinDurationToSendPaddingAfterBweDecrease = std::chrono::seconds(5);
-  static constexpr duration kMaxDurationInRecoveryFromBwe = std::chrono::seconds(30);
+  static constexpr duration kMaxDurationInStartMode = std::chrono::seconds(15);
+  static constexpr duration kMaxDurationInRecoverMode = std::chrono::seconds(10);
+  static constexpr duration kMaxDurationInHoldMode = std::chrono::seconds(5);
+  static constexpr double kBweSharpDropThreshold = 0.66;
+  static constexpr double kStartModeFactor = 3;
+  static constexpr double kRecoverBweFactor = 0.85;
+  static constexpr double kStableModeAvailableFactor = 1.1;
   explicit RtpPaddingManagerHandler(std::shared_ptr<erizo::Clock> the_clock = std::make_shared<erizo::SteadyClock>());
 
   void enable() override;
@@ -33,21 +46,28 @@ class RtpPaddingManagerHandler: public Handler, public std::enable_shared_from_t
   void read(Context *ctx, std::shared_ptr<DataPacket> packet) override;
   void write(Context *ctx, std::shared_ptr<DataPacket> packet) override;
   void notifyUpdate() override;
+  PaddingManagerMode getCurrentPaddingMode();
 
  private:
   bool isTimeToCalculateBitrate();
   void recalculatePaddingRate();
   void distributeTotalTargetPaddingBitrate(int64_t bitrate);
   int64_t getTotalTargetBitrate();
+  void maybeTriggerTimedModeChanges();
+  void forceModeSwitch(PaddingManagerMode new_mode);
 
  private:
   bool initialized_;
   std::shared_ptr<erizo::Clock> clock_;
   time_point last_rate_calculation_time_;
   time_point last_time_bwe_decreased_;
+  time_point last_mode_change_;
+  uint64_t estimated_before_drop_;
   WebRtcConnection* connection_;
   std::shared_ptr<Stats> stats_;
   int64_t last_estimated_bandwidth_;
+  bool can_recover_;
+  PaddingManagerMode current_mode_;
 };
 
 }  // namespace erizo

--- a/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
+++ b/erizo/src/erizo/rtp/SenderBandwidthEstimantionHandler.cpp
@@ -14,6 +14,11 @@ namespace erizo {
 
 DEFINE_LOGGER(SenderBandwidthEstimationHandler, "rtp.SenderBandwidthEstimationHandler");
 
+const uint16_t SenderBandwidthEstimationHandler::kMaxSrListSize;
+const uint32_t SenderBandwidthEstimationHandler::kStartSendBitrate;
+const uint32_t SenderBandwidthEstimationHandler::kMinSendBitrate;
+const uint32_t SenderBandwidthEstimationHandler::kMinSendBitrateLimit;
+const uint32_t SenderBandwidthEstimationHandler::kMaxSendBitrate;
 constexpr duration SenderBandwidthEstimationHandler::kMinUpdateEstimateInterval;
 
 SenderBandwidthEstimationHandler::SenderBandwidthEstimationHandler(std::shared_ptr<Clock> the_clock) :

--- a/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
@@ -404,7 +404,8 @@ TEST_P(RtpPaddingManagerHandlerTestWithParam, shouldDistributePaddingWithNoPubli
 INSTANTIATE_TEST_CASE_P(
   Padding_values, RtpPaddingManagerHandlerTestWithParam, testing::Values(
     //                                          targetBitrates,       bwe, bitrate, expectedPaddingBitrate
-    std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200},  600,     100, 100*RtpPaddingManagerHandler::kStableModeAvailableFactor),
+    std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200},  600,     100,
+                                                  100*RtpPaddingManagerHandler::kStableModeAvailableFactor),
     std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200}, 1500,     100,                      0),
     std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200},   99,     100,                      0),
     std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200},  600,     600,                      0),

--- a/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
+++ b/erizo/src/test/rtp/RtpPaddingManagerHandlerTest.cpp
@@ -29,6 +29,7 @@ using erizo::MovingIntervalRateStat;
 using erizo::IceConfig;
 using erizo::RtpMap;
 using erizo::RtpPaddingManagerHandler;
+using erizo::PaddingManagerMode;
 using erizo::WebRtcConnection;
 using erizo::Pipeline;
 using erizo::InboundHandler;
@@ -47,8 +48,8 @@ class RtpPaddingManagerHandlerBaseTest : public erizo::BaseHandlerTest {
  protected:
   void internalSetHandler() {
     clock = std::make_shared<erizo::SimulatedClock>();
-    padding_calculator_handler = std::make_shared<RtpPaddingManagerHandler>(clock);
-    pipeline->addBack(padding_calculator_handler);
+    padding_manager_handler = std::make_shared<RtpPaddingManagerHandler>(clock);
+    pipeline->addBack(padding_manager_handler);
   }
 
   void whenSubscribersWithTargetBitrate(std::vector<uint32_t> subscriber_bitrates) {
@@ -117,7 +118,7 @@ class RtpPaddingManagerHandlerBaseTest : public erizo::BaseHandlerTest {
 
   std::vector<std::shared_ptr<erizo::MockMediaStream>> subscribers;
   std::vector<std::shared_ptr<erizo::MockMediaStream>> publishers;
-  std::shared_ptr<RtpPaddingManagerHandler> padding_calculator_handler;
+  std::shared_ptr<RtpPaddingManagerHandler> padding_manager_handler;
   std::shared_ptr<erizo::SimulatedClock> clock;
 };
 
@@ -157,120 +158,188 @@ TEST_F(RtpPaddingManagerHandlerTest, basicBehaviourShouldWritePackets) {
 
 TEST_F(RtpPaddingManagerHandlerTest, shouldDistributePaddingEvenlyAmongStreamsWithoutPublishers) {
   auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
-
+  //  Stable mode
+  clock->advanceTime(RtpPaddingManagerHandler::kMaxDurationInStartMode + std::chrono::milliseconds(1));
   whenSubscribersWithTargetBitrate({200, 200, 200, 200, 200});
   whenPublishers(0);
   whenBandwidthEstimationIs(600);
   whenCurrentTotalVideoBitrateIs(100);
 
-  expectPaddingBitrate(100);
+  expectPaddingBitrate(110);
 
   clock->advanceTime(std::chrono::milliseconds(200));
   pipeline->write(packet);
 }
 
-TEST_F(RtpPaddingManagerHandlerTest, shouldStopPaddingIfRembGoesDown) {
+TEST_F(RtpPaddingManagerHandlerTest, shouldGoToHoldModeWhenRembSharplyGoesDown) {
   auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
 
+  clock->advanceTime(RtpPaddingManagerHandler::kMaxDurationInStartMode + std::chrono::milliseconds(1));
   whenSubscribersWithTargetBitrate({500});
   whenPublishers(0);
   whenBandwidthEstimationIs(300);
   whenCurrentTotalVideoBitrateIs(100);
 
-  expectPaddingBitrate(200);
+  expectPaddingBitrate(220);
   clock->advanceTime(std::chrono::milliseconds(200));
   pipeline->write(packet);
 
-  whenBandwidthEstimationIs(200);
-  whenCurrentTotalVideoBitrateIs(100);
-
+  whenBandwidthEstimationIs(100);
+  whenCurrentTotalVideoBitrateIs(50);
   expectPaddingBitrate(0);
   clock->advanceTime(std::chrono::milliseconds(200));
   pipeline->write(packet);
+  EXPECT_EQ(padding_manager_handler->getCurrentPaddingMode(), PaddingManagerMode::HOLD);
 }
 
-TEST_F(RtpPaddingManagerHandlerTest, shouldNotSendPaddingInTheBackoffPeriod) {
+TEST_F(RtpPaddingManagerHandlerTest, shouldNotGoToHoldModeWhenRembGoesSlightlyDown) {
   auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
 
+  clock->advanceTime(RtpPaddingManagerHandler::kMaxDurationInStartMode + std::chrono::milliseconds(1));
   whenSubscribersWithTargetBitrate({500});
   whenPublishers(0);
   whenBandwidthEstimationIs(300);
   whenCurrentTotalVideoBitrateIs(100);
 
-  expectPaddingBitrate(200);
+  expectPaddingBitrate(220);
   clock->advanceTime(std::chrono::milliseconds(200));
   pipeline->write(packet);
 
-  whenBandwidthEstimationIs(200);
+  whenBandwidthEstimationIs(280);
   whenCurrentTotalVideoBitrateIs(100);
+  expectPaddingBitrate(198);
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+  EXPECT_EQ(padding_manager_handler->getCurrentPaddingMode(), PaddingManagerMode::STABLE);
+}
 
+TEST_F(RtpPaddingManagerHandlerTest, shouldGoToHoldModeWhenRembSharplyGoesDownInStartMode) {
+  auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+  const uint64_t subscribers_target_bitrate = 500;
+  const uint64_t bandwidth_estimation = 300;
+  const uint64_t total_video_bitrate = 100;
+  whenSubscribersWithTargetBitrate({subscribers_target_bitrate});
+  whenPublishers(0);
+  whenBandwidthEstimationIs(bandwidth_estimation);
+  whenCurrentTotalVideoBitrateIs(total_video_bitrate);
+
+  const float expected_padding = subscribers_target_bitrate - total_video_bitrate;
+  expectPaddingBitrate(expected_padding);
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+  EXPECT_EQ(padding_manager_handler->getCurrentPaddingMode(), PaddingManagerMode::START);
+
+  whenBandwidthEstimationIs(100);
+  whenCurrentTotalVideoBitrateIs(50);
+  expectPaddingBitrate(0);
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+  EXPECT_EQ(padding_manager_handler->getCurrentPaddingMode(), PaddingManagerMode::HOLD);
+}
+
+
+TEST_F(RtpPaddingManagerHandlerTest, shouldStartInStartModeAndSendMoreAggressivePadding) {
+  auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+  const uint64_t subscribers_target_bitrate = 1500;
+  const uint64_t bandwidth_estimation = 300;
+  const uint64_t total_video_bitrate = 100;
+  whenSubscribersWithTargetBitrate({subscribers_target_bitrate});
+  whenPublishers(0);
+  whenBandwidthEstimationIs(bandwidth_estimation);
+  whenCurrentTotalVideoBitrateIs(total_video_bitrate);
+
+  const float expected_padding =
+    bandwidth_estimation * RtpPaddingManagerHandler::kStartModeFactor - total_video_bitrate;
+  expectPaddingBitrate(expected_padding);
   clock->advanceTime(std::chrono::milliseconds(200));
   pipeline->write(packet);
 
-  whenBandwidthEstimationIs(200);
+  EXPECT_EQ(padding_manager_handler->getCurrentPaddingMode(), PaddingManagerMode::START);
+}
+
+TEST_F(RtpPaddingManagerHandlerTest, shouldNeverGoOverTargetBitrateInStartMode) {
+  auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+  const uint64_t subscribers_target_bitrate = 500;
+  const uint64_t bandwidth_estimation = 300;
+  const uint64_t total_video_bitrate = 100;
+  whenSubscribersWithTargetBitrate({subscribers_target_bitrate});
+  whenPublishers(0);
+  whenBandwidthEstimationIs(bandwidth_estimation);
+  whenCurrentTotalVideoBitrateIs(total_video_bitrate);
+
+  const float expected_padding = subscribers_target_bitrate - total_video_bitrate;
+  expectPaddingBitrate(expected_padding);
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+
+  EXPECT_EQ(padding_manager_handler->getCurrentPaddingMode(), PaddingManagerMode::START);
+}
+
+TEST_F(RtpPaddingManagerHandlerTest, shouldGoToRecoverModeAfterHoldIfBweIsConsistent) {
+  auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+  clock->advanceTime(RtpPaddingManagerHandler::kMaxDurationInStartMode + std::chrono::milliseconds(1));
+  whenSubscribersWithTargetBitrate({500});
+  whenPublishers(0);
+  whenBandwidthEstimationIs(300);
   whenCurrentTotalVideoBitrateIs(100);
 
+  expectPaddingBitrate(220);
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+
+  whenBandwidthEstimationIs(100);
+  whenCurrentTotalVideoBitrateIs(50);
+  expectPaddingBitrate(0);
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+  EXPECT_EQ(padding_manager_handler->getCurrentPaddingMode(), PaddingManagerMode::HOLD);
+  clock->advanceTime(RtpPaddingManagerHandler::kMaxDurationInHoldMode + std::chrono::milliseconds(1));
+  pipeline->write(packet);
+  expectPaddingBitrate(205);
+  EXPECT_EQ(padding_manager_handler->getCurrentPaddingMode(), PaddingManagerMode::RECOVER);
+}
+
+TEST_F(RtpPaddingManagerHandlerTest, shouldNotGoToRecoveryModeAfterAFailedAttempt) {
+  auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
+
+  clock->advanceTime(RtpPaddingManagerHandler::kMaxDurationInStartMode + std::chrono::milliseconds(1));
+  whenSubscribersWithTargetBitrate({500});
+  whenPublishers(0);
+  whenBandwidthEstimationIs(300);
+  whenCurrentTotalVideoBitrateIs(100);
+
+  expectPaddingBitrate(220);
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+  EXPECT_EQ(padding_manager_handler->getCurrentPaddingMode(), PaddingManagerMode::STABLE);
+
+  whenBandwidthEstimationIs(100);
+  whenCurrentTotalVideoBitrateIs(50);
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
+  EXPECT_EQ(padding_manager_handler->getCurrentPaddingMode(), PaddingManagerMode::HOLD);
+
+
+  clock->advanceTime(RtpPaddingManagerHandler::kMaxDurationInHoldMode + std::chrono::milliseconds(1));
+  pipeline->write(packet);
+  expectPaddingBitrate(205);
+  EXPECT_EQ(padding_manager_handler->getCurrentPaddingMode(), PaddingManagerMode::RECOVER);
+
+
+  whenBandwidthEstimationIs(90);
+  clock->advanceTime(std::chrono::milliseconds(200));
+  pipeline->write(packet);
   expectPaddingBitrate(0, 2);
-  clock->advanceTime(
-    RtpPaddingManagerHandler::kMinDurationToSendPaddingAfterBweDecrease - std::chrono::milliseconds(1));
+  EXPECT_EQ(padding_manager_handler->getCurrentPaddingMode(), PaddingManagerMode::HOLD);
+
+  clock->advanceTime(RtpPaddingManagerHandler::kMaxDurationInHoldMode + std::chrono::milliseconds(1));
   pipeline->write(packet);
-}
-
-TEST_F(RtpPaddingManagerHandlerTest, shouldRampUpAfterBackoff) {
-  auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
-
-  whenSubscribersWithTargetBitrate({500});
-  whenPublishers(0);
-  whenBandwidthEstimationIs(300);
-  whenCurrentTotalVideoBitrateIs(100);
-
-  expectPaddingBitrate(200);
-  clock->advanceTime(std::chrono::milliseconds(200));
-  pipeline->write(packet);
-
-  whenBandwidthEstimationIs(200);
-  whenCurrentTotalVideoBitrateIs(100);
-
-  expectPaddingBitrate(0);
-  clock->advanceTime(std::chrono::milliseconds(200));
-  pipeline->write(packet);
-
-  whenBandwidthEstimationIs(200);
-  whenCurrentTotalVideoBitrateIs(100);
-  std::chrono::steady_clock::duration kDurationLowerThanMaxDurationInRecovery =
-    RtpPaddingManagerHandler::kMaxDurationInRecoveryFromBwe - std::chrono::seconds(1);
-  double correcting_factor = static_cast<double>(kDurationLowerThanMaxDurationInRecovery.count())/
-    RtpPaddingManagerHandler::kMaxDurationInRecoveryFromBwe.count();
-  expectPaddingBitrate(100 * correcting_factor);
-  clock->advanceTime(kDurationLowerThanMaxDurationInRecovery);
-  pipeline->write(packet);
-}
-
-TEST_F(RtpPaddingManagerHandlerTest, shouldRecoverPaddingBitrateCompletely) {
-  auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
-
-  whenSubscribersWithTargetBitrate({500});
-  whenPublishers(0);
-  whenBandwidthEstimationIs(300);
-  whenCurrentTotalVideoBitrateIs(100);
-
-  expectPaddingBitrate(200);
-  clock->advanceTime(std::chrono::milliseconds(200));
-  pipeline->write(packet);
-
-  whenBandwidthEstimationIs(200);
-  whenCurrentTotalVideoBitrateIs(100);
-
-  expectPaddingBitrate(0);
-  clock->advanceTime(std::chrono::milliseconds(200));
-  pipeline->write(packet);
-
-  whenBandwidthEstimationIs(500);
-  whenCurrentTotalVideoBitrateIs(100);
-
-  expectPaddingBitrate(400);
-  clock->advanceTime(RtpPaddingManagerHandler::kMaxDurationInRecoveryFromBwe + std::chrono::milliseconds(100));
-  pipeline->write(packet);
+  expectPaddingBitrate(44);
+  EXPECT_EQ(padding_manager_handler->getCurrentPaddingMode(), PaddingManagerMode::STABLE);
 }
 
 typedef std::vector<uint32_t> SubscriberBitratesList;
@@ -304,7 +373,7 @@ class RtpPaddingManagerHandlerTestWithParam : public RtpPaddingManagerHandlerBas
   uint64_t expected_padding_bitrate;
 };
 
-TEST_P(RtpPaddingManagerHandlerTestWithParam, shouldDistributePaddingWithPublishers) {
+TEST_P(RtpPaddingManagerHandlerTestWithParam, shouldDistributePaddingWithPublishersInStableMode) {
   auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
 
   whenSubscribersWithTargetBitrate(subscribers);
@@ -314,11 +383,11 @@ TEST_P(RtpPaddingManagerHandlerTestWithParam, shouldDistributePaddingWithPublish
 
   expectPaddingBitrate(expected_padding_bitrate);
 
-  clock->advanceTime(std::chrono::milliseconds(200));
+  clock->advanceTime(RtpPaddingManagerHandler::kMaxDurationInStartMode + std::chrono::milliseconds(1));
   pipeline->write(packet);
 }
 
-TEST_P(RtpPaddingManagerHandlerTestWithParam, shouldDistributePaddingWithNoPublishers) {
+TEST_P(RtpPaddingManagerHandlerTestWithParam, shouldDistributePaddingWithNoPublishersInStableMode) {
   auto packet = erizo::PacketTools::createDataPacket(erizo::kArbitrarySeqNumber, AUDIO_PACKET);
 
   whenSubscribersWithTargetBitrate(subscribers);
@@ -328,14 +397,14 @@ TEST_P(RtpPaddingManagerHandlerTestWithParam, shouldDistributePaddingWithNoPubli
 
   expectPaddingBitrate(expected_padding_bitrate);
 
-  clock->advanceTime(std::chrono::milliseconds(200));
+  clock->advanceTime(RtpPaddingManagerHandler::kMaxDurationInStartMode + std::chrono::milliseconds(1));
   pipeline->write(packet);
 }
 
 INSTANTIATE_TEST_CASE_P(
   Padding_values, RtpPaddingManagerHandlerTestWithParam, testing::Values(
     //                                          targetBitrates,       bwe, bitrate, expectedPaddingBitrate
-    std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200},  600,     100,                    100),
+    std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200},  600,     100, 100*RtpPaddingManagerHandler::kStableModeAvailableFactor),
     std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200}, 1500,     100,                      0),
     std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200},   99,     100,                      0),
     std::make_tuple(SubscriberBitratesList{200, 200, 200, 200, 200},  600,     600,                      0),


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

This PR implements a new algorithm to decide the amount of padding to send.
The new algorithm is based on a FSM with 4 states:
* `Start` - a ramp-up state where we will send more padding than the current estimate. This state will be triggered when a stream starts and will last for a few seconds.
* `Stable` - a mode similar to the old algorithm that adjust padding based on the current estimate, the target bitrate and the media that is being sent.
* `Hold` - After a big drop in estimate is detected, we will go into hold mode and stop sending padding for a few seconds.
* `Recover` - After being on hold, this state will check if the estimate drop was transitory by adjusting padding with the estimate detected before the drop. If another drop is detected in this state, the new lower estimation will be used in stable mode.

We currently have no way to "restart" which may be a good idea in some situations (big changes in the target bw, for instance)

- [x]  It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.