### PR TITLE
Use ontrack and onremovetrack instead of onaddstream and onremovestream

### DIFF
--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -86,6 +86,12 @@ class ErizoConnection extends EventEmitterConst {
     if (this.stack.peerConnection) {
       this.peerConnection = this.stack.peerConnection; // For backwards compatibility
       this.stack.peerConnection.onaddstream = (evt) => {
+        const stream = evt.stream;
+        stream.onremovetrack = () => {
+          if (stream.getTracks().size === 0) {
+            this.emit(ConnectionEvent({ type: 'remove-stream', stream: evt.stream }));
+          }
+        };
         this.emit(ConnectionEvent({ type: 'add-stream', stream: evt.stream }));
       };
 
@@ -144,7 +150,7 @@ class ErizoConnection extends EventEmitterConst {
   removeStream(stream) {
     const streamId = stream.getID();
     if (!this.streamsMap.has(streamId)) {
-      log.debug(`message: Cannot remove stream not in map, ${this.toLog()}, ${stream.toLog()}`);
+      log.warning(`message: Cannot remove stream not in map, ${this.toLog()}, ${stream.toLog()}`);
       return;
     }
     this.streamsMap.remove(streamId);

--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -88,14 +88,16 @@ class ErizoConnection extends EventEmitterConst {
       this.stack.peerConnection.onaddstream = (evt) => {
         const stream = evt.stream;
         stream.onremovetrack = () => {
-          if (stream.getTracks().size === 0) {
-            this.emit(ConnectionEvent({ type: 'remove-stream', stream: evt.stream }));
+          if (stream.getTracks().length === 0) {
+            this.emit(ConnectionEvent({ type: 'remove-stream', stream }));
+            this.streamRemovedListener(evt.stream.id);
           }
         };
         this.emit(ConnectionEvent({ type: 'add-stream', stream: evt.stream }));
       };
 
       this.stack.peerConnection.onremovestream = (evt) => {
+        log.warning('onremovestream', evt.stream);
         this.emit(ConnectionEvent({ type: 'remove-stream', stream: evt.stream }));
         this.streamRemovedListener(evt.stream.id);
       };

--- a/erizo_controller/erizoClient/src/ErizoConnectionManager.js
+++ b/erizo_controller/erizoClient/src/ErizoConnectionManager.js
@@ -85,22 +85,20 @@ class ErizoConnection extends EventEmitterConst {
     // PeerConnection Events
     if (this.stack.peerConnection) {
       this.peerConnection = this.stack.peerConnection; // For backwards compatibility
-      this.stack.peerConnection.onaddstream = (evt) => {
-        const stream = evt.stream;
+      this.stack.peerConnection.ontrack = (trackEvt) => {
+        if (trackEvt.streams.length !== 1) {
+          log.warning('More that one mediaStream associated with track!');
+        }
+        const stream = trackEvt.streams[0];
         stream.onremovetrack = () => {
           if (stream.getTracks().length === 0) {
             this.emit(ConnectionEvent({ type: 'remove-stream', stream }));
-            this.streamRemovedListener(evt.stream.id);
+            this.streamRemovedListener(stream.id);
           }
         };
-        this.emit(ConnectionEvent({ type: 'add-stream', stream: evt.stream }));
+        this.emit(ConnectionEvent({ type: 'add-stream', stream }));
       };
 
-      this.stack.peerConnection.onremovestream = (evt) => {
-        log.warning('onremovestream', evt.stream);
-        this.emit(ConnectionEvent({ type: 'remove-stream', stream: evt.stream }));
-        this.streamRemovedListener(evt.stream.id);
-      };
 
       this.stack.peerConnection.oniceconnectionstatechange = () => {
         const state = this.stack.peerConnection.iceConnectionState;

--- a/erizo_controller/erizoClient/src/Room.js
+++ b/erizo_controller/erizoClient/src/Room.js
@@ -80,7 +80,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     }
   };
 
-  const dispatchStreamSubscribed = (streamInput, evt) => {
+  const maybeDispatchStreamSubscribed = (streamInput, evt) => {
     const stream = streamInput;
     // Draw on html
     log.info(`message: Stream subscribed, ${stream.toLog()}, ${toLog()}`);
@@ -88,9 +88,11 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     if (!that.p2p) {
       stream.pc.addStream(stream);
     }
-    stream.state = 'subscribed';
-    const evt2 = StreamEvent({ type: 'stream-subscribed', stream });
-    that.dispatchEvent(evt2);
+    if (stream.state !== 'subscribed') {
+      stream.state = 'subscribed';
+      const evt2 = StreamEvent({ type: 'stream-subscribed', stream });
+      that.dispatchEvent(evt2);
+    }
   };
 
   const maybeDispatchStreamUnsubscribed = (streamInput) => {
@@ -169,7 +171,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     const connection = that.erizoConnectionManager.getOrBuildErizoConnection(connectionOptions);
     stream.addPC(connection, false, connectionOptions);
     connection.on('connection-failed', that.dispatchEvent.bind(this));
-    stream.on('added', dispatchStreamSubscribed.bind(null, stream));
+    stream.on('added', maybeDispatchStreamSubscribed.bind(null, stream));
     stream.on('icestatechanged', (evt) => {
       log.debug(`message: icestatechanged, ${stream.toLog()}, iceConnectionState: ${evt.msg.state}, ${toLog()}`);
       if (evt.msg.state === 'failed') {
@@ -266,7 +268,7 @@ const Room = (altIo, altConnectionHelpers, altConnectionManager, specInput) => {
     stream.addPC(connection, false, connectionOpts);
     connection.on('connection-failed', that.dispatchEvent.bind(this));
 
-    stream.on('added', dispatchStreamSubscribed.bind(null, stream));
+    stream.on('added', maybeDispatchStreamSubscribed.bind(null, stream));
     stream.on('icestatechanged', (evt) => {
       log.debug(`message: icestatechanged, ${stream.toLog()}, iceConnectionState: ${evt.msg.state}, ${toLog()}`);
       if (evt.msg.state === 'failed') {


### PR DESCRIPTION
<!--
For more information about contributing code to Licode see: 
http://lynckia.com/licode/contribute.html
-->

**Description**

In the latest chrome versions we've detected that `onremovestream` is not triggered even when the negotiation removing the stream is successful. Since that event is deprecated, this PR listens to `onremovetrack` and acts when all tracks in the MediaStream have been remove sending a `stream-removed` event that we use to trigger Licode's `stream-unsubscribed`.

This PR also replaces onstreamadded (which is also deprecated but still works) and uses `ontrack` 

[] It needs and includes Unit Tests

**Changes in Client or Server public APIs**

<!--
Add a detailed description of any change in the public APIs.
If you have included related documentation check the box below.
-->

[] It includes documentation for these changes in `/doc`.