### PR TITLE
Fix overuse estimator crash

### DIFF
--- a/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
+++ b/erizo/src/erizo/rtp/BandwidthEstimationHandler.cpp
@@ -47,7 +47,10 @@ BandwidthEstimationHandler::BandwidthEstimationHandler(std::shared_ptr<RemoteBit
   min_bitrate_bps_{kMinBitRateAllowed},
   bitrate_{0}, last_send_bitrate_{0}, last_remb_time_{0},
   running_{false}, active_{true}, initialized_{false} {
-    rtc::LogMessage::SetLogToStderr(false);
+    // Print RTC_LOG warnings and errors even in release builds.
+  rtc::LogMessage::ConfigureLogging("tstamp thread error");
+  rtc::LogMessage::LogToDebug(rtc::LS_ERROR);
+  rtc::LogMessage::SetLogToStderr(true);
 }
 
 void BandwidthEstimationHandler::enable() {

--- a/erizo/src/third_party/webrtc/src/webrtc/modules/remote_bitrate_estimator/overuse_estimator.h
+++ b/erizo/src/third_party/webrtc/src/webrtc/modules/remote_bitrate_estimator/overuse_estimator.h
@@ -59,6 +59,9 @@ class OveruseEstimator {
   // based on.
   unsigned int num_of_deltas() const { return num_of_deltas_; }
 
+  // Resets the estimator
+  void Reset();
+
  private:
   double UpdateMinFramePeriod(double ts_delta);
   void UpdateNoiseEstimate(double residual, double ts_delta, bool stable_state);


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

We've detected some crashes from the overuse estimator covariance matrix not being positive semi-definite. To prevent more crashes, this PR restarts the matrix every time this happens instead of crashing and generating dump. It also adds logs so we can further diagnose the problem and fix the root issue.

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.