### PR TITLE
Fix recording not stopping

### DIFF
--- a/erizo/src/erizo/media/ExternalOutput.cpp
+++ b/erizo/src/erizo/media/ExternalOutput.cpp
@@ -105,6 +105,7 @@ void ExternalOutput::syncClose() {
   if (!recording_) {
     return;
   }
+  recording_ = false;
   // Stop our thread so we can safely nuke libav stuff and close our
   // our file.
   cond_.notify_one();
@@ -113,7 +114,6 @@ void ExternalOutput::syncClose() {
   if (audio_stream_ != nullptr && video_stream_ != nullptr && context_ != nullptr) {
       av_write_trailer(context_);
   }
-
   if (video_stream_ && video_stream_->codec != nullptr) {
       avcodec_close(video_stream_->codec);
   }
@@ -557,7 +557,7 @@ void ExternalOutput::sendLoop() {
       inited_ = true;
     }
   }
-
+  ELOG_WARN("We are bailing boys");
   // Since we're bailing, let's completely drain our queues of all data.
   while (audio_queue_.getSize() > 0) {
     boost::shared_ptr<DataPacket> audio_packet = audio_queue_.popPacket(true);  // ignore our minimum depth check

--- a/erizo/src/erizo/media/ExternalOutput.cpp
+++ b/erizo/src/erizo/media/ExternalOutput.cpp
@@ -557,7 +557,6 @@ void ExternalOutput::sendLoop() {
       inited_ = true;
     }
   }
-  ELOG_WARN("We are bailing boys");
   // Since we're bailing, let's completely drain our queues of all data.
   while (audio_queue_.getSize() > 0) {
     boost::shared_ptr<DataPacket> audio_packet = audio_queue_.popPacket(true);  // ignore our minimum depth check

--- a/erizo/src/erizo/media/ExternalOutput.cpp
+++ b/erizo/src/erizo/media/ExternalOutput.cpp
@@ -106,6 +106,7 @@ void ExternalOutput::syncClose() {
   if (!recording_) {
     return;
   }
+  recording_ = false;
   // Stop our thread so we can safely nuke libav stuff and close our
   // our file.
   cond_.notify_one();
@@ -130,7 +131,7 @@ void ExternalOutput::syncClose() {
   }
 
   pipeline_initialized_ = false;
-  closed_ = false;
+  closed_ = true;
 
   ELOG_DEBUG("Closed Successfully");
 }

--- a/erizo/src/erizo/media/ExternalOutput.h
+++ b/erizo/src/erizo/media/ExternalOutput.h
@@ -53,14 +53,14 @@ class ExternalOutput : public MediaSink, public RawDataReceiver, public Feedback
 
   void notifyUpdateToHandlers() override;
 
-  bool isRecording() { return recording_; }
+  bool hasClosed() { return closed_; }
 
  private:
   std::shared_ptr<Worker> worker_;
   Pipeline::Ptr pipeline_;
   std::unique_ptr<webrtc::UlpfecReceiver> fec_receiver_;
   RtpPacketQueue audio_queue_, video_queue_;
-  std::atomic<bool> recording_, inited_;
+  std::atomic<bool> recording_, inited_, closed_;
   boost::mutex mtx_;  // a mutex we use to signal our writer thread that data is waiting.
   boost::thread thread_;
   boost::condition_variable cond_;
@@ -163,3 +163,4 @@ class ExternalOuputWriter : public OutboundHandler {
 
 }  // namespace erizo
 #endif  // ERIZO_SRC_ERIZO_MEDIA_EXTERNALOUTPUT_H_
+

--- a/erizoAPI/ExternalOutput.cc
+++ b/erizoAPI/ExternalOutput.cc
@@ -23,6 +23,9 @@ class AsyncCloser : public Nan::AsyncWorker {
     ~AsyncCloser() {}
     void Execute() {
       external_output_->close();
+      while (external_output_->isRecording()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      }
     }
     void HandleOKCallback() {
       Nan::HandleScope scope;

--- a/erizoAPI/ExternalOutput.cc
+++ b/erizoAPI/ExternalOutput.cc
@@ -23,9 +23,6 @@ class AsyncCloser : public Nan::AsyncWorker {
     ~AsyncCloser() {}
     void Execute() {
       external_output_->close();
-      while (external_output_->isRecording()) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-      }
     }
     void HandleOKCallback() {
       Nan::HandleScope scope;

--- a/erizoAPI/ExternalOutput.cc
+++ b/erizoAPI/ExternalOutput.cc
@@ -23,7 +23,7 @@ class AsyncCloser : public Nan::AsyncWorker {
     ~AsyncCloser() {}
     void Execute() {
       external_output_->close();
-      while (external_output_->isRecording()) {
+      while (!external_output_->hasClosed()) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
       }
     }
@@ -163,6 +163,7 @@ NAN_METHOD(ExternalOutput::init) {
   int r = me->init();
   info.GetReturnValue().Set(Nan::New(r));
 }
+
 
 
 


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

There was an error where when recording where the recording would not stop and files kept growing even though licode gave no error.  What I found is that the promise that removed the ExternalOutput was always pending and never resolved and the callback was never executed but, the recording would stop on most occasions. After removing the lines shown in the PR the callback is always called and the recording stops all the times I tested it. 

To check this you check that the log inside the callback in the removeExternalOutput() function on line 115 of erizo_controller/erizoJS/models/Publisher.js is never reached. 

I don´t know the root issue of this problem, and my manual testing is limited so this might cause other issues with removing that check. I will leave this PR as a draft, as a point of discussion and potential fix until a better solution is found or further testing is done. 

<!--
Add a short description here, please.
If the contribution needs and includes Unit Tests check the box below.
-->

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.