### PR TITLE
Avoid generating malformed padding packets

### DIFF
--- a/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.cpp
@@ -165,7 +165,12 @@ void RtpPaddingGeneratorHandler::recalculatePaddingRate(uint64_t target_padding_
   }
   uint64_t bytes_per_marker = target_padding_bitrate / (marker_rate * 8);
   number_of_full_padding_packets_ = bytes_per_marker / (kMaxPaddingSize + rtp_header_length_);
-  last_padding_packet_size_ = bytes_per_marker % (kMaxPaddingSize + rtp_header_length_) - rtp_header_length_;
+  int last_payload_size =
+    static_cast<int>(bytes_per_marker % (kMaxPaddingSize + rtp_header_length_) - rtp_header_length_);
+  int clamped_payload_size =
+    std::clamp(last_payload_size,
+    static_cast<int>(0), static_cast<int>(kMaxPaddingSize));
+  last_padding_packet_size_ = static_cast<uint8_t>(clamped_payload_size);
 }
 
 uint64_t RtpPaddingGeneratorHandler::getBurstSize() {

--- a/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.cpp
+++ b/erizo/src/erizo/rtp/RtpPaddingGeneratorHandler.cpp
@@ -169,7 +169,7 @@ void RtpPaddingGeneratorHandler::recalculatePaddingRate(uint64_t target_padding_
     static_cast<int>(bytes_per_marker % (kMaxPaddingSize + rtp_header_length_) - rtp_header_length_);
   int clamped_payload_size =
     std::clamp(last_payload_size,
-    static_cast<int>(0), static_cast<int>(kMaxPaddingSize));
+      0, static_cast<int>(kMaxPaddingSize));
   last_padding_packet_size_ = static_cast<uint8_t>(clamped_payload_size);
 }
 


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**
The result for the calculation for the last padding packet in a burst could result below 0 when the remaining padding bytes are less than the header size in bytes.
This could create problems down the line.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.